### PR TITLE
Avoid error messages if direnv is installed but nix isn't

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
-use flake .
+if has nix; then
+  use flake .
+fi


### PR DESCRIPTION
If someone’s using `direnv` but has not `nix` installed, either you don’t allow the `.envrc` and you get `direnv: error /home/ariasuni/projets/contrib/eza/.envrc is blocked. Run `direnv allow` to approve its content`, or you allow it and get `environment:1270: nix : commande introuvable`, everytime you enter the directory.

As an alternative, use a condition so that direnv doesn’t try to use nix if it’s not installed.