### PR TITLE
Don't match for numbers and remove single-use fn

### DIFF
--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -101,7 +101,7 @@ pub enum ShowIcons {
 
     /// Show icons next to file names, with the given number of spaces between
     /// the icon and the file name.
-    On(u32),
+    On(usize),
 }
 
 /// Whether to embed hyperlinks.
@@ -182,11 +182,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
 
             bits.push(style.paint(file_icon));
 
-            match spaces_count {
-                1 => bits.push(style.paint(" ")),
-                2 => bits.push(style.paint("  ")),
-                n => bits.push(style.paint(spaces(n))),
-            }
+            bits.push(style.paint(" ".repeat(spaces_count)));
         }
 
         if self.file.parent_dir.is_none() {
@@ -474,9 +470,4 @@ pub trait Colours: FiletypeColours {
     fn mount_point(&self) -> Style;
 
     fn colour_file(&self, file: &File<'_>) -> Style;
-}
-
-/// Generate a string made of `n` spaces.
-fn spaces(width: u32) -> String {
-    (0..width).map(|_| ' ').collect()
 }

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -47,7 +47,7 @@ impl<'a> Render<'a> {
             let contents = filename.paint();
             #[rustfmt::skip]
             let width = match (filename.options.embed_hyperlinks, filename.options.show_icons) {
-                (EmbedHyperlinks::On, ShowIcons::On(spacing)) => filename.bare_width() + 1 + (spacing as usize),
+                (EmbedHyperlinks::On, ShowIcons::On(spacing)) => filename.bare_width() + 1 + spacing,
                 (EmbedHyperlinks::On, ShowIcons::Off) => filename.bare_width(),
                 (EmbedHyperlinks::Off, _) => *contents.width(),
             };

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -164,7 +164,7 @@ impl<'a> Render<'a> {
                 let contents = filename.paint();
                 #[rustfmt::skip]
                 let width = match (filename.options.embed_hyperlinks, filename.options.show_icons) {
-                    (EmbedHyperlinks::On, ShowIcons::On(spacing)) => filename.bare_width() + 1 + (spacing as usize),
+                    (EmbedHyperlinks::On, ShowIcons::On(spacing)) => filename.bare_width() + 1 + spacing,
                     (EmbedHyperlinks::On, ShowIcons::Off) => filename.bare_width(),
                     (EmbedHyperlinks::Off, _) => *contents.width(),
                 };


### PR DESCRIPTION
This addresses #446 

About the type change: It came up because `String::repeat` expects `usize`.
But all the other places using the field are already converting anyway so it was a no-brainer to change it in my opinion