### PR TITLE
docs(readme): Update deb instructions to use keyring

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To install eza from this repo use:
 sudo mkdir -p /etc/apt/keyrings
 wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | sudo gpg --dearmor -o /etc/apt/keyrings/gierens.gpg
 echo "deb [signed-by=/etc/apt/keyrings/gierens.gpg] http://deb.gierens.de stable main" | sudo tee /etc/apt/sources.list.d/gierens.list
-sudo chmod o+r /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.list
+sudo chmod 644 /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.list
 sudo apt update
 sudo apt install -y eza
 ```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,14 @@ pacman -S eza
 Eza is available from [deb.gierens.de](http://deb.gierens.de). The GPG public
 key is in this repo under [deb.asc](/deb.asc).
 
-To install eza from this repo use:
+First make sure you have the `gpg` command, and otherwise install it via:
+
+```bash
+sudo apt update
+sudo apt install -y gpg
+```
+
+Then install eza via:
 
 ```bash
 sudo mkdir -p /etc/apt/keyrings

--- a/README.md
+++ b/README.md
@@ -102,20 +102,13 @@ key is in this repo under [deb.asc](/deb.asc).
 To install eza from this repo use:
 
 ```bash
-wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | sudo tee /etc/apt/trusted.gpg.d/gierens.asc
-echo "deb http://deb.gierens.de stable main" | sudo tee /etc/apt/sources.list.d/gierens.list
+sudo mkdir -p /etc/apt/keyrings
+wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | sudo gpg --dearmor -o /etc/apt/keyrings/gierens.gpg
+echo "deb [signed-by=/etc/apt/keyrings/gierens.gpg] http://deb.gierens.de stable main" | sudo tee /etc/apt/sources.list.d/gierens.list
+sudo chmod o+r /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.list
 sudo apt update
 sudo apt install -y eza
 ```
-
-**Note:** on some systems like Docker containers apt might require the key
-to be in dearmored format, then use this command instead:
-
-```bash
-wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/gierens.asc
-```
-
-before proceeding with the others from above.
 
 ### Nix (Linux, MacOS)
 


### PR DESCRIPTION
trusted.gpg.d requires de-armored keys on some systems (Ubuntu 20.04) and ASCII-armored keys on others (Debian 12)

this keyring method works on both systems. I tested in an ubuntu:20.04 container and a debian:12 container

it also uses `dd of=` instead of `tee` to avoid dumping binary to the terminal

fixes #259