### PR TITLE
fix(hyperlink): respect spec on Windows and make it for with Konsole

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,6 @@ dependencies = [
  "ansiterm",
  "chrono",
  "criterion",
- "gethostname",
  "git2",
  "glob",
  "lazy_static",
@@ -371,6 +370,7 @@ dependencies = [
  "natord",
  "num_cpus",
  "number_prefix",
+ "percent-encoding",
  "phf",
  "proc-mounts",
  "scoped_threadpool",
@@ -379,7 +379,6 @@ dependencies = [
  "timeago",
  "trycmd",
  "unicode-width",
- "urlencoding",
  "uzers",
  "zoneinfo_compiled",
 ]
@@ -410,16 +409,6 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
-]
-
-[[package]]
-name = "gethostname"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
-dependencies = [
- "libc",
- "windows-targets",
 ]
 
 [[package]]
@@ -753,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "phf"
@@ -1257,12 +1246,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ name = "eza"
 
 [dependencies]
 ansiterm = "0.12.2"
-gethostname = "0.4.3"
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 glob = "0.3"
 lazy_static = "1.3"
@@ -82,13 +81,13 @@ log = "0.4"
 natord = "1.0"
 num_cpus = "1.16"
 number_prefix = "0.4"
+percent-encoding = "2.3.0"
 phf = { version = "0.11.2", features = ["macros"] }
 scoped_threadpool = "0.1"
 term_grid = "0.1"
 terminal_size = "0.2.6"
 timeago = { version = "0.4.2", default-features = false }
 unicode-width = "0.1"
-urlencoding = "2.1.3"
 zoneinfo_compiled = "0.5.1"
 
 [dependencies.git2]


### PR DESCRIPTION
Follow-up of #352 

- Remove the hostname part of the `file://` URL because it probably won’t work with some host/DNS configs, and doesn’t work at all in Konsole.
- Respect the spec on Windows by URL encoding the path (needs test!!)
- Replace `urlencoding` by [`percent-encoding`](https://crates.io/crates/percent-encoding) which is more ergonomic (and I trust it’s fast and reliable because it comes from Servo)