### PR TITLE
build: add `codegen-units = 1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ debug = false
 [profile.release]
 lto = true
 strip = true
+opt-level = 3
 codegen-units = 1
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ debug = false
 [profile.release]
 lto = true
 strip = true
-opt-level = 3
+codegen-units = 1
 
 [[bench]]
 name = "my_benchmark"


### PR DESCRIPTION
`opt-level = 3` is the default for release builds (https://doc.rust-lang.org/stable/book/ch14-01-release-profiles.html).
`codegen-units = 1` lengthens the build by about 4 seconds on my system and produces a ~20KiB smaller binary.