### PR TITLE
added git-ignored color/style option

### DIFF
--- a/man/eza_colors.5.md
+++ b/man/eza_colors.5.md
@@ -193,6 +193,9 @@ LIST OF CODES
 `gt`
 : a modified metadata flag in Git
 
+`gi`
+: an ignored flag in Git
+
 `xx`
 : “punctuation”, including many background UI elements
 

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -199,6 +199,7 @@ impl UiStyles {
             "gd" => self.git.deleted              = pair.to_style(),
             "gv" => self.git.renamed              = pair.to_style(),
             "gt" => self.git.typechange           = pair.to_style(),
+            "gi" => self.git.ignored              = pair.to_style(),
 
             "xx" => self.punctuation              = pair.to_style(),
             "da" => self.date                     = pair.to_style(),


### PR DESCRIPTION
I tried to specify colors of ignored git files, and then saw that it was an issue on the exa page. Turns out it was an incredibly trivial fix :smile:

So I see some recent activity on the exa page, but either way I am glad to see community stepping up to maintain this project, and I will definitely do my part as a long time exa user to contribute to which ever project. 