### PR TITLE
docs: correct color option spellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ These options are available when running with `--long` (`-l`):
 
 Some of the options accept parameters:
 
-- Valid **--co{u}lor** options are **always**, **automatic** (or **auto** for short), and **never**.
+- Valid **--colo\[u\]r** options are **always**, **automatic** (or **auto** for short), and **never**.
 - Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **newest**, while its reverse has the aliases **age** and **oldest**.
 - Valid time fields are **modified**, **changed**, **accessed**, and **created**.
 - Valid time styles are **default**, **iso**, **long-iso**, **full-iso**, and **relative**.


### PR DESCRIPTION
Corrects a small typo in the description of the `--colo[u]r` option's parameters.