### PR TITLE
docs: Add missing options to man page and CLI --help info

### DIFF
--- a/completions/bash/eza
+++ b/completions/bash/eza
@@ -4,7 +4,7 @@ _eza() {
     prev=${COMP_WORDS[COMP_CWORD-1]}
 
     case "$prev" in
-        -'?'|--help|-v|--version)
+        --help|-v|--version)
             return
             ;;
 

--- a/completions/nush/eza.nu
+++ b/completions/nush/eza.nu
@@ -1,6 +1,6 @@
 export extern "eza" [
     --version(-v)              # Show version of eza
-    --help(-?)                 # Show list of command-line options
+    --help                     # Show list of command-line options
     --oneline(-1)              # Display one entry per line
     --long(-l)                 # Display extended file metadata as a table
     --grid(-G)                 # Display entries in a grid

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -11,7 +11,7 @@ __eza() {
     # `-S` for delimiting options with `--` like in `eza -- -a`.
     _arguments -s -S \
         "(- *)"{-v,--version}"[Show version of eza]" \
-        "(- *)"{-'\?',--help}"[Show list of command-line options]" \
+        "(- *)"{--help}"[Show list of command-line options]" \
         {-1,--oneline}"[Display one entry per line]" \
         {-l,--long}"[Display extended file metadata as a table]" \
         {-G,--grid}"[Display entries as a grid]" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -38,6 +38,16 @@ EXAMPLES
 : Displays a tree of files, three levels deep, as well as each file’s metadata.
 
 
+META OPTIONS
+===============
+
+`--help`
+: Show list of command-line options.
+
+`-v`, `--version`
+: Show version of eza.
+
+
 DISPLAY OPTIONS
 ===============
 
@@ -58,6 +68,9 @@ DISPLAY OPTIONS
 
 `-T`, `--tree`
 : Recurse into directories as a tree.
+
+`-X`, `--dereference`
+: Dereference symbolic links when displaying information.
 
 `-x`, `--across`
 : Sort the grid across, rather than downwards.
@@ -97,6 +110,9 @@ FILTERING AND SORTING OPTIONS
 `-a`, `--all`
 : Show hidden and “dot” files.
 Use this twice to also show the ‘`.`’ and ‘`..`’ directories.
+
+`-A`, `--almost-all`
+: Equivalent to --all; included for compatibility with `ls -A`.
 
 `-d`, `--list-dirs`
 : List directories as regular files, rather than recursing and listing their contents.

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -8,7 +8,7 @@ static USAGE_PART1: &str = "Usage:
   eza [options] [files...]
 
 META OPTIONS
-  -?, --help         show list of command-line options
+  --help             show list of command-line options
   -v, --version      show version of eza
 
 DISPLAY OPTIONS
@@ -18,6 +18,7 @@ DISPLAY OPTIONS
   -x, --across       sort the grid across, rather than downwards
   -R, --recurse      recurse into directories
   -T, --tree         recurse into directories as a tree
+  -X, --dereference  dereference symbolic links when displaying information
   -F, --classify     display type indicator by file names
   --colo[u]r=WHEN    when to use terminal colours (always, auto, never)
   --colo[u]r-scale   highlight levels of file sizes distinctly
@@ -27,8 +28,10 @@ DISPLAY OPTIONS
   --hyperlink        display entries as hyperlinks
   -w, --width COLS   set screen width in columns
 
+
 FILTERING AND SORTING OPTIONS
   -a, --all                  show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories
+  -A, --almost-all           equivalent to --all; included for compatibility with `ls -A`
   -d, --list-dirs            list directories as files; don't list their contents
   -L, --level DEPTH          limit the depth of recursion
   -r, --reverse              reverse the sort order


### PR DESCRIPTION
Add missing --dereference, --almost-all, --help, --version to man pages. 
Add --dereference, --almost-all to CLI --help message.

Fixes #488