### PR TITLE
fix: nix flake check also builds the package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -153,6 +153,7 @@
         checks = {
           formatting = treefmtEval.config.build.check self;
           build = packages.check;
+          default = packages.default;
           test = packages.test;
           lint = packages.clippy;
           trycmd = packages.trycmd;


### PR DESCRIPTION
I mentioned that nix flake check would also build the default package. This is not the case as I found out today reading the mane page of `nix flake check` more carefully. In order to also build the default package It has to be added to the checks. **Or** nix build should be added back to the workflow.

@cafkafk Is it a better solution to make `nix flake check` also build the package or add back `nix build`?

## Drawbacks of adding the default package to the checks
`nix flake check` takes way longer.
## Advantages of adding the default package to the checks
every supported target will be tested.




Again sorry for missunderstanding the docs and stating that `nix flake check` would build even tho it doesn't.