### PR TITLE
feat(ci): add apt installation workflow

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -1,0 +1,28 @@
+name: Apt Installation
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+    branches: [ main ]
+    paths:
+      - 'deb.asc'
+      - '.github/workflows/apt.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'deb.asc'
+      - '.github/workflows/apt.yml'
+jobs:
+  apt_installation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install eza via apt repo
+        run: |
+          wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | sudo tee /etc/apt/trusted.gpg.d/gierens.asc && \
+          echo "deb http://deb.gierens.de stable main" | sudo tee /etc/apt/sources.list.d/gierens.list && \
+          sudo apt update && \
+          sudo apt install -y eza
+      - name: Run eza
+        run: eza
+      - name: Open man page
+        run: man eza | cat

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches: [ main ]
     paths:
-      - '.github/workflows/*'
+      - '.github/workflows/unit-tests.yml'
       - 'src/**'
       - 'Cargo.*'
       - build.rs
   pull_request:
     branches: [ main ]
     paths:
-      - '.github/workflows/*'
+      - '.github/workflows/unit-tests.yml'
       - 'src/**'
       - 'Cargo.*'
       - build.rs


### PR DESCRIPTION
This adds a workflow that every night and on changes to the gpg key or this workflow installs eza from the deb repo and runs it and opens the man page to verify that the deb repo is working correctly.

I also limited the unit-tests workflow to run on unit-tests workflow changes instead of all workflow changes as this seems like an overkill.