### PR TITLE
Make Nix Flake Check Pass

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -60,7 +60,7 @@ fn git_hash() -> String {
 
     String::from_utf8_lossy(
         &Command::new("git")
-            .args(&["rev-parse", "--short", "HEAD"])
+            .args(["rev-parse", "--short", "HEAD"])
             .output().unwrap()
             .stdout).trim().to_string()
 }
@@ -97,7 +97,7 @@ fn version_string() -> String {
 
 /// Finds whether a feature is enabled by examining the Cargo variable.
 fn feature_enabled(name: &str) -> bool {
-    env::var(&format!("CARGO_FEATURE_{}", name))
+    env::var(format!("CARGO_FEATURE_{}", name))
         .map(|e| ! e.is_empty())
         .unwrap_or(false)
 }

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -68,7 +68,7 @@ impl FromIterator<PathBuf> for GitCache {
                         git.repos.push(r);
                     }
                     Err(miss) => {
-                        git.misses.push(miss)
+                        git.misses.push(miss);
                     }
                 }
             }

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -170,15 +170,13 @@ impl GitRepo {
                 if e.code() != git2::ErrorCode::NotFound {
                     error!("Error opening Git repo from env using GIT_DIR: {:?}", e);
                     return Err(path);
-                } else {
-                    // nothing found, search using discover
-                    match git2::Repository::discover(&path) {
-                        Ok(r) => r,
-                        Err(e) => {
-                            error!("Error discovering Git repositories: {:?}", e);
-                            return Err(path);
-
-                        }
+                }
+                // nothing found, search using discover
+                match git2::Repository::discover(&path) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        error!("Error discovering Git repositories: {:?}", e);
+                        return Err(path);
                     }
                 }
             }

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -314,8 +314,8 @@ fn reorient(path: &Path) -> PathBuf {
 
     // TODO: I’m not 100% on this func tbh
     let path = match current_dir() {
-        Err(_)   => Path::new(".").join(&path),
-        Ok(dir)  => dir.join(&path),
+        Err(_)   => Path::new(".").join(path),
+        Ok(dir)  => dir.join(path),
     };
 
     path.canonicalize().unwrap_or(path)
@@ -381,7 +381,7 @@ fn current_branch(repo: &git2::Repository) -> Option<String>{
 impl f::SubdirGitRepo{
     pub fn from_path(dir : &Path, status : bool) -> Self{
 
-        let path = &reorient(&dir);
+        let path = &reorient(dir);
         let g = git2::Repository::open(path);
         if let Ok(repo) = g{
 

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -397,7 +397,7 @@ impl f::SubdirGitRepo{
                     return Self{status : f::SubdirGitRepoStatus::GitClean, branch};
                 }
                 Err(e) => {
-                    error!("Error looking up Git statuses: {:?}", e);
+                    error!("Error looking up Git statuses: {e:?}");
                 }
             }
         }

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -397,7 +397,7 @@ impl f::SubdirGitRepo{
                     return Self{status : f::SubdirGitRepoStatus::GitClean, branch};
                 }
                 Err(e) => {
-                    error!("Error looking up Git statuses: {:?}", e)
+                    error!("Error looking up Git statuses: {:?}", e);
                 }
             }
         }

--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -82,7 +82,7 @@ pub struct Permissions {
     pub setuid:         bool,
 }
 
-/// The file's FileAttributes field, available only on Windows.
+/// The file's `FileAttributes` field, available only on Windows.
 #[derive(Copy, Clone)]
 pub struct Attributes {
     pub archive:         bool,

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -316,10 +316,9 @@ impl<'dir> File<'dir> {
         if let FileTarget::Ok(f) = target {
             if f.is_link() {
                 return f.link_target_recurse();
-            } else {
-                return FileTarget::Ok(f);
             }
-        } 
+            return FileTarget::Ok(f);
+        }
         target
     }
 

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -234,17 +234,17 @@ impl SortField {
             Self::ModifiedAge   => b.modified_time().cmp(&a.modified_time()),  // flip b and a
 
             Self::FileType => match a.type_char().cmp(&b.type_char()) { // todo: this recomputes
-                Ordering::Equal  => natord::compare(&*a.name, &*b.name),
+                Ordering::Equal  => natord::compare(&a.name, &b.name),
                 order            => order,
             },
 
             Self::Extension(ABCabc) => match a.ext.cmp(&b.ext) {
-                Ordering::Equal  => natord::compare(&*a.name, &*b.name),
+                Ordering::Equal  => natord::compare(&a.name, &b.name),
                 order            => order,
             },
 
             Self::Extension(AaBbCc) => match a.ext.cmp(&b.ext) {
-                Ordering::Equal  => natord::compare_ignore_case(&*a.name, &*b.name),
+                Ordering::Equal  => natord::compare_ignore_case(&a.name, &b.name),
                 order            => order,
             },
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -27,7 +27,7 @@ pub fn configure<T: AsRef<OsStr>>(ev: Option<T>) {
 
     let result = log::set_logger(GLOBAL_LOGGER);
     if let Err(e) = result {
-        eprintln!("Failed to initialise logger: {}", e);
+        eprintln!("Failed to initialise logger: {e}");
     }
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -8,10 +8,7 @@ use ansi_term::{Colour, ANSIString};
 /// Sets the internal logger, changing the log level based on the value of an
 /// environment variable.
 pub fn configure<T: AsRef<OsStr>>(ev: Option<T>) {
-    let ev = match ev {
-        Some(v)  => v,
-        None     => return,
-    };
+    let Some(ev) = ev else { return };
 
     let env_var = ev.as_ref();
     if env_var.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,30 +84,30 @@ fn main() {
                 }
 
                 Err(e) if e.kind() == ErrorKind::BrokenPipe => {
-                    warn!("Broken pipe error: {}", e);
+                    warn!("Broken pipe error: {e}");
                     exit(exits::SUCCESS);
                 }
 
                 Err(e) => {
-                    eprintln!("{}", e);
+                    eprintln!("{e}");
                     exit(exits::RUNTIME_ERROR);
                 }
             }
         }
 
         OptionsResult::Help(help_text) => {
-            print!("{}", help_text);
+            print!("{help_text}");
         }
 
         OptionsResult::Version(version_str) => {
-            print!("{}", version_str);
+            print!("{version_str}");
         }
 
         OptionsResult::InvalidOptions(error) => {
-            eprintln!("exa: {}", error);
+            eprintln!("exa: {error}");
 
             if let Some(s) = error.suggestion() {
-                eprintln!("{}", s);
+                eprintln!("{s}");
             }
 
             exit(exits::OPTIONS_ERROR);
@@ -180,14 +180,14 @@ impl<'args> Exa<'args> {
             match File::from_args(PathBuf::from(file_path), None, None, self.options.view.deref_links) {
                 Err(e) => {
                     exit_status = 2;
-                    writeln!(io::stderr(), "{:?}: {}", file_path, e)?;
+                    writeln!(io::stderr(), "{file_path:?}: {e}")?;
                 }
 
                 Ok(f) => {
                     if f.points_to_directory() && ! self.options.dir_action.treat_dirs_as_files() {
                         match f.to_dir() {
                             Ok(d)   => dirs.push(d),
-                            Err(e)  => writeln!(io::stderr(), "{:?}: {}", file_path, e)?,
+                            Err(e)  => writeln!(io::stderr(), "{file_path:?}: {e}")?,
                         }
                     }
                     else {

--- a/src/options/error.rs
+++ b/src/options/error.rs
@@ -63,8 +63,8 @@ impl From<glob::PatternError> for OptionsError {
 impl fmt::Display for NumberSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Arg(arg) => write!(f, "option {}", arg),
-            Self::Env(env) => write!(f, "environment variable {}", env),
+            Self::Arg(arg) => write!(f, "option {arg}"),
+            Self::Env(env) => write!(f, "environment variable {env}"),
         }
     }
 }
@@ -79,20 +79,20 @@ impl fmt::Display for OptionsError {
                     write!(f, "Option {} has no {:?} setting ({})", arg, attempt, Choices(values))
                 }
                 else {
-                    write!(f, "Option {} has no {:?} setting", arg, attempt)
+                    write!(f, "Option {arg} has no {attempt:?} setting")
                 }
             }
-            Self::Parse(e)                   => write!(f, "{}", e),
-            Self::Unsupported(e)             => write!(f, "{}", e),
-            Self::Conflict(a, b)             => write!(f, "Option {} conflicts with option {}", a, b),
-            Self::Duplicate(a, b) if a == b  => write!(f, "Flag {} was given twice", a),
-            Self::Duplicate(a, b)            => write!(f, "Flag {} conflicts with flag {}", a, b),
-            Self::Useless(a, false, b)       => write!(f, "Option {} is useless without option {}", a, b),
-            Self::Useless(a, true, b)        => write!(f, "Option {} is useless given option {}", a, b),
-            Self::Useless2(a, b1, b2)        => write!(f, "Option {} is useless without options {} or {}", a, b1, b2),
+            Self::Parse(e)                   => write!(f, "{e}"),
+            Self::Unsupported(e)             => write!(f, "{e}"),
+            Self::Conflict(a, b)             => write!(f, "Option {a} conflicts with option {b}"),
+            Self::Duplicate(a, b) if a == b  => write!(f, "Flag {a} was given twice"),
+            Self::Duplicate(a, b)            => write!(f, "Flag {a} conflicts with flag {b}"),
+            Self::Useless(a, false, b)       => write!(f, "Option {a} is useless without option {b}"),
+            Self::Useless(a, true, b)        => write!(f, "Option {a} is useless given option {b}"),
+            Self::Useless2(a, b1, b2)        => write!(f, "Option {a} is useless without options {b1} or {b2}"),
             Self::TreeAllAll                 => write!(f, "Option --tree is useless given --all --all"),
-            Self::FailedParse(s, n, e)       => write!(f, "Value {:?} not valid for {}: {}", s, n, e),
-            Self::FailedGlobPattern(ref e)   => write!(f, "Failed to parse glob pattern: {}", e),
+            Self::FailedParse(s, n, e)       => write!(f, "Value {s:?} not valid for {n}: {e}"),
+            Self::FailedGlobPattern(ref e)   => write!(f, "Failed to parse glob pattern: {e}"),
         }
     }
 }

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -33,10 +33,7 @@ impl SortField {
         let Some(word) = matches.get(&flags::SORT)? else { return Ok(Self::default()) };
 
         // Get String because we can’t match an OsStr
-        let word = match word.to_str() {
-            Some(w)  => w,
-            None     => return Err(OptionsError::BadArgument(&flags::SORT, word.into()))
-        };
+        let Some(word) = word.to_str() else { return Err(OptionsError::BadArgument(&flags::SORT, word.into())) };
 
         let field = match word {
             "name" | "filename" => {

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -184,10 +184,7 @@ impl IgnorePatterns {
 
         // If there are no inputs, we return a set of patterns that doesn’t
         // match anything, rather than, say, `None`.
-        let inputs = match matches.get(&flags::IGNORE_GLOB)? {
-            Some(is)  => is,
-            None      => return Ok(Self::empty()),
-        };
+        let Some(inputs) = matches.get(&flags::IGNORE_GLOB)? else { return Ok(Self::empty()) };
 
         // Awkwardly, though, a glob pattern can be invalid, and we need to
         // deal with invalid patterns somehow.

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -30,10 +30,7 @@ impl SortField {
     /// Returns the default sort field if none is given, or `Err` if the
     /// value doesn’t correspond to a sort field we know about.
     fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {
-        let word = match matches.get(&flags::SORT)? {
-            Some(w)  => w,
-            None     => return Ok(Self::default()),
-        };
+        let Some(word) = matches.get(&flags::SORT)? else { return Ok(Self::default()) };
 
         // Get String because we can’t match an OsStr
         let word = match word.to_str() {

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -102,21 +102,21 @@ impl fmt::Display for HelpString {
     /// Format this help options into an actual string of help
     /// text to be displayed to the user.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", USAGE_PART1)?;
+        write!(f, "{USAGE_PART1}")?;
 
         if cfg!(feature = "git") {
-            write!(f, "\n{}", GIT_FILTER_HELP)?;
+            write!(f, "\n{GIT_FILTER_HELP}")?;
         }
 
-        write!(f, "\n{}", USAGE_PART2)?;
+        write!(f, "\n{USAGE_PART2}")?;
 
         if cfg!(feature = "git") {
-            write!(f, "\n{}", GIT_VIEW_HELP)?;
+            write!(f, "\n{GIT_VIEW_HELP}")?;
         }
 
         if xattr::ENABLED {
-            write!(f, "\n{}", EXTENDED_HELP)?;
-            write!(f, "\n{}", SECATTR_HELP)?;
+            write!(f, "\n{EXTENDED_HELP}")?;
+            write!(f, "\n{SECATTR_HELP}")?;
         }
 
         writeln!(f)

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -164,7 +164,7 @@ impl Args {
             // the pair “-- --arg”, without it getting matched as a flag that
             // doesn’t exist.
             if ! parsing {
-                frees.push(arg)
+                frees.push(arg);
             }
             else if arg == "--" {
                 parsing = false;
@@ -194,7 +194,7 @@ impl Args {
                     let flag = Flag::Long(arg.long);
                     match arg.takes_value {
                         TakesValue::Forbidden => {
-                            result_flags.push((flag, None))
+                            result_flags.push((flag, None));
                         }
                         TakesValue::Necessary(values) => {
                             if let Some(next_arg) = inputs.next() {
@@ -283,7 +283,7 @@ impl Args {
                         let flag = Flag::Short(*byte);
                         match arg.takes_value {
                             TakesValue::Forbidden => {
-                                result_flags.push((flag, None))
+                                result_flags.push((flag, None));
                             }
                             TakesValue::Necessary(values) |
                             TakesValue::Optional(values) => {

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -484,9 +484,9 @@ pub enum ParseError {
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NeedsValue { flag, values: None }      => write!(f, "Flag {} needs a value", flag),
-            Self::NeedsValue { flag, values: Some(cs) }  => write!(f, "Flag {} needs a value ({})", flag, Choices(cs)),
-            Self::ForbiddenValue { flag }                => write!(f, "Flag {} cannot take a value", flag),
+            Self::NeedsValue { flag, values: None }      => write!(f, "Flag {flag} needs a value"),
+            Self::NeedsValue { flag, values: Some(cs) }  => write!(f, "Flag {flag} needs a value ({})", Choices(cs)),
+            Self::ForbiddenValue { flag }                => write!(f, "Flag {flag} cannot take a value"),
             Self::UnknownShortArgument { attempt }       => write!(f, "Unknown argument -{}", *attempt as char),
             Self::UnknownArgument { attempt }            => write!(f, "Unknown argument --{}", attempt.to_string_lossy()),
         }

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -316,7 +316,7 @@ impl Args {
 
             // Otherwise, it’s a free string, usually a file name.
             else {
-                frees.push(arg)
+                frees.push(arg);
             }
         }
 

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -71,7 +71,7 @@ impl fmt::Display for Flag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Self::Short(short)  => write!(f, "-{}", *short as char),
-            Self::Long(long)    => write!(f, "--{}", long),
+            Self::Long(long)    => write!(f, "--{long}"),
         }
     }
 }
@@ -330,7 +330,7 @@ impl Args {
         }
     }
 
-    fn lookup_long<'b>(&self, long: &'b OsStr) -> Result<&Arg, ParseError> {
+    fn lookup_long(&self, long: &OsStr) -> Result<&Arg, ParseError> {
         match self.0.iter().find(|arg| arg.long == long) {
             Some(arg)  => Ok(arg),
             None       => Err(ParseError::UnknownArgument { attempt: long.to_os_string() })

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -494,14 +494,14 @@ impl fmt::Display for ParseError {
 }
 
 #[cfg(unix)]
-fn os_str_to_bytes<'b>(s: &'b OsStr) ->  &'b [u8]{
+fn os_str_to_bytes(s: &OsStr) -> &[u8]{
     use std::os::unix::ffi::OsStrExt;
 
     return s.as_bytes()
 }
 
 #[cfg(unix)]
-fn bytes_to_os_str<'b>(b:  &'b [u8]) ->  &'b OsStr{
+fn bytes_to_os_str(b: &[u8]) -> &OsStr{
     use std::os::unix::ffi::OsStrExt;
 
     return OsStr::from_bytes(b);

--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -27,10 +27,7 @@ impl UseColours {
             None => Self::Automatic,
         };
 
-        let word = match matches.get_where(|f| f.matches(&flags::COLOR) || f.matches(&flags::COLOUR))? {
-            Some(w)  => w,
-            None => return Ok(default_value),
-        };
+        let Some(word) = matches.get_where(|f| f.matches(&flags::COLOR) || f.matches(&flags::COLOUR))? else { return Ok(default_value) };
 
         if word == "always" {
             Ok(Self::Always)

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -33,7 +33,7 @@ impl Mode {
         let flag = matches.has_where_any(|f| f.matches(&flags::LONG) || f.matches(&flags::ONE_LINE)
                                           || f.matches(&flags::GRID) || f.matches(&flags::TREE));
 
-        let flag = if let Some(f) = flag { f } else {
+        let Some(flag) = flag else {
             Self::strict_check_long_flags(matches)?;
             let grid = grid::Options::deduce(matches)?;
             return Ok(Self::Grid(grid));

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -84,7 +84,7 @@ impl Mode {
             for option in &[ &flags::BINARY, &flags::BYTES, &flags::INODE, &flags::LINKS,
                              &flags::HEADER, &flags::BLOCKS, &flags::TIME, &flags::GROUP, &flags::NUMERIC ] {
                 if matches.has(option)? {
-                    return Err(OptionsError::Useless(*option, false, &flags::LONG));
+                    return Err(OptionsError::Useless(option, false, &flags::LONG));
                 }
             }
 

--- a/src/output/cell.rs
+++ b/src/output/cell.rs
@@ -143,7 +143,7 @@ impl Deref for TextCellContents {
     type Target = [ANSIString<'static>];
 
     fn deref(&self) -> &Self::Target {
-        &*self.0
+        &self.0
     }
 }
 

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -179,14 +179,14 @@ impl<'a> Render<'a> {
             self.add_files_to_table(&mut pool, &mut table, &mut rows, &self.files, TreeDepth::root());
 
             for row in self.iterate_with_table(table.unwrap(), rows) {
-                writeln!(w, "{}", row.strings())?
+                writeln!(w, "{}", row.strings())?;
             }
         }
         else {
             self.add_files_to_table(&mut pool, &mut None, &mut rows, &self.files, TreeDepth::root());
 
             for row in self.iterate(rows) {
-                writeln!(w, "{}", row.strings())?
+                writeln!(w, "{}", row.strings())?;
             }
         }
 

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -328,7 +328,7 @@ impl<'a> Render<'a> {
             }
 
             let count = egg.xattrs.len();
-            for (index, xattr) in egg.xattrs.enumerate() {
+            for (index, xattr) in egg.xattrs.iter().enumerate() {
                 let params = TreeParams::new(depth.deeper(), errors.is_empty() && index == count - 1);
                 let r = self.render_xattr(xattr, params);
                 rows.push(r);

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -357,7 +357,7 @@ impl<'a> Render<'a> {
         let error_message = if let Some(path) = path {
             format!("<{}: {}>", path.display(), error)
         } else {
-            format!("<{}>", error)
+            format!("<{error}>")
         };
 
         // TODO: broken_symlink() doesn’t quite seem like the right name for

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -328,7 +328,7 @@ impl<'a> Render<'a> {
             }
 
             let count = egg.xattrs.len();
-            for (index, xattr) in egg.xattrs.into_iter().enumerate() {
+            for (index, xattr) in egg.xattrs.enumerate() {
                 let params = TreeParams::new(depth.deeper(), errors.is_empty() && index == count - 1);
                 let r = self.render_xattr(xattr, params);
                 rows.push(r);

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -317,7 +317,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
     // and if that's the case then I think it's best to not try and generalize escape::escape to this case,
     // as this adaptation would incur some unneeded operations there
     pub fn escape_color_and_hyperlinks(&self, bits: &mut Vec<ANSIString<'_>>, good: Style, bad: Style) {
-        let string = self.file.name.to_owned();
+        let string = self.file.name.clone();
 
         if string.chars().all(|c| c >= 0x20 as char && c != 0x7f as char) {
             let painted = good.paint(string);

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -430,5 +430,5 @@ pub trait Colours: FiletypeColours {
 
 /// Generate a string made of `n` spaces.
 fn spaces(width: u32) -> String {
-    (0 .. width).into_iter().map(|_| ' ').collect()
+    (0 .. width).map(|_| ' ').collect()
 }

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -61,7 +61,7 @@ impl<'a> Render<'a> {
         }
 
         if let Some(display) = grid.fit_into_width(self.console_width) {
-            write!(w, "{}", display)
+            write!(w, "{display}")
         }
         else {
             // File names too long for a grid - drop down to just listing them!

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -44,12 +44,10 @@ impl<'a> Render<'a> {
         for file in &self.files {
             let filename = self.file_style.for_file(file, self.theme);
             let contents = filename.paint();
-            let width;
-
-            match (filename.options.embed_hyperlinks, filename.options.show_icons) {
-                (EmbedHyperlinks::On, ShowIcons::On(spacing)) => width = filename.bare_width() + 1 + (spacing as usize),
-                (EmbedHyperlinks::On, ShowIcons::Off) => width = filename.bare_width(),
-                (EmbedHyperlinks::Off, _) => width = *contents.width(),
+            let width = match (filename.options.embed_hyperlinks, filename.options.show_icons) {
+                (EmbedHyperlinks::On, ShowIcons::On(spacing)) => filename.bare_width() + 1 + (spacing as usize),
+                (EmbedHyperlinks::On, ShowIcons::Off) => filename.bare_width(),
+                (EmbedHyperlinks::Off, _) => *contents.width(),
             };
 
             grid.add(tg::Cell {

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -54,7 +54,7 @@ impl<'a> Render<'a> {
                 contents:  contents.strings().to_string(),
                 // with hyperlink escape sequences,
                 // the actual *contents.width() is larger than actually needed, so we take only the filename
-                width:     width,
+                width,
             });
         }
 

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -227,7 +227,7 @@ impl<'a> Render<'a> {
         let original_height = divide_rounding_up(rows.len(), column_count);
         let height = divide_rounding_up(num_cells, column_count);
 
-        for (i, (file_name, row)) in file_names.iter().zip(rows.into_iter()).enumerate() {
+        for (i, (file_name, row)) in file_names.iter().zip(rows).enumerate() {
             let index = if self.grid.across {
                     i % column_count
                 }
@@ -271,7 +271,7 @@ impl<'a> Render<'a> {
         }
         else {
             for column in &columns {
-                for cell in column.iter() {
+                for cell in column {
                     let cell = grid::Cell {
                         contents: ANSIStrings(&cell.contents).to_string(),
                         width:    *cell.width,

--- a/src/output/render/git.rs
+++ b/src/output/render/git.rs
@@ -60,7 +60,9 @@ impl f::GitStatus {
 
 pub trait Colours {
     fn not_modified(&self) -> Style;
-    #[allow(clippy::new_ret_no_self)]
+    // FIXME: this amount of allows needed to keep clippy happy should be enough
+    // of an argument that new needs to be renamed.
+    #[allow(clippy::new_ret_no_self,clippy::wrong_self_convention)]
     fn new(&self) -> Style;
     fn modified(&self) -> Style;
     fn deleted(&self) -> Style;

--- a/src/output/render/octal.rs
+++ b/src/output/render/octal.rs
@@ -17,7 +17,7 @@ impl Render for Option<f::OctalPermissions> {
                 let octal_group  = f::OctalPermissions::bits_to_octal(perm.group_read, perm.group_write, perm.group_execute);
                 let octal_other  = f::OctalPermissions::bits_to_octal(perm.other_read, perm.other_write, perm.other_execute);
 
-                TextCell::paint(style, format!("{}{}{}{}", octal_sticky, octal_owner, octal_group, octal_other))
+                TextCell::paint(style, format!("{octal_sticky}{octal_owner}{octal_group}{octal_other}"))
             },
             None => TextCell::paint(style, "----".into())
         }

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -179,6 +179,7 @@ impl Column {
     /// Get the alignment this column should use.
     #[cfg(unix)]
     pub fn alignment(self) -> Alignment {
+        #[allow(clippy::wildcard_in_or_patterns)]
         match self {
             Self::FileSize   |
             Self::HardLinks  |

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -476,7 +476,7 @@ impl<'a, 'f> Table<'a> {
     }
 
     pub fn add_widths(&mut self, row: &Row) {
-        self.widths.add_widths(row)
+        self.widths.add_widths(row);
     }
 
     fn permissions_plus(&self, file: &File<'_>, xattrs: bool) -> Option<f::PermissionsPlus> {

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -480,27 +480,21 @@ impl<'a, 'f> Table<'a> {
     }
 
     fn permissions_plus(&self, file: &File<'_>, xattrs: bool) -> Option<f::PermissionsPlus> {
-        match file.permissions() {
-            Some(p) => Some(f::PermissionsPlus {
-                file_type: file.type_char(),
-                #[cfg(unix)]
-                permissions: p,
-                #[cfg(windows)]
-                attributes: file.attributes(),
-                xattrs
-            }),
-            None => None,
-        }
+        file.permissions().map(|p| f::PermissionsPlus {
+            file_type: file.type_char(),
+            #[cfg(unix)]
+            permissions: p,
+            #[cfg(windows)]
+            attributes: file.attributes(),
+            xattrs
+        })
     }
 
     #[cfg(unix)]
     fn octal_permissions(&self, file: &File<'_>) -> Option<f::OctalPermissions> {
-        match file.permissions() {
-            Some(p) => Some(f::OctalPermissions {
-                permissions: p,
-            }),
-            None => None,
-        }
+        file.permissions().map(|p| f::OctalPermissions {
+            permissions: p,
+        })
     }
 
     fn display(&self, file: &File<'_>, column: Column, xattrs: bool) -> TextCell {

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -437,7 +437,7 @@ pub struct Row {
     cells: Vec<TextCell>,
 }
 
-impl<'a, 'f> Table<'a> {
+impl<'a> Table<'a> {
     pub fn new(options: &'a Options, git: Option<&'a GitCache>, theme: &'a Theme) -> Table<'a> {
         let columns = options.columns.collect(git.is_some());
         let widths = TableWidths::zero(columns.len());

--- a/src/output/time.rs
+++ b/src/output/time.rs
@@ -83,14 +83,14 @@ impl TimeFormat {
 fn default_local(time: SystemTime) -> String {
     let date = LocalDateTime::at(systemtime_epoch(time));
     let date_format = get_dateformat(&date);
-    date_format.format(&date, &*LOCALE)
+    date_format.format(&date, &LOCALE)
 }
 
 #[allow(trivial_numeric_casts)]
 fn default_zoned(time: SystemTime, zone: &TimeZone) -> String {
     let date = zone.to_zoned(LocalDateTime::at(systemtime_epoch(time)));
     let date_format = get_dateformat(&date);
-    date_format.format(&date, &*LOCALE)
+    date_format.format(&date, &LOCALE)
 }
 
 fn get_dateformat(date: &LocalDateTime) -> &'static DateFormat<'static> {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -194,7 +194,7 @@ impl ExtensionMappings {
     }
 
     fn add(&mut self, pattern: glob::Pattern, style: Style) {
-        self.mappings.push((pattern, style))
+        self.mappings.push((pattern, style));
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

##### Description
<!--- Describe your changes in detail -->
I handled all clippy lints. This makes `nix flake check` pass, and allows further work to add clippy to CI.

This will increase code quality.

##### Related Issue
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

##### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This should make the code more readable and easier to use, and currently we are
at a reasonable time with not that many open pull requests (that I expect will get merged).

Rather now than in a few weeks, if the new PR trend is growing at a constant rate.

##### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using `cargo test`, `nix flake check`, `nix build ./#clippy`, now CI tests as well.

##### Screenshots (if appropriate):

##### Checklist while waiting for a review
- [x] Have you performed a self review of the code?
- [-] Have you added adequate tests?
- [x] If this adds a feature, has completions been added for zsh and fish?
- [x] Have you updated documentation, man pages, help?
- [x] Have you ensured any option flags are respected?
- [?] Does your code pass CI tests?
- [x] Does your commit summaries follow conventional commits?

##### all fixes
- refactor(clippy): fix borrowed trait implements required
- refactor(clippy): simplify format strings
- refactor(clippy): consistent style
- refactor(clippy): clippy::explicit_auto_deref
- refactor(clippy): clippy::explicit_auto_deref
- refactor(clippy): clippy::redundant_else
- refactor(clippy): clippy::manual_map
- refactor(clippy): clippy::semicolon_if_nothing_returned
- refactor(clippy): clippy::extra_unused_lifetimes
- refactor(clippy): allow clippy::wildcard_in_or_patterns
- refactor(clippy): clippy::uninlined_format_args
- refactor(clippy): allow Colours::new call with self
- refactor(clippy): clippy::explicit_iter_loop
- refactor(clippy): clippy::uninlined_format_args
- refactor(clippy): clippy::needless_late_init
- refactor(clippy): clippy::useless_conversion
- refactor(clippy): clippy::implicit_clone
- refactor(clippy): clippy::uninlined_format_args
- refactor(clippy): clippy::into-iter-on-ref
- refactor(clippy): clippy::semicolon_if_nothing_returned
- refactor(clippy): clippy::into_iter_on_ref
- refactor(clippy): clippy::needless_lifetimes
- refactor(clippy): clippy::uninlined_format_args
- refactor(clippy): trivial clippy lints
- refactor(clippy): clippy::semicolon_if_nothing_returned
- refactor(clippy): clippy::semicolon_if_nothing_returned
- refactor(clippy): clippy::manual_let_else
- refactor(clippy): clippy::semicolon_if_nothing_returned
- refactor(clippy): clippy::semicolon_if_nothing_returned
- refactor(clippy): clippy::uninlined_format_args
- refactor(clippy): clippy::manual_let_else
- refactor(clippy): clippy::manual_let_else
- refactor(clippy): clippy::manual_let_else
- refactor(clippy): clippy::manual_let_else
- refactor(clippy): clippy::manual_let_else
