### PR TITLE
feat: add bright colour options, change punctuation default

### DIFF
--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -78,7 +78,7 @@ impl UiStyles {
                 },
             },
 
-            punctuation:  Black.bold(),
+            punctuation:  DarkGray.bold(),
             date:         Blue.normal(),
             inode:        Purple.normal(),
             blocks:       Cyan.normal(),

--- a/src/theme/lsc.rs
+++ b/src/theme/lsc.rs
@@ -118,6 +118,15 @@ impl<'var> Pair<'var> {
                 "35" => style = style.fg(Purple),
                 "36" => style = style.fg(Cyan),
                 "37" => style = style.fg(White),
+                // Bright foreground colours
+                "90" => style = style.fg(DarkGray),
+                "91" => style = style.fg(BrightRed),
+                "92" => style = style.fg(BrightGreen),
+                "93" => style = style.fg(BrightYellow),
+                "94" => style = style.fg(BrightBlue),
+                "95" => style = style.fg(BrightPurple),
+                "96" => style = style.fg(BrightCyan),
+                "97" => style = style.fg(BrightGray),
                 "38" => if let Some(c) = parse_into_high_colour(&mut iter) { style = style.fg(c) },
 
                 // Background colours
@@ -129,8 +138,16 @@ impl<'var> Pair<'var> {
                 "45" => style = style.on(Purple),
                 "46" => style = style.on(Cyan),
                 "47" => style = style.on(White),
+                // Bright background colours
+                "100" => style = style.on(DarkGray),
+                "101" => style = style.on(BrightRed),
+                "102" => style = style.on(BrightGreen),
+                "103" => style = style.on(BrightYellow),
+                "104" => style = style.on(BrightBlue),
+                "105" => style = style.on(BrightPurple),
+                "106" => style = style.on(BrightCyan),
+                "107" => style = style.on(BrightGray),
                 "48" => if let Some(c) = parse_into_high_colour(&mut iter) { style = style.on(c) },
-
                  _   => {/* ignore the error and do nothing */},
             }
         }


### PR DESCRIPTION
#### Comparison to DarkGray.Bold from Black.Bold  
[I know it's not much of a difference.. but it might be more visible]
![image](https://github.com/eza-community/eza/assets/121899304/16538440-64d5-4f04-ba65-98b2336d273f)

After many of these such issues: https://github.com/eza-community/eza/issues/234

I figured it was time to add some of the updates that we merged into the newly maintained ansiterm at [rustadopt](https://github.com/rustadpot/ansiterm-rs)

Some of which, are the option for bright colors on terminals that support it. I know that it's a bad picture, but it's possible that these dashes will show up on lighter terminals. If not, the default color can be changed on something we agree on (one of them may very well be a new brighter one)
#### This is the BrightGray:
![image](https://github.com/eza-community/eza/assets/121899304/a46ba26c-0a93-43b7-b913-e43001c44fba)



I still have to add into the documentation / man-pages that we support bright colors 90 - 108