### PR TITLE
Re-align `--git-ignore` line in help message

### DIFF
--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -37,7 +37,10 @@ FILTERING AND SORTING OPTIONS
   -D, --only-dirs            list only directories
   -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore";
 
-  static USAGE_PART2: &str = "  \
+static GIT_FILTER_HELP: &str = "  \
+  --git-ignore               ignore files mentioned in '.gitignore'";
+
+static USAGE_PART2: &str = "  \
   Valid sort fields:         name, Name, extension, Extension, size, type,
                              modified, accessed, created, inode, and none.
                              date, time, old, and new all refer to modified.
@@ -63,8 +66,6 @@ LONG VIEW OPTIONS
   --no-user                suppress the user field
   --no-time                suppress the time field";
 
-static GIT_FILTER_HELP: &str = "  \
-  --git-ignore             ignore files mentioned in '.gitignore'";
 static GIT_VIEW_HELP:   &str = "  \
   --git                    list each file's Git status, if tracked or ignored
   --no-git                 suppress Git status (always overrides --git, --git-repos, --git-repos-no-status)


### PR DESCRIPTION
Before:

```
FILTERING AND SORTING OPTIONS
  -a, --all                  show hidden and 'dot' files
  -d, --list-dirs            list directories as files; don't list their contents
  -L, --level DEPTH          limit the depth of recursion
  -r, --reverse              reverse the sort order
  -s, --sort SORT_FIELD      which field to sort by
  --group-directories-first  list directories before other files
  -D, --only-dirs            list only directories
  -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore
  --git-ignore             ignore files mentioned in '.gitignore'
  Valid sort fields:         name, Name, extension, Extension, size, type,
                             modified, accessed, created, inode, and none.
                             date, time, old, and new all refer to modified.
```

After:

```
FILTERING AND SORTING OPTIONS
  -a, --all                  show hidden and 'dot' files
  -d, --list-dirs            list directories as files; don't list their contents
  -L, --level DEPTH          limit the depth of recursion
  -r, --reverse              reverse the sort order
  -s, --sort SORT_FIELD      which field to sort by
  --group-directories-first  list directories before other files
  -D, --only-dirs            list only directories
  -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore
  --git-ignore               ignore files mentioned in '.gitignore'
  Valid sort fields:         name, Name, extension, Extension, size, type,
                             modified, accessed, created, inode, and none.
                             date, time, old, and new all refer to modified.

```

Also put the strings in the source code in the same order they appear so that the alignment is «visually obvious».