### PR TITLE
feat: add rustfmt.toml file to prevent flags.rs fmt on save

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+ignore = ['src/options/flags.rs']

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-ignore = ['src/options/flags.rs']

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -1,4 +1,3 @@
-#![rustfmt::skip]
 use crate::options::parser::{Arg, Args, TakesValue, Values};
 
 // exa options

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -1,3 +1,4 @@
+#![rustfmt::skip]
 use crate::options::parser::{Arg, Args, TakesValue, Values};
 
 // exa options


### PR DESCRIPTION
This prevents most LSP's/Editors that will auto run rustfmt on save. Most do not respect the .nix file, so this will keep `flags.rs` from getting formatted each time someone contributes.