### PR TITLE
Fix+improve Git repository lookup (`GIT_DIR`; `GIT_CEILING_DIRECTORIES`)

### DIFF
--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -180,7 +180,7 @@ impl GitRepo {
     fn discover(path: PathBuf, flags: git2::RepositoryOpenFlags) -> Result<Self, PathBuf> {
         info!("Opening Git repository for {:?} ({:?})", path, flags);
         let unused: [&OsStr; 0] = [];
-        let repo = match git2::Repository::open_ext(&path, flags, &unused) {
+        let repo = match git2::Repository::open_ext(&path, flags, unused) {
             Ok(r) => r,
             Err(e) => {
                 error!("Error opening Git repository for {path:?}: {e:?}");

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -171,8 +171,10 @@ impl GitRepo {
                     error!("Error opening Git repo from env using GIT_DIR: {:?}", e);
                     return Err(path);
                 } else {
-                    // nothing found, search using discover
-                    match git2::Repository::discover(&path) {
+                    // Perform Git's default search in the absence of GIT_DIR:
+                    let flags = git2::RepositoryOpenFlags::FROM_ENV;
+                    let unused: [&OsStr; 0] = [];
+                    match git2::Repository::open_ext(&path, flags, &unused) {
                         Ok(r) => r,
                         Err(e) => {
                             error!("Error discovering Git repositories: {:?}", e);

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -1,5 +1,6 @@
 //! Getting the Git status of files and directories.
 
+use std::env;
 use std::ffi::OsStr;
 #[cfg(target_family = "unix")]
 use std::os::unix::ffi::OsStrExt;
@@ -48,6 +49,20 @@ impl FromIterator<PathBuf> for GitCache {
             misses: Vec::new(),
         };
 
+        if let Ok(path) = env::var("GIT_DIR") {
+            // These flags are consistent with how `git` uses GIT_DIR:
+            let flags = git2::RepositoryOpenFlags::NO_SEARCH | git2::RepositoryOpenFlags::NO_DOTGIT;
+            match GitRepo::discover(path.into(), flags) {
+                Ok(repo) => {
+                    debug!("Opened GIT_DIR repo");
+                    git.repos.push(repo);
+                }
+                Err(miss) => {
+                    git.misses.push(miss);
+                }
+            }
+        }
+
         for path in iter {
             if git.misses.contains(&path) {
                 debug!("Skipping {:?} because it already came back Gitless", path);
@@ -56,7 +71,8 @@ impl FromIterator<PathBuf> for GitCache {
                 debug!("Skipping {:?} because we already queried it", path);
             }
             else {
-                match GitRepo::discover(path) {
+                let flags = git2::RepositoryOpenFlags::FROM_ENV;
+                match GitRepo::discover(path, flags) {
                     Ok(r) => {
                         if let Some(r2) = git.repos.iter_mut().find(|e| e.has_workdir(&r.workdir)) {
                             debug!("Adding to existing repo (workdir matches with {:?})", r2.workdir);
@@ -158,31 +174,17 @@ impl GitRepo {
         path.starts_with(&self.original_path) || self.extra_paths.iter().any(|e| path.starts_with(e))
     }
 
-    /// Searches for a Git repository at any point above the given path.
-    /// Returns the original buffer if none is found.
-    fn discover(path: PathBuf) -> Result<Self, PathBuf> {
-        info!("Searching for Git repository above {:?}", path);
-        // Search with GIT_DIR env variable first if set
-        let repo = match git2::Repository::open_from_env() {
+    /// Open a Git repository. Depending on the flags, the path is either
+    /// the repository's "gitdir" (or a "gitlink" to the gitdir), or the
+    /// path is the start of a rootwards search for the repository.
+    fn discover(path: PathBuf, flags: git2::RepositoryOpenFlags) -> Result<Self, PathBuf> {
+        info!("Opening Git repository for {:?} ({:?})", path, flags);
+        let unused: [&OsStr; 0] = [];
+        let repo = match git2::Repository::open_ext(&path, flags, &unused) {
             Ok(r) => r,
             Err(e) => {
-                // anything other than NotFound implies GIT_DIR was set and we got actual error
-                if e.code() != git2::ErrorCode::NotFound {
-                    error!("Error opening Git repo from env using GIT_DIR: {:?}", e);
-                    return Err(path);
-                } else {
-                    // Perform Git's default search in the absence of GIT_DIR:
-                    let flags = git2::RepositoryOpenFlags::FROM_ENV;
-                    let unused: [&OsStr; 0] = [];
-                    match git2::Repository::open_ext(&path, flags, &unused) {
-                        Ok(r) => r,
-                        Err(e) => {
-                            error!("Error discovering Git repositories: {:?}", e);
-                            return Err(path);
-
-                        }
-                    }
-                }
+                error!("Error opening Git repository for {:?}: {:?}", path, e);
+                return Err(path);
             }
         };
 

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -179,8 +179,7 @@ impl GitRepo {
     /// path is the start of a rootwards search for the repository.
     fn discover(path: PathBuf, flags: git2::RepositoryOpenFlags) -> Result<Self, PathBuf> {
         info!("Opening Git repository for {:?} ({:?})", path, flags);
-        let unused: [&OsStr; 0] = [];
-        let repo = match git2::Repository::open_ext(&path, flags, &unused) {
+        let repo = match git2::Repository::open_ext(&path, flags, [] as [&OsStr; 0]) {
             Ok(r) => r,
             Err(e) => {
                 error!("Error opening Git repository for {:?}: {:?}", path, e);

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -179,7 +179,8 @@ impl GitRepo {
     /// path is the start of a rootwards search for the repository.
     fn discover(path: PathBuf, flags: git2::RepositoryOpenFlags) -> Result<Self, PathBuf> {
         info!("Opening Git repository for {:?} ({:?})", path, flags);
-        let repo = match git2::Repository::open_ext(&path, flags, [] as [&OsStr; 0]) {
+        let unused: [&OsStr; 0] = [];
+        let repo = match git2::Repository::open_ext(&path, flags, &unused) {
             Ok(r) => r,
             Err(e) => {
                 error!("Error opening Git repository for {path:?}: {e:?}");


### PR DESCRIPTION
This PR fixes the `GIT_DIR`-related issues mentioned in #115, and also adds support for `GIT_CEILING_DIRECTORIES`.

(Normally I'd do those two things in separate PRs, but every line that the latter changes is also changed by the former - I put them in separate commits though, so unless you squash when merging, they'll stay as cleanly separated atoms of change in the history.) 

`GIT_CEILING_DIRECTORIES` is actually my main goal here. I depend on Git's ceiling directory feature every day to keep a lot of my `(exa|eza) --long --git ...` invocations from freezing up (for 2-3 seconds at a time in the worst case). So I had done that change first (a couple days ago, after I realized that [my PR to the Exa upstream](https://github.com/ogham/exa/pull/1228) probably wasn't going to move), then while testing that I noticed the `GIT_DIR` stuff.

These changes are the first Rust code I've ever written, so if there's anything unusually off from how Rust code Is Supposed To Be, please feel free to let me know so I can fix it!