### PR TITLE
Fix issue #578

### DIFF
--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -83,7 +83,7 @@ impl<'a> Render<'a> {
                 (
                     EmbedHyperlinks::Off,
                     ShowIcons::Always(spacing) | ShowIcons::Automatic(spacing),
-                ) => filename.bare_width() + 1 + (spacing as usize) + space_filename_offset,
+                ) => filename.bare_width() + classification_width + 1 + (spacing as usize) + space_filename_offset,
                 (EmbedHyperlinks::Off, _) => *contents.width(),
             };
 


### PR DESCRIPTION
Fixes #578. In the case when `hyperlink` is off and `icons` is on, the width of classification char will not be counted into the `width`. Using `*contents.width()` or adding `classification_width` should fix it I think.
Don't know how to make a good test though.