### PR TITLE
Add vendored-libgit2 feature to git2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ features = ["format"]
 version = "0.18"
 optional = true
 default-features = false
+features = ["vendored-libgit2"]
 
 [target.'cfg(unix)'.dependencies]
 uzers = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ features = ["format"]
 version = "0.18"
 optional = true
 default-features = false
+# This builds libgit2 into the binary to avoid dependency problems on systems
+# that don't have the required version of libgit2 yet.
+# See: https://github.com/eza-community/eza/pull/192
 features = ["vendored-libgit2"]
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This builds libgit2 into the binary to avoid dependency problems on systems that don't have the required version of libgit2 yet.

### Background:
When building the deb package from eza tag v0.11.0 and installing it you run into this problem:
![Screenshot from 2023-09-04 09-26-31](https://github.com/eza-community/eza/assets/49617392/5d0d54a6-8cbf-432e-bdff-af815d086089)

I'm not exactly sure why this didn't appear before and how we got into this, but my best guess is this https://github.com/eza-community/eza/pull/182 where be bumped the https://github.com/rust-lang/git2-rs/ version. Somehow the new version requires the `vendored-libgit2` feature to be set to ship libgit2 with it and before it didn't, although I can't really tell where from their changelog.

You might wonder why don't we just add this as dependency to our deb package ... well, neither the newest Ubuntu nor Debian have the required libgit2 v1.7 in their repos but only v1.1 or v1.5.