### PR TITLE
fix(readme): revert to old apt install command suggestion and add hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,18 @@ key is in this repo under [deb.asc](/deb.asc).
 
 To install eza from this repo use:
 ```bash
-wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/gierens.asc
+wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | sudo tee /etc/apt/trusted.gpg.d/gierens.asc
 echo "deb http://deb.gierens.de stable main" | sudo tee /etc/apt/sources.list.d/gierens.list
 sudo apt update
 sudo apt install -y eza
 ```
+
+**Note:** on some systems like Docker containers apt might require the key
+to be in dearmored format, then use this command instead:
+```bash
+wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/gierens.asc
+```
+before proceeding with the others from above.
 
 ### Nix (Linux, MacOS)
 


### PR DESCRIPTION
Deamoring seems to break the installation on some normal Debian system while the only reported issue without it was in a Ubuntu Docker container. Thus we should not recommand dearmoring but only mention it for containers as edge cases.

Resolves #259 