### PR TITLE
ci: make various improvements

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -12,6 +12,11 @@ on:
     paths:
       - 'deb.asc'
       - '.github/workflows/apt.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   apt_installation:
     runs-on: ubuntu-latest

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Conventional Commits
@@ -14,6 +18,3 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: webiny/action-conventional-commits@v1.1.0
-        # optional, required for private repos
-        # with:
-        #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build Nix targets

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -20,5 +20,3 @@ jobs:
 
     steps:
     - uses: actions/labeler@v4
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
     - uses: actions/stale@v8
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        
         days-before-pr-stale: 30
         days-before-pr-close: 14
         stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity.'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,6 +16,10 @@ on:
       - 'Cargo.*'
       - build.rs
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -34,10 +38,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
+      - run: rustup toolchain install ${{ matrix.rust }} --profile minimal
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-hack
         uses: nick-fields/retry@v2


### PR DESCRIPTION
- Use the action Swatinem/rust-cache@v2 as it caches previously used
  dependencies, which helps save a lot of time.
- remove secrets.GITHUB_TOKEN as it's available by default.
- Use Github Actions concurrency feature, which will cancel previous
  jobs from a PR if it's been updated.
