### PR TITLE
Add `.envrc` so direnv automatically opens the nix dev environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ parts
 prime
 stage
 *.snap
+.direnv


### PR DESCRIPTION
I use and like [direnv](https://direnv.net) because it saves me from needing to always run `nix develop...`
The file shouldn't do anything for ppl that don't have direnv installed so it's a harmless addition but positive imo