### PR TITLE
fix: reenable debug symbols in debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,11 +121,6 @@ nix = []
 # Should only be used inside of flake.nix locally (not on CI)
 nix-local = []
 
-
-# make dev builds faster by excluding debug symbols
-[profile.dev]
-debug = false
-
 # use LTO for smaller binaries (that take longer to build)
 [profile.release]
 lto = true


### PR DESCRIPTION
I was trying to debug #521 and was very confused when my breakpoints weren't working at all.

I mean, not having debug symbols defeats the purpose of a debug profile in the first place. So I think it's best to reenable it.