### PR TITLE
fix(completions): remove stray backslashes

### DIFF
--- a/completions/bash/eza
+++ b/completions/bash/eza
@@ -38,13 +38,13 @@ _eza()
         # _parse_help doesn’t pick up short options when they are on the same line than long options
         --*)
             # colo[u]r isn’t parsed correctly so we filter these options out and add them by hand
-            parse_help=$( eza --help | grep -oE ' (\-\-[[:alnum:]@-]+)' | tr -d ' ' | grep -v '\-\-colo' )
+            parse_help=$( eza --help | grep -oE ' (--[[:alnum:]@-]+)' | tr -d ' ' | grep -v '\--colo' )
             completions=$( echo '--color --colour --color-scale --colour-scale' $parse_help )
             COMPREPLY=( $( compgen -W "$completions" -- "$cur" ) )
             ;;
 
         -*)
-            completions=$( eza --help | grep -oE ' (\-[[:alnum:]@])' | tr -d ' ' )
+            completions=$( eza --help | grep -oE ' (-[[:alnum:]@])' | tr -d ' ' )
             COMPREPLY=( $( compgen -W "$completions" -- "$cur" ) )
             ;;
 


### PR DESCRIPTION
[Grep 3.8 causes warnings on regular expressions with stray backslashes:](https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html)

> Regular expressions with stray backslashes now cause warnings, as
> their unspecified behavior can lead to unexpected results.
> For example, '\a' and 'a' are not always equivalent
> <https://bugs.gnu.org/39678>... The warnings are intended as a
> transition aid; they are likely to be errors in future releases.

On a fresh Fedora 38 container with grep 3.8, this results in warnings showing up in the terminal when trying to use the bash completions:

![Grep errors appearing in the terminal when using bash completions](https://github.com/eza-community/eza/assets/47428697/b687e54c-a98a-473b-92b2-c67f1bcc3ea1)

I can't say *why* these particular backslashes are stray backslashes, but removing them results in the completions working without any errors:

![The bash completions working without errors with the changes from this PR](https://github.com/eza-community/eza/assets/47428697/85928b5b-2565-488a-aeb2-9f7188697f58)
