### PR TITLE
docs: cafkafk -> eza-community

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 rust-version = "1.70.0"
 exclude = ["/devtools/*", "/Justfile", "/Vagrantfile", "/screenshots.png"]
 readme = "README.md"
-homepage = "https://github.com/cafkafk/eza"
+homepage = "https://github.com/eza-community/eza"
 license = "MIT"
-repository = "https://github.com/cafkafk/eza"
+repository = "https://github.com/eza-community/eza"
 version = "0.10.7"
 
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ eza is a modern, maintained replacement for ls, built on [exa](https://github.co
 [![Built with Nix](https://img.shields.io/badge/Built_With-Nix-5277C3.svg?logo=nixos&labelColor=73C3D5)](https://nixos.org)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
 
-[![Unit tests](https://github.com/cafkafk/eza/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/cafkafk/eza/actions/workflows/unit-tests.yml)
+[![Unit tests](https://github.com/eza-community/eza/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/eza-community/eza/actions/workflows/unit-tests.yml)
 ![Crates.io](https://img.shields.io/crates/v/eza?link=https%3A%2F%2Fcrates.io%2Fcrates%2Feza)
-![Crates.io](https://img.shields.io/crates/l/eza?link=https%3A%2F%2Fgithub.com%2Fcafkafk%2Feza%2Fblob%2Fmain%2FLICENCE)
+![Crates.io](https://img.shields.io/crates/l/eza?link=https%3A%2F%2Fgithub.com%2Feza-community%2Feza%2Fblob%2Fmain%2FLICENCE)
 
 </div>
 
@@ -31,12 +31,12 @@ By deliberately making some decisions differently, eza attempts to be a more fea
 
 **eza** features not in exa (non-exhaustive):
 
- -   Fixes [“The Grid Bug”](https://github.com/cafkafk/eza/issues/66#issuecomment-1656758327) introduced in exa 2021.
+ -   Fixes [“The Grid Bug”](https://github.com/eza-community/eza/issues/66#issuecomment-1656758327) introduced in exa 2021.
  -   Hyperlink support.
  -   Selinux context output.
  -   Git repo status output.
  -   Human readable relative dates.
- -   Several security fixes (see [dependabot](https://github.com/cafkafk/eza/security/dependabot?q=is%3Aclosed))
+ -   Several security fixes (see [dependabot](https://github.com/eza-community/eza/security/dependabot?q=is%3Aclosed))
  -   Many smaller bug fixes/changes!
 
 ---
@@ -49,11 +49,11 @@ By deliberately making some decisions differently, eza attempts to be a more fea
 
 If you already have Nix setup with flake support, you can try out eza with the `nix run` command:
 
-    nix run github:cafkafk/eza
+    nix run github:eza-community/eza
 
 Nix will build eza and run it. 
 
-If you want to pass arguments this way, use e.g. `nix run github:cafkafk/eza -- -ol`.
+If you want to pass arguments this way, use e.g. `nix run github:eza-community/eza -- -ol`.
 
 <a id="installation">
 <h1>Installation</h1>
@@ -75,7 +75,7 @@ Cargo will build the `eza` binary and place it in `$HOME/.local/share/cargo/bin/
 
 If you already have a Rust environment set up, you can use the `cargo install` command in your local clone of the repo:
 
-    git clone https://github.com/cafkafk/eza.git
+    git clone https://github.com/eza-community/eza.git
     cd eza
     cargo install --path .
 
@@ -192,7 +192,7 @@ Some of the options accept parameters:
     <img src="https://img.shields.io/badge/rustc-1.63.0+-lightgray.svg" alt="Rust 1.63.0+" />
 </a>
 
-<a href="https://github.com/cafkafk/eza/blob/master/LICENCE">
+<a href="https://github.com/eza-community/eza/blob/master/LICENCE">
     <img src="https://img.shields.io/badge/licence-MIT-green" alt="MIT Licence" />
 </a>
 </h1></a>

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ fn main() -> io::Result<()> {
     #![allow(clippy::write_with_newline)]
 
     let tagline = "eza - A modern, maintained replacement for ls";
-    let url     = "https://github.com/cafkafk/eza";
+    let url     = "https://github.com/eza-community/eza";
 
     let ver =
         if is_debug_build() {

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -267,8 +267,8 @@ AUTHOR
 
 eza is maintained by Christina Sørensen and many other contributors.
 
-**Source code:** `https://github.com/cafkafk/eza` \
-**Contributors:** `https://github.com/cafkafk/eza/graphs/contributors`
+**Source code:** `https://github.com/eza-community/eza` \
+**Contributors:** `https://github.com/eza-community/eza/graphs/contributors`
 
 Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors of exa, from which eza was forked.
 

--- a/man/eza_colors.5.md
+++ b/man/eza_colors.5.md
@@ -274,8 +274,8 @@ AUTHOR
 
 eza is maintained by Christina Sørensen and many other contributors.
 
-**Source code:** `https://github.com/cafkafk/eza` \
-**Contributors:** `https://github.com/cafkafk/eza/graphs/contributors`
+**Source code:** `https://github.com/eza-community/eza` \
+**Contributors:** `https://github.com/eza-community/eza/graphs/contributors`
 
 Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors of exa, from which eza was forked.
 


### PR DESCRIPTION
This repository was transferred from `cafkafk` to `eza-community` (https://github.com/ogham/exa/issues/1139#issuecomment-1664997468)

This PR replaces all remaining references to the old repository.