### PR TITLE
feat: Optimize checking for empty directories when a directory has subdirectories

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -428,9 +428,6 @@ impl<'dir> File<'dir> {
     }
 
     // To display icons for empty folders.
-    // The naive approach, as one would think that this info may have been cached.
-    // but as mentioned in the size function comment above, different filesystems
-    // make it difficult to get any info about a dir by it's size, so this may be it.
     #[cfg(unix)]
     pub fn is_empty_dir(&self) -> bool {
         if self.is_directory() {
@@ -442,14 +439,30 @@ impl<'dir> File<'dir> {
                 // has subdirectories.
                 false
             } else {
-                match Dir::read_dir(self.path.clone()) {
-                    // . & .. are skipped, if the returned iterator has .next(), it's not empty
-                    Ok(has_files) => has_files.files(super::DotFilter::Dotfiles, None, false, false).next().is_none(),
-                    Err(_) => false,
-                }
+                self.is_empty_directory()
             }
         } else {
             false
+        }
+    }
+
+    #[cfg(windows)]
+    pub fn is_empty_dir(&self) -> bool {
+        if self.is_directory() {
+            self.is_empty_directory()
+        } else {
+            false
+        }
+    }
+
+    // The naive approach, as one would think that this info may have been cached.
+    // but as mentioned in the size function comment above, different filesystems
+    // make it difficult to get any info about a dir by it's size, so this may be it.
+    fn is_empty_directory(&self) -> bool {
+        match Dir::read_dir(self.path.clone()) {
+            // . & .. are skipped, if the returned iterator has .next(), it's not empty
+            Ok(has_files) => has_files.files(super::DotFilter::Dotfiles, None, false, false).next().is_none(),
+            Err(_) => false,
         }
     }
 

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -427,6 +427,16 @@ impl<'dir> File<'dir> {
         }
     }
 
+    #[cfg(windows)]
+    pub fn size(&self) -> f::Size {
+        if self.is_directory() {
+            f::Size::None
+        }
+        else {
+            f::Size::Some(self.metadata.len())
+        }
+    }
+
     // To display icons for empty folders.
     #[cfg(unix)]
     pub fn is_empty_dir(&self) -> bool {
@@ -463,16 +473,6 @@ impl<'dir> File<'dir> {
             // . & .. are skipped, if the returned iterator has .next(), it's not empty
             Ok(has_files) => has_files.files(super::DotFilter::Dotfiles, None, false, false).next().is_none(),
             Err(_) => false,
-        }
-    }
-
-    #[cfg(windows)]
-    pub fn size(&self) -> f::Size {
-        if self.is_directory() {
-            f::Size::None
-        }
-        else {
-            f::Size::Some(self.metadata.len())
         }
     }
 

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -441,14 +441,15 @@ impl<'dir> File<'dir> {
         }
     }
 
-    // To display icons for empty folders.
     /// Determines if the directory is empty or not.
     ///
     /// For Unix platforms, this function first checks the link count to quickly 
-    /// determine non-empty directories. If the link count is less than or equal to 2,
-    /// it then checks the directory contents to determine if it's truly empty.
-    /// The naive approach used here checks the contents directly, as certain filesystems 
-    /// make it difficult to infer emptiness based on directory size alone.
+    /// determine non-empty directories. On most UNIX filesystems the link count
+    /// is two plus the number of subdirectories. If the link count is less than
+    /// or equal to 2, it then checks the directory contents to determine if
+    /// it's truly empty. The naive approach used here checks the contents
+    /// directly, as certain filesystems make it difficult to infer emptiness
+    /// based on directory size alone.
     #[cfg(unix)]
     pub fn is_empty_dir(&self) -> bool {
         if self.is_directory() {


### PR DESCRIPTION
On a unix system a directory will have a link count of two when it does not have any subdirectories.  This adds a check to `is_empty_dir` to check the link count to avoid the expensive listing of a directory.

Also noticed there is not a windows version of `is_empty_dir` so eza will most likely not compile on windows.  I am not a windows developer and have no way to build or test a windows version.