### PR TITLE
Revert "Support for Windows Hidden Files"

### DIFF
--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -129,24 +129,11 @@ impl<'dir, 'ig> Files<'dir, 'ig> {
                     }
                 }
 
-                let file = File::from_args(
-                    path.clone(),
-                    self.dir,
-                    filename,
-                    self.deref_links
-                ).map_err(|e| (path.clone(), e));
-
-                // Windows has its own concept of hidden files, with a flag
-                // stored in the file's attributes
-                #[cfg(windows)]
-                if !self.dotfiles && file.as_ref().is_ok_and(|f| f.attributes().hidden) {
-                    continue;
-                }
-
-                return Some(file);
+                return Some(File::from_args(path.clone(), self.dir, filename, self.deref_links)
+                                 .map_err(|e| (path.clone(), e)))
             }
 
-            return None;
+            return None
         }
     }
 }


### PR DESCRIPTION
Reverts eza-community/eza#225

as pointed out by @cfxegbert on element, is_ok_and was first stabilized in 1.70 (https://github.com/rust-lang/rust/pull/110019), but we have to support 1.65 for gentoo, so unfortunately this will have to be reverted temporarily