### PR TITLE
Revise deb package script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ target
 /eza-linux-x86_64-*.zip
 /eza-macos-x86_64
 /eza-macos-x86_64-*.zip
-/eza_*_amd64.deb
+/eza_*.deb
 /MD5SUMS
 /SHA1SUMS
 

--- a/devtools/deb-package.sh
+++ b/devtools/deb-package.sh
@@ -1,26 +1,68 @@
-#!/bin/bash
+#!/bin/bash -e
 
-if [ -z "$1" ]
-  then
-    echo "Usage: deb-package.sh <version>"
-    echo ""
-    echo "Package the given version number into a .deb package."
-    echo "Example: deb-package.sh 0.10.7"
-    exit 1
-fi
-
+REPO_URL="https://github.com/eza-community/eza"
+NAME="eza"
 DESTDIR=/usr/bin
 DOCDIR=/usr/share/man/
-NAME="eza"
-VERSION=$1
-ARCH="amd64"
-DEB_TMP_DIR="${NAME}_${VERSION}_${ARCH}"
-DEB_PACKAGE="${NAME}_${VERSION}_${ARCH}.deb"
 
-cargo build --release --features vendored-libgit2
+TAG=$(git describe --tags --abbrev=0)
+VERSION=${TAG:1}
+
+echo "checkout tag ${TAG}"
+git checkout --quiet ${TAG}
+
+echo "build man pages"
 just man
 
-read -r -d '' DEB_CONTROL << EOM
+declare -A TARGETS
+TARGETS["amd64"]="x86_64-unknown-linux-gnu"
+TARGETS["arm64"]="aarch64-unknown-linux-gnu"
+TARGETS["armhf"]="arm-unknown-linux-gnueabihf"
+
+echo "download release notes"
+RELEASE_NOTES=$(curl -s ${REPO_URL}/releases/tag/${TAG})
+
+for ARCH in "${!TARGETS[@]}"; do
+    echo "building ${ARCH} package:"
+
+    DEB_TMP_DIR="${NAME}_${VERSION}_${ARCH}"
+    DEB_PACKAGE="${NAME}_${VERSION}_${ARCH}.deb"
+
+    TARGET=${TARGETS[$ARCH]}
+    echo " -> downloading ${TARGET} archive"
+    wget -q -O "${ARCH}.tar.gz" "${REPO_URL}/releases/download/${TAG}/${NAME}_${TARGET}.tar.gz"
+
+    echo " -> verifying ${TARGET} archive"
+    CHECKSUM=$(md5sum "${ARCH}.tar.gz" | cut -d ' ' -f 1)
+    echo "    checksum: ${CHECKSUM}"
+    grep -q "${CHECKSUM}" <<< "${RELEASE_NOTES}" \
+        || (echo "checksum mismatch" && exit 1)
+    echo "    checksum ok"
+
+    echo " -> creating directory structure"
+    mkdir -p ${DEB_TMP_DIR}
+    mkdir -p ${DEB_TMP_DIR}${DESTDIR}
+    mkdir -p ${DEB_TMP_DIR}${DOCDIR}
+    mkdir -p ${DEB_TMP_DIR}${DOCDIR}/man1
+    mkdir -p ${DEB_TMP_DIR}${DOCDIR}/man5
+    mkdir -p ${DEB_TMP_DIR}/DEBIAN
+    mkdir -p ${DEB_TMP_DIR}/usr/share/doc/${NAME}
+    chmod 755 -R ${DEB_TMP_DIR}
+    
+    echo " -> extract executable"
+    tar -xzf "${ARCH}.tar.gz"
+    cp ${NAME} ${DEB_TMP_DIR}${DESTDIR}
+    chmod 755 ${DEB_TMP_DIR}${DESTDIR}/${NAME}
+
+    echo " -> compress man pages"
+    gzip -cn9 target/man/eza.1 > ${DEB_TMP_DIR}${DOCDIR}man1/eza.1.gz
+    gzip -cn9 target/man/eza_colors.5 > ${DEB_TMP_DIR}${DOCDIR}man5/eza_colors.5.gz
+    gzip -cn9 target/man/eza_colors-explanation.5 > ${DEB_TMP_DIR}${DOCDIR}man5/eza_colors-explanation.5.gz
+    chmod 644 ${DEB_TMP_DIR}${DOCDIR}/**/*.gz
+    
+    echo " -> create control file"
+    touch ${DEB_TMP_DIR}/DEBIAN/control
+    cat > ${DEB_TMP_DIR}/DEBIAN/control <<EOM
 Package: ${NAME}
 Version: ${VERSION}
 Section: utils
@@ -36,8 +78,17 @@ Description: Modern replacement for ls
  It also has extra features not present in the original ls, such as viewing the
  Git status for a directory, or recursing into directories with a tree view.
 EOM
-
-read -r -d '' DEB_COPYRIGHT << EOM
+    chmod 644 ${DEB_TMP_DIR}/DEBIAN/control
+    
+    echo " -> copy changelog"
+    cp CHANGELOG.md ${DEB_TMP_DIR}/usr/share/doc/${NAME}/changelog
+    gzip -cn9 ${DEB_TMP_DIR}/usr/share/doc/${NAME}/changelog > ${DEB_TMP_DIR}/usr/share/doc/${NAME}/changelog.gz
+    rm ${DEB_TMP_DIR}/usr/share/doc/${NAME}/changelog
+    chmod 644 ${DEB_TMP_DIR}/usr/share/doc/${NAME}/changelog.gz
+    
+    echo " -> create copyright file"
+    touch ${DEB_TMP_DIR}/usr/share/doc/${NAME}/copyright
+    cat > ${DEB_TMP_DIR}/usr/share/doc/${NAME}/copyright << EOM
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: ${NAME}
 Upstream-Contact: Christina Sørensen <christina@cafkafk.com>
@@ -70,52 +121,16 @@ License: MIT
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
 EOM
-
-# create temporary build directory
-mkdir -p ${DEB_TMP_DIR}
-
-# create directory structure
-mkdir -p ${DEB_TMP_DIR}${DESTDIR}
-mkdir -p ${DEB_TMP_DIR}${DOCDIR}
-mkdir -p ${DEB_TMP_DIR}${DOCDIR}/man1
-mkdir -p ${DEB_TMP_DIR}${DOCDIR}/man5
-mkdir -p ${DEB_TMP_DIR}/DEBIAN
-mkdir -p ${DEB_TMP_DIR}/usr/share/doc/${NAME}
-
-# fix directory permissions
-chmod 755 -R ${DEB_TMP_DIR}
-
-# binary
-cp target/release/${NAME} ${DEB_TMP_DIR}${DESTDIR}
-chmod 755 ${DEB_TMP_DIR}${DESTDIR}/${NAME}
-
-# man page
-gzip -cn9 target/man/eza.1 > ${DEB_TMP_DIR}${DOCDIR}man1/eza.1.gz
-gzip -cn9 target/man/eza_colors.5 > ${DEB_TMP_DIR}${DOCDIR}man5/eza_colors.5.gz
-gzip -cn9 target/man/eza_colors-explanation.5 > ${DEB_TMP_DIR}${DOCDIR}man5/eza_colors-explanation.5.gz
-chmod 644 ${DEB_TMP_DIR}${DOCDIR}/**/*.gz
-
-# control file
-touch ${DEB_TMP_DIR}/DEBIAN/control
-echo "${DEB_CONTROL}" > ${DEB_TMP_DIR}/DEBIAN/control
-chmod 644 ${DEB_TMP_DIR}/DEBIAN/control
-
-# changelog
-cp CHANGELOG.md ${DEB_TMP_DIR}/usr/share/doc/${NAME}/changelog
-gzip -cn9 ${DEB_TMP_DIR}/usr/share/doc/${NAME}/changelog > ${DEB_TMP_DIR}/usr/share/doc/${NAME}/changelog.gz
-rm ${DEB_TMP_DIR}/usr/share/doc/${NAME}/changelog
-chmod 644 ${DEB_TMP_DIR}/usr/share/doc/${NAME}/changelog.gz
-
-# copyright file
-touch ${DEB_TMP_DIR}/usr/share/doc/${NAME}/copyright
-echo "${DEB_COPYRIGHT}" > ${DEB_TMP_DIR}/usr/share/doc/${NAME}/copyright
-chmod 644 ${DEB_TMP_DIR}/usr/share/doc/${NAME}/copyright
-
-# build package
-dpkg-deb --build --root-owner-group ${DEB_TMP_DIR}
-
-# clean up
-rm -rf ${DEB_TMP_DIR}
-
-# test package
-lintian ${DEB_PACKAGE}
+    chmod 644 ${DEB_TMP_DIR}/usr/share/doc/${NAME}/copyright
+    
+    echo " -> build ${ARCH} package"
+    dpkg-deb --build --root-owner-group ${DEB_TMP_DIR} > /dev/null
+    
+    echo " -> cleanup"
+    rm -rf ${DEB_TMP_DIR} ${ARCH}.tar.gz ${NAME}
+    
+    # gierens: this does not work on my arch at the moment and
+    #          i'm verifying on the repo host anyway thus the || true
+    echo " -> lint ${ARCH} package"
+    lintian ${DEB_PACKAGE} || true
+done


### PR DESCRIPTION
Since we are now shipping three linux architectures I thought I automate the process for the deb packages just a little bit more with my script and ended up over-engineering it completely.

It now automatically checks out the most recent tag, loops over the three architectures, pulls the corresponding binary asset from the release page and verifies that the checksum is present in the release notes, and then builds the corresponding package, leaving me with three .deb files I can just scp to the repo host. :rocket: 

@cafkafk this assumes that the assets have a name of the form `eza_{{ target }}.tar.gz` and that the corresponding md5sum is somewhere present in the release notes.