### PR TITLE
fix: query stdout terminal size to see if the output gose to a tty.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "trycmd",
  "unicode-width",
  "uzers",
+ "windows-sys",
  "zoneinfo_compiled",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,9 @@ proc-mounts = "0.3"
 [target.'cfg(unix)'.dependencies]
 uzers = "0.11.3"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = "0.48.0"
+
 [build-dependencies]
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ These options are available when running with `--long` (`-l`):
 
 Some of the options accept parameters:
 
-- Valid **--color** options are **always**, **automatic**, and **never**.
+- Valid **--color** options are **always**, **automatic** (or **auto** for short), and **never**.
 - Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **newest**, while its reverse has the aliases **age** and **oldest**.
 - Valid time fields are **modified**, **changed**, **accessed**, and **created**.
 - Valid time styles are **default**, **iso**, **long-iso**, **full-iso**, and **relative**.

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ These options are available when running with `--long` (`-l`):
 
 Some of the options accept parameters:
 
-- Valid **--color** options are **always**, **automatic** (or **auto** for short), and **never**.
+- Valid **--co{u}lor** options are **always**, **automatic** (or **auto** for short), and **never**.
 - Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **newest**, while its reverse has the aliases **age** and **oldest**.
 - Valid time fields are **modified**, **changed**, **accessed**, and **created**.
 - Valid time styles are **default**, **iso**, **long-iso**, **full-iso**, and **relative**.

--- a/completions/bash/eza
+++ b/completions/bash/eza
@@ -9,7 +9,7 @@ _eza() {
             ;;
 
         --colour)
-            mapfile -t COMPREPLY < <(compgen -W 'always auto never' -- "$cur")
+            mapfile -t COMPREPLY < <(compgen -W 'always automatic auto never' -- "$cur")
             return
             ;;
 

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -14,6 +14,7 @@ complete -c eza -l color \
     -l colour -d "When to use terminal colours" -x -a "
     always\t'Always use colour'
     auto\t'Use colour if standard output is a terminal'
+    automatic\t'Use colour if standard output is a terminal'
     never\t'Never use colour'
 "
 complete -c eza -l color-scale \

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -19,7 +19,7 @@ __eza() {
         {-R,--recurse}"[Recurse into directories]" \
         {-T,--tree}"[Recurse into directories as a tree]" \
         {-F,--classify}"[Display type indicator by file names]" \
-        --colo{,u}r="[When to use terminal colours]:(when):(always auto never)" \
+        --colo{,u}r="[When to use terminal colours]:(when):(always auto automatic never)" \
         --colo{,u}r-scale"[Highlight levels of file sizes distinctly]" \
         --icons"[Display icons]" \
         --no-icons"[Hide icons]" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -62,9 +62,15 @@ DISPLAY OPTIONS
 `-x`, `--across`
 : Sort the grid across, rather than downwards.
 
-`--color`, `--colour=WHEN`
-: When to use terminal colours.
-Valid settings are ‘`always`’, ‘`automatic`’, and ‘`never`’.
+`--color=WHEN`, `--colour=WHEN`
+: When to use terminal colours (using ANSI escape code to colorize the output).
+
+Valid settings are ‘`always`’, ‘`automatic`’ (or ‘`auto`’ for short), and ‘`never`’.
+The default value is ‘`automatic`’.
+
+The default behavior (‘`automatic`’ or ‘`auto`’) is to colorize the output only when the standard output is connected to a real terminal. If the output of `eza` is redirected to a file or piped into another program, terminal colors will not be used. Setting this option to ‘`always`’ causes `eza` to always output terminal color, while ‘`never`’ disables the use of terminal color.
+
+Manually setting this option overrides `NO_COLOR` environment.
 
 `--color-scale`, `--colour-scale`
 : Colour file sizes on a scale.

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@
 
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::io::{self, ErrorKind, Write};
+use std::io::{self, ErrorKind, IsTerminal, Write};
 use std::path::{Component, PathBuf};
 use std::process::exit;
 
@@ -57,20 +57,8 @@ fn main() {
     if let Err(e) = ansiterm::enable_ansi_support() {
         warn!("Failed to enable ANSI support: {}", e);
     }
-    #[cfg(unix)]
-    let stdout_istty = {
-        use std::os::fd::AsRawFd;
-        terminal_size::terminal_size_using_fd(io::stdout().as_raw_fd()).is_some()
-    };
-    #[cfg(windows)]
-    let stdout_istty = {
-        use std::os::windows::io::RawHandle;
-        use windows_sys::Win32::System::Console::{GetStdHandle, STD_OUTPUT_HANDLE};
-        terminal_size::terminal_size_using_handle(unsafe {
-            GetStdHandle(STD_OUTPUT_HANDLE) as RawHandle
-        })
-        .is_some()
-    };
+
+    let stdout_istty = io::stdout().is_terminal();
 
     let args: Vec<_> = env::args_os().skip(1).collect();
     match Options::parse(args.iter().map(std::convert::AsRef::as_ref), &LiveVars) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::io::{self, ErrorKind, Write};
+use std::os::fd::AsRawFd;
 use std::path::{Component, PathBuf};
 use std::process::exit;
 
@@ -71,9 +72,9 @@ fn main() {
             let writer = io::stdout();
 
             let console_width = options.view.width.actual_terminal_width();
-            let theme = options
-                .theme
-                .to_theme(terminal_size::terminal_size().is_some());
+            let stdout_istty =
+                terminal_size::terminal_size_using_fd(io::stdout().as_raw_fd()).is_some();
+            let theme = options.theme.to_theme(stdout_istty);
             let exa = Exa {
                 options,
                 writer,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -63,7 +63,7 @@ impl TerminalWidth {
             terminal_size::terminal_size_using_handle(unsafe {
                 GetStdHandle(STD_OUTPUT_HANDLE) as RawHandle
             })
-            .map(|(w, h)| w.0 as _)
+            .map(|(w, _h)| w.0 as _)
         };
 
         #[rustfmt::skip]


### PR DESCRIPTION
`terminal_size::terminal_size()` is used to determine if stdout is connected to a real tty/pty. In previous version of `terminal-size`, this method only queries the terminal size for `stdout`. However, it is changed in the following commit
https://github.com/eminence/terminal-size/commit/08f0e73926c11adc3105dbf4eb84dd8c9e6c873a Now the method will use `stdout, stdin, stderr`, trying its best to determine the terminal size. This cannot be used to determine if `eza` output is piped or redirected.
We should use `terminal_size_using_fd` on `stdout.as_raw_fd` instead.
This patch makes `eza --color=auto` behaves like `ls --color=auto`.

Resolves #434 Fixes #433

Also Resolves #441 as well.