### PR TITLE
fix(git-repos): don’t show color when color is disabled

### DIFF
--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -271,20 +271,19 @@ pub enum SubdirGitRepoStatus{
     NoRepo,
     GitClean,
     GitDirty,
-    GitUnknown
 }
 
 #[derive(Clone)]
 pub struct SubdirGitRepo{
-    pub status : SubdirGitRepoStatus,
+    pub status : Option<SubdirGitRepoStatus>,
     pub branch : Option<String>
 }
 
 impl Default for SubdirGitRepo{
     fn default() -> Self {
         Self{
-            status : SubdirGitRepoStatus::NoRepo,
-            branch : None
+            status: Some(SubdirGitRepoStatus::NoRepo),
+            branch: None
         }
     }
 }

--- a/src/output/render/mod.rs
+++ b/src/output/render/mod.rs
@@ -8,6 +8,7 @@ pub use self::filetype::Colours as FiletypeColours;
 
 mod git;
 pub use self::git::Colours as GitColours;
+pub use self::git::RepoColours as GitRepoColours;
 
 #[cfg(unix)]
 mod groups;

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -128,11 +128,11 @@ impl Columns {
         }
 
         if self.subdir_git_repos {
-            columns.push(Column::SubdirGitRepoStatus);
+            columns.push(Column::SubdirGitRepo(true));
         }
 
         if self.subdir_git_repos_no_stat {
-            columns.push(Column::SubdirGitRepoNoStatus);
+            columns.push(Column::SubdirGitRepo(false));
         }
 
         columns
@@ -157,8 +157,7 @@ pub enum Column {
     #[cfg(unix)]
     Inode,
     GitStatus,
-    SubdirGitRepoStatus,
-    SubdirGitRepoNoStatus,
+    SubdirGitRepo(bool),
     #[cfg(unix)]
     Octal,
     #[cfg(unix)]
@@ -220,8 +219,7 @@ impl Column {
             #[cfg(unix)]
             Self::Inode         => "inode",
             Self::GitStatus     => "Git",
-            Self::SubdirGitRepoStatus => "Repo",
-            Self::SubdirGitRepoNoStatus => "Repo",
+            Self::SubdirGitRepo(_) => "Repo",
             #[cfg(unix)]
             Self::Octal         => "Octal",
             #[cfg(unix)]
@@ -488,11 +486,8 @@ impl<'a> Table<'a> {
             Column::GitStatus => {
                 self.git_status(file).render(self.theme)
             }
-            Column::SubdirGitRepoStatus => {
-                self.subdir_git_repo(file, true).render()
-            }
-            Column::SubdirGitRepoNoStatus => {
-                self.subdir_git_repo(file, false).render()
+            Column::SubdirGitRepo(status) => {
+                self.subdir_git_repo(file, status).render(self.theme)
             }
             #[cfg(unix)]
             Column::Octal => {

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -67,6 +67,13 @@ impl UiStyles {
                 conflicted:  Red.normal(),
             },
 
+            git_repo: GitRepo {
+                branch_main: Green.normal(),
+                branch_other: Yellow.normal(),
+                git_clean: Green.normal(),
+                git_dirty: Yellow.bold(),
+            },
+
             security_context: SecurityContext {
                 none:       Style::default(),
                 selinux: SELinuxContext {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -273,6 +273,14 @@ impl render::GitColours for Theme {
     fn conflicted(&self)    -> Style { self.ui.git.conflicted }
 }
 
+impl render::GitRepoColours for Theme {
+    fn branch_main(&self) -> Style { self.ui.git_repo.branch_main }
+    fn branch_other(&self) -> Style { self.ui.git_repo.branch_other }
+    fn no_repo(&self) -> Style { self.ui.punctuation }
+    fn git_clean(&self) -> Style { self.ui.git_repo.git_clean }
+    fn git_dirty(&self) -> Style { self.ui.git_repo.git_dirty }
+}
+
 #[cfg(unix)]
 impl render::GroupColours for Theme {
     fn yours(&self)      -> Style { self.ui.users.group_yours }

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -13,6 +13,7 @@ pub struct UiStyles {
     pub users:            Users,
     pub links:            Links,
     pub git:              Git,
+    pub git_repo:         GitRepo,
     pub security_context: SecurityContext,
     pub file_type:        FileType,
 
@@ -105,6 +106,14 @@ pub struct Git {
     pub typechange: Style,  // gt
     pub ignored: Style,     // gi
     pub conflicted: Style,  // gc
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct GitRepo {
+    pub branch_main: Style,
+    pub branch_other: Style,
+    pub git_clean: Style,
+    pub git_dirty: Style,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]

--- a/tests/cmd/long_git_repos_no_status_nix.stdout
+++ b/tests/cmd/long_git_repos_no_status_nix.stdout
@@ -3,7 +3,7 @@
 .rw-r--r--  0 nixbld  1 Jan  1970 - - c
 .rw-r--r--  0 nixbld  1 Jan  1970 - - d
 .rw-r--r--  0 nixbld  1 Jan  1970 - - e
-drwxr-xr-x  - nixbld  1 Jan  1970 - - exa
+drwxr-xr-x  - nixbld  1 Jan  1970 -   exa
 .rw-r--r--  0 nixbld  1 Jan  1970 - - f
 .rw-r--r--  0 nixbld  1 Jan  1970 - - g
 .rw-r--r--  0 nixbld  1 Jan  1970 - - h
@@ -18,4 +18,4 @@ drwxr-xr-x  - nixbld  1 Jan  1970 - - exa
 .rw-r--r--  0 nixbld  1 Jan  1970 - - o
 .rw-r--r--  0 nixbld  1 Jan  1970 - - p
 .rw-r--r--  0 nixbld  1 Jan  1970 - - q
-drwxr-xr-x  - nixbld  1 Jan  1970 - - vagrant
+drwxr-xr-x  - nixbld  1 Jan  1970 -   vagrant


### PR DESCRIPTION
Fix #391

In the end, I find that the way traits are used for this is pretty elegant.

A `trait` is used to define a set of functions, each returning a `Style` for a particular element or type of element. This trait is implemented on `Theme`, and when we pass around the actual theme, we cast it to a particular `trait` in a particular render function, which means we can only use the `Style`s returned by the functions of the trait.

Also I changed the colors to use the terminal theme, and now the status column don’t even appear if we use `--git-repos-no-status`.

Result:
![image](https://github.com/eza-community/eza/assets/2446451/5ba4aa86-a387-47ea-898e-8030f867995f)
![image](https://github.com/eza-community/eza/assets/2446451/0b5108d6-c0d5-4a22-b5f6-099936baa5ea)
