### PR TITLE
Add Width Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s.
 - **--icons**: display icons
 - **--no-icons**: don't display icons (always overrides --icons)
 - **--hyperlink**: display entries as hyperlinks
+- **-w**, **--width=(columns)**: set screen width in columns
 
 ### Filtering options
 

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -28,6 +28,7 @@ complete -c eza -l git-ignore -d "Ignore files mentioned in '.gitignore'"
 complete -c eza -s a -l all -d "Show hidden and 'dot' files"
 complete -c eza -s d -l list-dirs -d "List directories like regular files"
 complete -c eza -s L -l level -d "Limit the depth of recursion" -x -a "1 2 3 4 5 6 7 8 9"
+complete -c eza -s w -l width -d "Limits column output of grid, 0 implies auto-width" 
 complete -c eza -s r -l reverse -d "Reverse the sort order"
 complete -c eza -s s -l sort -d "Which field to sort by" -x -a "
     accessed\t'Sort by file accessed time'

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -30,6 +30,7 @@ __eza() {
         {-d,--list-dirs}"[List directories like regular files]" \
         {-D,--only-dirs}"[List only directories]" \
         {-L,--level}"+[Limit the depth of recursion]" \
+        {-w,--width}"+[Limits column output of grid, 0 implies auto-width]" \
         {-r,--reverse}"[Reverse the sort order]" \
         {-s,--sort}="[Which field to sort by]:(sort field):(accessed age changed created date extension Extension filename Filename inode modified oldest name Name newest none size time type)" \
         {-I,--ignore-glob}"[Ignore files that match these glob patterns]" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -78,6 +78,9 @@ Valid settings are ‘`always`’, ‘`automatic`’, and ‘`never`’.
 `--hyperlink`
 : Display entries as hyperlinks
 
+`-w`, `--width=COLS`
+Set screen width in columns.
+
 
 FILTERING AND SORTING OPTIONS
 =============================
@@ -204,7 +207,7 @@ eza responds to the following environment variables:
 
 ## `COLUMNS`
 
-Overrides the width of the terminal, in characters.
+Overrides the width of the terminal, in characters, however, `-w` takes precedence.
 
 For example, ‘`COLUMNS=80 eza`’ will show a grid view with a maximum width of 80 characters.
 

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -14,6 +14,7 @@ pub static RECURSE:     Arg = Arg { short: Some(b'R'), long: "recurse",     take
 pub static TREE:        Arg = Arg { short: Some(b'T'), long: "tree",        takes_value: TakesValue::Forbidden };
 pub static CLASSIFY:    Arg = Arg { short: Some(b'F'), long: "classify",    takes_value: TakesValue::Forbidden };
 pub static DEREF_LINKS: Arg = Arg { short: Some(b'X'), long: "dereference", takes_value: TakesValue::Forbidden };
+pub static WIDTH:       Arg = Arg { short: Some(b'w'), long: "width",       takes_value: TakesValue::Necessary(None) };
 
 pub static COLOR:  Arg = Arg { short: None, long: "color",  takes_value: TakesValue::Necessary(Some(COLOURS)) };
 pub static COLOUR: Arg = Arg { short: None, long: "colour", takes_value: TakesValue::Necessary(Some(COLOURS)) };
@@ -77,7 +78,7 @@ pub static ALL_ARGS: Args = Args(&[
     &VERSION, &HELP,
 
     &ONE_LINE, &LONG, &GRID, &ACROSS, &RECURSE, &TREE, &CLASSIFY, &DEREF_LINKS,
-    &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE,
+    &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE, &WIDTH,
 
     &ALL, &ALMOST_ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
     &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS,

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -25,6 +25,7 @@ DISPLAY OPTIONS
   --icons            display icons
   --no-icons         don't display icons (always overrides --icons)
   --hyperlink        display entries as hyperlinks
+  -w, --width COLS   set screen width in columns
 
 FILTERING AND SORTING OPTIONS
   -a, --all                  show hidden and 'dot' files


### PR DESCRIPTION
`ls` has a `-w/--width` option limiting the columns of the grid output. `exa/eza` only allows to specify the number of columns via the `COLUMNS` environment variable for some reason.

This adds the `-w/--width` option to the existing column limiting, meaning it behaves just like when specifying the `COLUMNS` variable, but with the `ls`-like command line argument. In case both `COLUMNS` and `-w`, then the cli option takes precedence.

The only difference to the `-w` option of `ls` is, that `ls -w 0` sets the columns to infinity, while here it goes back to automatic width detection just as for the `COLUMNS` variable.

Resolves https://github.com/ogham/exa/issues/1168