### PR TITLE
Add --no-git option

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ These options are available when running with `--long` (`-l`):
 - **-@**, **--extended**: list each file’s extended attributes and sizes
 - **--changed**: use the changed timestamp field
 - **--git**: list each file’s Git status, if tracked or ignored
-- **--no-git**: suppress Git status (always overrides `--git`)
+- **--no-git**: suppress Git status (always overrides `--git`, `--git-repos`, `--git-repos-no-status`)
 - **--time-style**: how to format timestamps
 - **--no-permissions**: suppress the permissions field
 - **-o**, **--octal-permissions**: list each file's permission in octal format

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ These options are available when running with `--long` (`-l`):
 - **-@**, **--extended**: list each file’s extended attributes and sizes
 - **--changed**: use the changed timestamp field
 - **--git**: list each file’s Git status, if tracked or ignored
+- **--no-git**: suppress Git status (always overrides `--git`)
 - **--time-style**: how to format timestamps
 - **--no-permissions**: suppress the permissions field
 - **-o**, **--octal-permissions**: list each file's permission in octal format

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -92,6 +92,7 @@ complete -c eza -l no-time -d "Suppress the time field"
 
 # Optional extras
 complete -c eza -l git -d "List each file's Git status, if tracked"
+complete -c eza -l no-git -d "Suppress Git status"
 complete -c eza -l git-repos -d "List each git-repos status and branch name"
 complete -c eza -l git-repos-no-status -d "List each git-repos branch name (much faster)"
 complete -c eza -s '@' -l extended -d "List each file's extended attributes and sizes"

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -55,6 +55,7 @@ __eza() {
         {-U,--created}"[Use the created timestamp field]" \
         {-X,--dereference}"[dereference symlinks for file information]" \
         --git"[List each file's Git status, if tracked]" \
+        --no-git"[Suppress Git status]" \
         --git-repos"[List each git-repos status and branch name]" \
         --git-repos-no-status"[List each git-repos branch name (much faster)]" \
         {-@,--extended}"[List each file's extended attributes and sizes]" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -200,7 +200,7 @@ This adds a two-character column indicating the staged and unstaged statuses res
 Directories will be shown to have the status of their contents, which is how ‘deleted’ is possible: if a directory contains a file that has a certain status, it will be shown to have that status.
 
 `--no-git`
-: Don't show Git status (always overrides `--git`)
+: Don't show Git status (always overrides `--git`, `--git-repos`, `--git-repos-no-status`)
 
 
 ENVIRONMENT VARIABLES

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -199,6 +199,9 @@ This adds a two-character column indicating the staged and unstaged statuses res
 
 Directories will be shown to have the status of their contents, which is how ‘deleted’ is possible: if a directory contains a file that has a certain status, it will be shown to have that status.
 
+`--no-git`
+: Don't show Git status (always overrides `--git`)
+
 
 ENVIRONMENT VARIABLES
 =====================

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -67,6 +67,7 @@ pub static NO_ICONS: Arg = Arg { short: None, long: "no-icons", takes_value: Tak
 
 // optional feature options
 pub static GIT:               Arg = Arg { short: None,       long: "git",                  takes_value: TakesValue::Forbidden };
+pub static NO_GIT:            Arg = Arg { short: None,       long: "no-git",               takes_value: TakesValue::Forbidden };
 pub static GIT_REPOS:         Arg = Arg { short: None,       long: "git-repos",            takes_value: TakesValue::Forbidden };
 pub static GIT_REPOS_NO_STAT: Arg = Arg { short: None,       long: "git-repos-no-status",  takes_value: TakesValue::Forbidden };
 pub static EXTENDED:          Arg = Arg { short: Some(b'@'), long: "extended",             takes_value: TakesValue::Forbidden };
@@ -87,5 +88,6 @@ pub static ALL_ARGS: Args = Args(&[
     &BLOCKSIZE, &TIME, &ACCESSED, &CREATED, &TIME_STYLE, &HYPERLINK,
     &NO_PERMISSIONS, &NO_FILESIZE, &NO_USER, &NO_TIME, &NO_ICONS,
 
-    &GIT, &GIT_REPOS, &GIT_REPOS_NO_STAT, &EXTENDED, &OCTAL, &SECURITY_CONTEXT
+    &GIT, &NO_GIT, &GIT_REPOS, &GIT_REPOS_NO_STAT,
+    &EXTENDED, &OCTAL, &SECURITY_CONTEXT
 ]);

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -67,6 +67,7 @@ static GIT_FILTER_HELP: &str = "  \
   --git-ignore             ignore files mentioned in '.gitignore'";
 static GIT_VIEW_HELP:   &str = "  \
   --git                    list each file's Git status, if tracked or ignored
+  --no-git                 suppress Git status (always overrides --git)
   --git-repos              list root of git-tree status";
 static EXTENDED_HELP:   &str = "  \
   -@, --extended           list each file's extended attributes and sizes";

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -67,7 +67,7 @@ static GIT_FILTER_HELP: &str = "  \
   --git-ignore             ignore files mentioned in '.gitignore'";
 static GIT_VIEW_HELP:   &str = "  \
   --git                    list each file's Git status, if tracked or ignored
-  --no-git                 suppress Git status (always overrides --git)
+  --no-git                 suppress Git status (always overrides --git, --git-repos, --git-repos-no-status)
   --git-repos              list root of git-tree status";
 static EXTENDED_HELP:   &str = "  \
   -@, --extended           list each file's extended attributes and sizes";

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -220,8 +220,8 @@ impl Columns {
         let time_types = TimeTypes::deduce(matches)?;
 
         let git = matches.has(&flags::GIT)? && !matches.has(&flags::NO_GIT)?;
-        let subdir_git_repos = matches.has(&flags::GIT_REPOS)?;
-        let subdir_git_repos_no_stat = !subdir_git_repos && matches.has(&flags::GIT_REPOS_NO_STAT)?;
+        let subdir_git_repos = matches.has(&flags::GIT_REPOS)? && !matches.has(&flags::NO_GIT)?;
+        let subdir_git_repos_no_stat = !subdir_git_repos && matches.has(&flags::GIT_REPOS_NO_STAT)? && !matches.has(&flags::NO_GIT)?;
 
         let blocksize        = matches.has(&flags::BLOCKSIZE)?;
         let group            = matches.has(&flags::GROUP)?;

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -88,7 +88,7 @@ impl Mode {
                 }
             }
 
-            if matches.has(&flags::GIT)? {
+            if matches.has(&flags::GIT)? && !matches.has(&flags::NO_GIT)? {
                 return Err(OptionsError::Useless(&flags::GIT, false, &flags::LONG));
             }
             else if matches.has(&flags::LEVEL)? && ! matches.has(&flags::RECURSE)? && ! matches.has(&flags::TREE)? {
@@ -219,7 +219,7 @@ impl Columns {
     fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {
         let time_types = TimeTypes::deduce(matches)?;
 
-        let git = matches.has(&flags::GIT)?;
+        let git = matches.has(&flags::GIT)? && !matches.has(&flags::NO_GIT)?;
         let subdir_git_repos = matches.has(&flags::GIT_REPOS)?;
         let subdir_git_repos_no_stat = !subdir_git_repos && matches.has(&flags::GIT_REPOS_NO_STAT)?;
 

--- a/xtests/outputs/help.ansitxt
+++ b/xtests/outputs/help.ansitxt
@@ -53,5 +53,5 @@ LONG VIEW OPTIONS
   --no-user                suppress the user field
   --no-time                suppress the time field
   --git                    list each file's Git status, if tracked or ignored
-  --no-git                 suppress Git status (always overrides --git)
+  --no-git                 suppress Git status (always overrides --git, --git-repos, --git-repos-no-status)
   -@, --extended           list each file's extended attributes and sizes

--- a/xtests/outputs/help.ansitxt
+++ b/xtests/outputs/help.ansitxt
@@ -53,4 +53,5 @@ LONG VIEW OPTIONS
   --no-user                suppress the user field
   --no-time                suppress the time field
   --git                    list each file's Git status, if tracked or ignored
+  --no-git                 suppress Git status (always overrides --git)
   -@, --extended           list each file's extended attributes and sizes


### PR DESCRIPTION
This PR adds the `--no-git` option. This option overrides `--git` in all cases and disables showing the Git status of files in long view (`-l`). This enables users of shell aliases and the like to turn off git status display in an *ad hoc* manner.

It might someday be worth looking into automatic `--no-`-prefixed versions of flags, but for now, this works.

(This is my first contribution to this codebase; I've done my best to make all the appropriate changes, but I'd appreciate any pointers if there's something I've missed. I took inspiration from the `--no-icons` option as prior art.)