### PR TITLE
Treefmt for configs (.toml, .yaml)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,13 @@ authors = ["Christina Sørensen <christina@cafkafk.com>"]
 categories = ["command-line-utilities"]
 edition = "2021"
 rust-version = "1.70.0"
-exclude = ["/devtools/*", "/Justfile", "/Vagrantfile", "/screenshots.png", "/tests"]
+exclude = [
+  "/devtools/*",
+  "/Justfile",
+  "/Vagrantfile",
+  "/screenshots.png",
+  "/tests",
+]
 readme = "README.md"
 homepage = "https://github.com/eza-community/eza"
 license = "MIT"
@@ -14,7 +20,7 @@ version = "0.13.0"
 
 
 [package.metadata.deb]
-license-file = [ "LICENCE", "4" ]
+license-file = ["LICENCE", "4"]
 depends = "$auto"
 extended-description = """
 eza is a modern, maintained replacement for ls
@@ -22,13 +28,41 @@ eza is a modern, maintained replacement for ls
 section = "utils"
 priority = "optional"
 assets = [
-    [ "target/release/eza", "/usr/bin/eza", "0755" ],
-    [ "target/release/../man/eza.1", "/usr/share/man/man1/eza.1", "0644" ],
-    [ "target/release/../man/eza_colors.5", "/usr/share/man/man5/eza_colors.5", "0644" ],
-    [ "target/release/../man/eza_colors-explanation.5", "/usr/share/man/man5/eza_colors-explanation.5", "0644" ],
-    [ "completions/bash/eza", "/usr/share/bash-completion/completions/eza", "0644" ],
-    [ "completions/zsh/_eza", "/usr/share/zsh/site-functions/_eza", "0644" ],
-    [ "completions/fish/eza.fish", "/usr/share/fish/vendor_completions.d/eza.fish", "0644" ],
+  [
+    "target/release/eza",
+    "/usr/bin/eza",
+    "0755",
+  ],
+  [
+    "target/release/../man/eza.1",
+    "/usr/share/man/man1/eza.1",
+    "0644",
+  ],
+  [
+    "target/release/../man/eza_colors.5",
+    "/usr/share/man/man5/eza_colors.5",
+    "0644",
+  ],
+  [
+    "target/release/../man/eza_colors-explanation.5",
+    "/usr/share/man/man5/eza_colors-explanation.5",
+    "0644",
+  ],
+  [
+    "completions/bash/eza",
+    "/usr/share/bash-completion/completions/eza",
+    "0644",
+  ],
+  [
+    "completions/zsh/_eza",
+    "/usr/share/zsh/site-functions/_eza",
+    "0644",
+  ],
+  [
+    "completions/fish/eza.fish",
+    "/usr/share/fish/vendor_completions.d/eza.fish",
+    "0644",
+  ],
 ]
 
 
@@ -48,7 +82,7 @@ log = "0.4"
 natord = "1.0"
 num_cpus = "1.16"
 number_prefix = "0.4"
-phf = { version = "0.11.2", features = ["macros"]}
+phf = { version = "0.11.2", features = ["macros"] }
 scoped_threadpool = "0.1"
 term_grid = "0.1"
 terminal_size = "0.2.6"

--- a/deny.toml
+++ b/deny.toml
@@ -20,13 +20,13 @@
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
 targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #{ triple = "x86_64-unknown-linux-musl" },
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+  # The triple can be any string, but only the target triples built in to
+  # rustc (as of 1.40) can be checked against actual config expressions
+  #{ triple = "x86_64-unknown-linux-musl" },
+  # You can also specify which target_features you promise are enabled for a
+  # particular target. target_features are currently not validated against
+  # the actual valid features supported by the target architecture.
+  #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
 ]
 # When creating the dependency graph used as the source of truth when checks are
 # executed, this field can be used to prune crates from the graph, removing them
@@ -74,7 +74,7 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
+  #"RUSTSEC-0000-0000",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -102,16 +102,16 @@ unlicensed = "deny"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "MIT",
-    "Unicode-DFS-2016",
-    "Apache-2.0",
-    #"Apache-2.0 WITH LLVM-exception",
+  "MIT",
+  "Unicode-DFS-2016",
+  "Apache-2.0",
+  #"Apache-2.0 WITH LLVM-exception",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 deny = [
-    #"Nokia",
+  #"Nokia",
 ]
 # Lint level for licenses considered copyleft
 copyleft = "warn"
@@ -137,9 +137,9 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+  # Each entry is the crate and version constraint, and its specific allow
+  # list
+  #{ allow = ["Zlib"], name = "adler32", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -158,8 +158,8 @@ exceptions = [
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
 #license-files = [
-    # Each entry is a crate relative path, and the (opaque) hash of its contents
-    #{ path = "LICENSE", hash = 0xbd0eed23 }
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
 
 [licenses.private]
@@ -172,7 +172,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-    #"https://sekretz.com/registry
+  #"https://sekretz.com/registry
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -199,17 +199,17 @@ workspace-default-features = "allow"
 external-default-features = "allow"
 # List of crates that are allowed. Use with care!
 allow = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+  #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # List of crates to deny
 deny = [
-    # Each entry the name of a crate and a version range. If version is
-    # not specified, all versions will be matched.
-    #{ name = "ansi_term", version = "=0.11.0" },
-    #
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+  # Each entry the name of a crate and a version range. If version is
+  # not specified, all versions will be matched.
+  #{ name = "ansi_term", version = "=0.11.0" },
+  #
+  # Wrapper crates can optionally be specified to allow the crate when it
+  # is a direct dependency of the otherwise banned crate
+  #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
 ]
 
 # List of features to allow/deny
@@ -237,14 +237,14 @@ deny = [
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+  #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite.
 skip-tree = [
-    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+  #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,11 @@
 [toolchain]
 channel = "1.70"
-components = [ "rustfmt", "rustc", "rust-src", "rust-analyzer", "cargo", "clippy" ]
+components = [
+  "rustfmt",
+  "rustc",
+  "rust-src",
+  "rust-analyzer",
+  "cargo",
+  "clippy",
+]
 profile = "minimal"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,14 +7,11 @@ description: |
   group. It also has extra features not present in the original ls, such as
   viewing the Git status for a directory, or recursing into directories with a
   tree view. eza is written in Rust, and it’s small, fast, and portable.
-
 grade: stable
 confinement: classic
-
 apps:
   eza:
     command: eza
-
 parts:
   eza:
     plugin: rust

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,9 +1,12 @@
 {
   projectRootFile = "Cargo.toml";
   programs = {
-    alejandra.enable = true;
-    rustfmt.enable = true;
-    shellcheck.enable = true;
+    alejandra.enable = true; # nix
+    rustfmt.enable = true; # rust
+    shellcheck.enable = true; # bash/shell
+    deadnix.enable = true; # find dead nix code
+    taplo.enable = true; # toml
+    yamlfmt.enable = true; # yaml
   };
   settings = {
     formatter.shellcheck.includes = ["*.sh" "./completions/bash/eza"];


### PR DESCRIPTION
- yaml: for GitHub Actions
- toml: for Rust configs mainly (I can change the style if there's an issue with the default style of the formatter) 
- deadnix: detecting dead nix code (@cafkafk should I remove it or is there use for this?)

## Why even bother?
I in my opinion part of making a codebase easy to navigate is proper formatting and the cost of CI time is not that high. But I still get why many think formatters are not needed for configuration files.

## Toml Style change
@cafkafk the toml style is different from what we currently use. Is the style using the formatter fine or is.

### Old
```toml
exclude = ["/devtools/*", "/Justfile", "/Vagrantfile", "/screenshots.png", "/tests"]
```
### New
```toml
exclude = [
  "/devtools/*",
  "/Justfile",
  "/Vagrantfile",
  "/screenshots.png",
  "/tests",
]
```
## Deadnix 
deadnix is really useful when having a bigger nix module with multiple files. This is not really the case yet. I don't think it's required to have deadnix but if the nix codebase gets bigger this could have use.
