### PR TITLE
refactor: replace `lazy_static` with `once_cell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,6 @@ dependencies = [
  "criterion",
  "git2",
  "glob",
- "lazy_static",
  "libc",
  "locale",
  "log",
@@ -554,12 +553,6 @@ checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ name = "eza"
 ansiterm = "0.12.2"
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 glob = "0.3"
-lazy_static = "1.3"
 libc = "0.2"
 locale = "0.2"
 log = "0.4"

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -5,8 +5,8 @@ use std::sync::{Mutex, MutexGuard};
 
 use chrono::prelude::*;
 
-use lazy_static::lazy_static;
 use log::*;
+use once_cell::sync::Lazy;
 #[cfg(unix)]
 use uzers::UsersCache;
 
@@ -352,9 +352,7 @@ impl Environment {
     }
 }
 
-lazy_static! {
-    static ref ENVIRONMENT: Environment = Environment::load_all();
-}
+static ENVIRONMENT: Lazy<Environment> = Lazy::new(Environment::load_all);
 
 pub struct Table<'a> {
     columns: Vec<Column>,


### PR DESCRIPTION
Parts of `once_cell` are already in `std`, and the `Lazy` part is going to be implemented later.
`clap` also depends on `once_cell`, so after the clap PR gets merged there's going to be one less dependency.