### PR TITLE
Expose vendored libgit2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,6 @@ features = ["format"]
 version = "0.18"
 optional = true
 default-features = false
-# This builds libgit2 into the binary to avoid dependency problems on systems
-# that don't have the required version of libgit2 yet.
-# See: https://github.com/eza-community/eza/pull/192
-features = ["vendored-libgit2"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 proc-mounts = "0.3"
@@ -83,6 +79,7 @@ default-features = false
 default = [ "git" ]
 git = [ "git2" ]
 vendored-openssl = ["git2/vendored-openssl"]
+vendored-libgit2 = ["git2/vendored-libgit2"]
 
 
 # make dev builds faster by excluding debug symbols

--- a/devtools/deb-package.sh
+++ b/devtools/deb-package.sh
@@ -17,6 +17,9 @@ ARCH="amd64"
 DEB_TMP_DIR="${NAME}_${VERSION}_${ARCH}"
 DEB_PACKAGE="${NAME}_${VERSION}_${ARCH}.deb"
 
+cargo build --release --features vendored-libgit2
+just man
+
 read -r -d '' DEB_CONTROL << EOM
 Package: ${NAME}
 Version: ${VERSION}


### PR DESCRIPTION
I exposed the `vendored-libgit2` feature as suggested and altered the `deb-package.sh` script to include the corresponding build commands.

Resolves #214