### PR TITLE
refactor(devtools): use musl target for amd64 deb package

### DIFF
--- a/devtools/deb-package.sh
+++ b/devtools/deb-package.sh
@@ -15,7 +15,7 @@ echo "build man pages"
 just man
 
 declare -A TARGETS
-TARGETS["amd64"]="x86_64-unknown-linux-gnu"
+TARGETS["amd64"]="x86_64-unknown-linux-musl"
 TARGETS["arm64"]="aarch64-unknown-linux-gnu"
 TARGETS["armhf"]="arm-unknown-linux-gnueabihf"
 


### PR DESCRIPTION
This changes the target for the `amd64` deb package to `x86_64-unknown-linux-musl`. I have been using this for a few releases already but haven't commited it yet.