### PR TITLE
Remove harmfull fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,25 +156,6 @@ zypper in eza
 
 The preceding repository also contains the Bash, Fish, and Zsh completions.
 
-### Fedora
-
-You can install Eza from [openSUSE:Factory/eza](https://build.opensuse.org/package/show/openSUSE:Factory/eza):
-
-```bash
-tee /etc/yum.repos.d/opensuse-tumbleweed-oss.repo <<EOL
-[opensuse-tumbleweed-oss]
-name=OpenSUSE Tumbleweed OSS
-baseurl=https://download.opensuse.org/tumbleweed/repo/oss/
-enabled=1
-gpgcheck=1
-gpgkey=https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.key
-EOL
-
-dnf install eza
-```
-
-The preceding repository also contains the Bash, Fish, and Zsh completions.
-
 ### Brew (MacOS)
 
 [![Homebrew package](https://repology.org/badge/version-for-repo/homebrew/eza.svg)](https://repology.org/project/eza/versions)


### PR DESCRIPTION
The fedora install instruction will break the user system has the tumbleweed repo hold much newer and sometimes different packages.
Trying to install another package or updating after the tumbleweed repo on Fedora 38 (and I suppose any other version) will remove core system packages to install the newer tumbleweed ones.

Exemple here [Pastebin](https://pastebin.com/GtKBRsrx)