### PR TITLE
deps: change ansi_term to ansiterm from rustadopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "ansiterm"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "4ab587f5395da16dd2e6939adf53dede583221b320cadfb94e02b5b7b9bf24cc"
 dependencies = [
  "winapi",
 ]
@@ -82,7 +82,7 @@ dependencies = [
 name = "eza"
 version = "0.11.0"
 dependencies = [
- "ansi_term",
+ "ansiterm",
  "datetime",
  "git2",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ name = "eza"
 
 
 [dependencies]
-ansi_term = "0.12"
+ansiterm = "0.12.2"
 glob = "0.3"
 lazy_static = "1.3"
 libc = "0.2"

--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -7,7 +7,7 @@
 //! # Contributors
 //! Please keep these lists sorted. If you're using vim, :sort i
 
-use ansi_term::Style;
+use ansiterm::Style;
 use phf::{phf_map, Map};
 
 use crate::fs::File;
@@ -265,7 +265,7 @@ pub struct FileTypeColor;
 impl FileColours for FileTypeColor {
     /// Map from the file type to the display style/color for the file.
     fn colour_file(&self, file: &File<'_>) -> Option<Style> {
-        use ansi_term::Colour::*;
+        use ansiterm::Colour::*;
 
         match FileType::get_file_type(file) {
             Some(FileType::Compiled)   => Some(Yellow.normal()),

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::OsStr;
 
-use ansi_term::{Colour, ANSIString};
+use ansiterm::{Colour, ANSIString};
 
 
 /// Sets the internal logger, changing the log level based on the value of an

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use std::ffi::{OsStr, OsString};
 use std::io::{self, Write, ErrorKind};
 use std::path::{Component, PathBuf};
 
-use ansi_term::{ANSIStrings, Style};
+use ansiterm::{ANSIStrings, Style};
 
 use log::*;
 
@@ -57,7 +57,7 @@ fn main() {
     logger::configure(env::var_os(vars::EXA_DEBUG));
 
     #[cfg(windows)]
-    if let Err(e) = ansi_term::enable_ansi_support() {
+    if let Err(e) = ansiterm::enable_ansi_support() {
         warn!("Failed to enable ANSI support: {}", e);
     }
 

--- a/src/output/cell.rs
+++ b/src/output/cell.rs
@@ -3,7 +3,7 @@
 use std::iter::Sum;
 use std::ops::{Add, Deref, DerefMut};
 
-use ansi_term::{Style, ANSIString, ANSIStrings};
+use ansiterm::{Style, ANSIString, ANSIStrings};
 use unicode_width::UnicodeWidthStr;
 
 

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -65,7 +65,7 @@ use std::mem::MaybeUninit;
 use std::path::PathBuf;
 use std::vec::IntoIter as VecIntoIter;
 
-use ansi_term::Style;
+use ansiterm::Style;
 use scoped_threadpool::Pool;
 
 use crate::fs::{Dir, File};

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -1,4 +1,4 @@
-use ansi_term::{ANSIString, Style};
+use ansiterm::{ANSIString, Style};
 
 
 pub fn escape(string: String, bits: &mut Vec<ANSIString<'_>>, good: Style, bad: Style) {

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::path::Path;
 
-use ansi_term::{ANSIString, Style};
+use ansiterm::{ANSIString, Style};
 
 use crate::fs::{File, FileTarget};
 use crate::output::cell::TextCellContents;

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Write};
 
-use ansi_term::ANSIStrings;
+use ansiterm::ANSIStrings;
 use term_grid as grid;
 
 use crate::fs::{Dir, File};

--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use ansiterm::Style;
 use phf::{phf_map, Map};
 
 use crate::fs::File;

--- a/src/output/lines.rs
+++ b/src/output/lines.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use ansi_term::ANSIStrings;
+use ansiterm::ANSIStrings;
 
 use crate::fs::File;
 use crate::fs::filter::FileFilter;

--- a/src/output/render/blocks.rs
+++ b/src/output/render/blocks.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use ansiterm::Style;
 use locale::Numeric as NumericLocale;
 use number_prefix::Prefix;
 
@@ -67,8 +67,8 @@ pub trait Colours {
 
 #[cfg(test)]
 pub mod test {
-    use ansi_term::Style;
-    use ansi_term::Colour::*;
+    use ansiterm::Style;
+    use ansiterm::Colour::*;
 
     use super::Colours;
     use crate::output::cell::{TextCell, DisplayWidth};

--- a/src/output/render/filetype.rs
+++ b/src/output/render/filetype.rs
@@ -1,4 +1,4 @@
-use ansi_term::{ANSIString, Style};
+use ansiterm::{ANSIString, Style};
 
 use crate::fs::fields as f;
 

--- a/src/output/render/git.rs
+++ b/src/output/render/git.rs
@@ -1,4 +1,4 @@
-use ansi_term::{ANSIString, Style, Color};
+use ansiterm::{ANSIString, Style, Color};
 
 use crate::output::cell::{TextCell, DisplayWidth};
 use crate::fs::fields as f;
@@ -79,8 +79,8 @@ pub mod test {
     use crate::output::cell::{TextCell, DisplayWidth};
     use crate::fs::fields as f;
 
-    use ansi_term::Colour::*;
-    use ansi_term::Style;
+    use ansiterm::Colour::*;
+    use ansiterm::Style;
 
 
     struct TestColours;

--- a/src/output/render/groups.rs
+++ b/src/output/render/groups.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use ansiterm::Style;
 use uzers::{Users, Groups};
 
 use crate::fs::fields as f;
@@ -62,8 +62,8 @@ pub mod test {
     use uzers::{User, Group};
     use uzers::mock::MockUsers;
     use uzers::os::unix::GroupExt;
-    use ansi_term::Colour::*;
-    use ansi_term::Style;
+    use ansiterm::Colour::*;
+    use ansiterm::Style;
 
 
     struct TestColours;

--- a/src/output/render/inode.rs
+++ b/src/output/render/inode.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use ansiterm::Style;
 
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
@@ -16,7 +16,7 @@ pub mod test {
     use crate::output::cell::TextCell;
     use crate::fs::fields as f;
 
-    use ansi_term::Colour::*;
+    use ansiterm::Colour::*;
 
 
     #[test]

--- a/src/output/render/links.rs
+++ b/src/output/render/links.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use ansiterm::Style;
 #[cfg(unix)]
 use locale::Numeric as NumericLocale;
 
@@ -32,8 +32,8 @@ pub mod test {
     #[cfg(unix)]
     use crate::fs::fields as f;
 
-    use ansi_term::Colour::*;
-    use ansi_term::Style;
+    use ansiterm::Colour::*;
+    use ansiterm::Style;
     #[cfg(unix)]
     use locale;
 

--- a/src/output/render/octal.rs
+++ b/src/output/render/octal.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use ansiterm::Style;
 
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
@@ -37,7 +37,7 @@ pub mod test {
     use crate::output::cell::TextCell;
     use crate::fs::fields as f;
 
-    use ansi_term::Colour::*;
+    use ansiterm::Colour::*;
 
 
     #[test]

--- a/src/output/render/permissions.rs
+++ b/src/output/render/permissions.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use ansi_term::{ANSIString, Style};
+use ansiterm::{ANSIString, Style};
 
 use crate::fs::fields as f;
 use crate::output::cell::{TextCell, DisplayWidth};
@@ -183,8 +183,8 @@ pub mod test {
     use crate::output::cell::TextCellContents;
     use crate::fs::fields as f;
 
-    use ansi_term::Colour::*;
-    use ansi_term::Style;
+    use ansiterm::Colour::*;
+    use ansiterm::Style;
 
 
     struct TestColours;

--- a/src/output/render/securityctx.rs
+++ b/src/output/render/securityctx.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use ansiterm::Style;
 
 use crate::fs::fields as f;
 use crate::output::cell::{TextCell, DisplayWidth};

--- a/src/output/render/size.rs
+++ b/src/output/render/size.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use ansiterm::Style;
 use locale::Numeric as NumericLocale;
 use number_prefix::Prefix;
 
@@ -95,8 +95,8 @@ pub mod test {
     use crate::fs::fields as f;
 
     use locale::Numeric as NumericLocale;
-    use ansi_term::Colour::*;
-    use ansi_term::Style;
+    use ansiterm::Colour::*;
+    use ansiterm::Style;
     use number_prefix::Prefix;
 
 

--- a/src/output/render/times.rs
+++ b/src/output/render/times.rs
@@ -1,7 +1,7 @@
 use std::time::SystemTime;
 
 use datetime::TimeZone;
-use ansi_term::Style;
+use ansiterm::Style;
 
 use crate::output::cell::TextCell;
 use crate::output::time::TimeFormat;

--- a/src/output/render/users.rs
+++ b/src/output/render/users.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use ansiterm::Style;
 use uzers::Users;
 
 use crate::fs::fields as f;
@@ -45,8 +45,8 @@ pub mod test {
 
     use uzers::User;
     use uzers::mock::MockUsers;
-    use ansi_term::Colour::*;
-    use ansi_term::Style;
+    use ansiterm::Colour::*;
+    use ansiterm::Style;
 
 
     struct TestColours;

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -1,5 +1,5 @@
-use ansi_term::Style;
-use ansi_term::Colour::*;
+use ansiterm::Style;
+use ansiterm::Colour::*;
 
 use crate::theme::ColourScale;
 use crate::theme::ui_styles::*;

--- a/src/theme/lsc.rs
+++ b/src/theme/lsc.rs
@@ -1,8 +1,8 @@
 use std::iter::Peekable;
 use std::ops::FnMut;
 
-use ansi_term::{Colour, Style};
-use ansi_term::Colour::*;
+use ansiterm::{Colour, Style};
+use ansiterm::Colour::*;
 
 
 // Parsing the LS_COLORS environment variable into a map of names to Style values.
@@ -143,7 +143,7 @@ impl<'var> Pair<'var> {
 #[cfg(test)]
 mod ansi_test {
     use super::*;
-    use ansi_term::Style;
+    use ansiterm::Style;
 
     macro_rules! test {
         ($name:ident: $input:expr => $result:expr) => {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use ansiterm::Style;
 
 use crate::fs::File;
 use crate::output::file_name::Colours as FileNameColours;
@@ -370,7 +370,7 @@ fn apply_overlay(mut base: Style, overlay: Style) -> Style {
 
     base
 }
-// TODO: move this function to the ansi_term crate
+// TODO: move this function to the ansiterm crate
 
 
 #[cfg(test)]
@@ -378,7 +378,7 @@ fn apply_overlay(mut base: Style, overlay: Style) -> Style {
 mod customs_test {
     use super::*;
     use crate::theme::ui_styles::UiStyles;
-    use ansi_term::Colour::*;
+    use ansiterm::Colour::*;
 
     macro_rules! test {
         ($name:ident:  ls $ls:expr, exa $exa:expr  =>  colours $expected:ident -> $process_expected:expr) => {

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use ansiterm::Style;
 
 use crate::theme::lsc::Pair;
 


### PR DESCRIPTION
newly maintained ansiterm over at [rustadopt](github.com/rustadopt)

Much cleaner/nicer PR than before as we no longer need to change `colour` -> `color` etc. and the API is totally unchanged.