### PR TITLE
fix: Broken zsh completion syntax

### DIFF
--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -46,7 +46,7 @@ __eza() {
         {-t,--time}="[Which time field to show]:(time field):(accessed changed created modified)" \
         --time-style="[How to format timestamps]:(time style):(default iso long-iso full-iso relative)" \
         --no-permissions"[Suppress the permissions field]" \
-        {-o, --octal-permissions}"[List each file's permission in octal format]" \
+        {-o,--octal-permissions}"[List each file's permission in octal format]" \
         --no-filesize"[Suppress the filesize field]" \
         --no-user"[Suppress the user field]" \
         --no-time"[Suppress the time field]" \


### PR DESCRIPTION
With the current build I get errors when I try to call the tab-completion for `eza` from zsh:

```shell
$ eza
_arguments:comparguments:327: invalid argument: {-o,
_arguments:comparguments:327: invalid argument: {-o,
_arguments:comparguments:327: invalid argument: {-o,
```

This PR fixes the slight typo in the completion file that causes this error.