### PR TITLE
ci: only apply labels when opening a PR

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -8,7 +8,9 @@
 # For inspiration see: https://github.com/NixOS/nixpkgs/blob/master/.github/workflows/labels.yml
 
 name: Labeler
-on: [pull_request_target]
+on:
+  pull_request_target:
+    types: [opened]
 
 jobs:
   label:


### PR DESCRIPTION
The problem with the default behavior is that it's simply too
aggressive. It will re-apply a label that a maintianer have removed
every time the PR is updated, making it impossible to manually adjust
labels that doesn't fit exactly according to the labeler rules.
