### PR TITLE
feat: Adds filtering for Windows hidden files

### DIFF
--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -130,8 +130,17 @@ impl<'dir, 'ig> Files<'dir, 'ig> {
                     }
                 }
 
-                return Some(File::from_args(path.clone(), self.dir, filename, self.deref_links)
-                                 .map_err(|e| (path.clone(), e)))
+                let file = File::from_args(path.clone(), self.dir, filename, self.deref_links)
+                                 .map_err(|e| (path.clone(), e));
+
+                // Windows has its own concept of hidden files, when dotfiles are
+                // hidden Windows hidden files should also be filtered out
+                #[cfg(windows)]
+                if !self.dotfiles && file.as_ref().is_ok_and(|f| f.attributes().hidden) {
+                    continue;
+                }
+
+                return Some(file);
             }
 
             return None


### PR DESCRIPTION
Adds an extra check on attributes().hidden on Windows. This hides Windows hidden files whenever dot files are also filtered out

Resolves #212

See #225 for context, this was reverted due to concerns over `is_ok_and` in Rust 1.65, but the minimum supported version has been bumped to 1.70 (see #313)