### PR TITLE
Dynamic Manpage Version

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -74,9 +74,10 @@ all-release: build-release test-release
 # build the man pages
 @man:
     mkdir -p "${CARGO_TARGET_DIR:-target}/man"
-    pandoc --standalone -f markdown -t man man/eza.1.md        > "${CARGO_TARGET_DIR:-target}/man/eza.1"
-    pandoc --standalone -f markdown -t man man/eza_colors.5.md > "${CARGO_TARGET_DIR:-target}/man/eza_colors.5"
-    pandoc --standalone -f markdown -t man man/eza_colors-explanation.5.md > "${CARGO_TARGET_DIR:-target}/man/eza_colors-explanation.5"
+    version=$(cat Cargo.toml | grep ^version | head -n 1 | awk '{print $NF}' | tr -d '"'); \
+    for page in eza.1 eza_colors.5 eza_colors-explanation.5; do \
+        pandoc --standalone -f markdown -t man <(cat "man/${page}.md" | sed "s/\$version/v${version}/g") > "${CARGO_TARGET_DIR:-target}/man/${page}"; \
+    done;
 
 # build and preview the main man page (eza.1)
 @man-1-preview: man

--- a/flake.nix
+++ b/flake.nix
@@ -34,14 +34,14 @@
         };
 
         treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
-        buildInputs = with pkgs; lib.optionals stdenv.isDarwin [libiconv darwin.apple_sdk.frameworks.Security];
+        buildInputs = with pkgs; [zlib] ++ lib.optionals stdenv.isDarwin [libiconv darwin.apple_sdk.frameworks.Security];
       in rec {
         # For `nix fmt`
         formatter = treefmtEval.config.build.wrapper;
 
         packages = {
           # For `nix build` `nix run`, & `nix profile install`:
-          default = naersk'.buildPackage {
+          default = naersk'.buildPackage rec {
             pname = "eza";
             version = "latest";
 
@@ -50,7 +50,7 @@
 
             # buildInputs = with pkgs; [ zlib ]
             #   ++ lib.optionals stdenv.isDarwin [ libiconv Security ];
-            buildInputs = buildInputs ++ (with pkgs; [zlib]);
+            inherit buildInputs;
 
             nativeBuildInputs = with pkgs; [cmake pkg-config installShellFiles pandoc];
 
@@ -61,9 +61,9 @@
             # outputs = [ "out" "man" ];
 
             postInstall = ''
-              pandoc --standalone -f markdown -t man man/eza.1.md > man/eza.1
-              pandoc --standalone -f markdown -t man man/eza_colors.5.md > man/eza_colors.5
-              pandoc --standalone -f markdown -t man man/eza_colors-explanation.5.md > man/eza_colors-explanation.5
+              pandoc --standalone -f markdown -t man <(cat "man/eza.1.md" | sed "s/\$version/${version}/g") > man/eza.1
+              pandoc --standalone -f markdown -t man <(cat "man/eza_colors.5.md" | sed "s/\$version/${version}/g") > man/eza_colors.5
+              pandoc --standalone -f markdown -t man <(cat "man/eza_colors-explanation.5.md" | sed "s/\$version/${version}/g")> man/eza_colors-explanation.5
               installManPage man/eza.1 man/eza_colors.5 man/eza_colors-explanation.5
               installShellCompletion \
                 --bash completions/bash/eza \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -1,4 +1,4 @@
-% eza(1) v0.9.0
+% eza(1) $version
 
 <!-- This is the eza(1) man page, written in Markdown. -->
 <!-- To generate the roff version, run `just man`, -->

--- a/man/eza_colors-explanation.5.md
+++ b/man/eza_colors-explanation.5.md
@@ -1,3 +1,9 @@
+% eza_colors-explanation(5) $version
+
+<!-- This is the eza_colors-explanation(5) man page, written in Markdown. -->
+<!-- To generate the roff version, run `just man`, -->
+<!-- and the man page will appear in the ‘target’ directory. -->
+
 # Name
 
 eza_colors-explanation — more details on customizing eza colors

--- a/man/eza_colors.5.md
+++ b/man/eza_colors.5.md
@@ -1,4 +1,4 @@
-% eza_colors(5) v0.9.0
+% eza_colors(5) $version
 
 <!-- This is the eza_colors(5) man page, written in Markdown. -->
 <!-- To generate the roff version, run `just man`, -->


### PR DESCRIPTION
At the moment the `eza.1` and `eza_colors.5` manpages show the hardcoded and outdated version v0.9.0, and `eza_colors-explanation.5` doesn't show any version and doesn't even have a header at all.

This adds the missing header and replaces the hardcoded version strings by `$version` which is then replaced in the `@man` rule by the version set in `Cargo.toml`. It also refactors the rule to use a for loop instead of three separate pandoc commands.