### PR TITLE
feat!: support env EZA_QUOTING_STYLE, replace --no-quotes with --quotes=always,atuo,never

### DIFF
--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -26,7 +26,12 @@ complete -c eza -l icons -d "When to display icons" -x -a "
   automatic\t'Display icons if standard output is a terminal'
   never\t'Never display icons'
 "
-complete -c eza -l no-quotes -d "Don't quote file names with spaces"
+complete -c eza -l quotes -d "When to quote filenames" -x -a "
+    always\t'Always quote filenames, even filenames with no spaces/special characters'
+    auto\t'Quote filenames if they contain spaces or special characters'
+    automatic\t'Quote filenames if they contain spaces or special characters'
+    never\t'Never quote filenames'
+    "
 complete -c eza -l hyperlink -d "Display entries as hyperlinks"
 complete -c eza -l smart-group -d "Only show group if it has a different name from owner"
 

--- a/completions/nush/eza.nu
+++ b/completions/nush/eza.nu
@@ -14,7 +14,7 @@ export extern "eza" [
     --color-scale              # Highlight levels of file sizes distinctly
     --colour-scale             # Highlight levels of file sizes distinctly
     --icons                    # When to display icons
-    --no-quotes                # Don't quote file names with spaces
+    --quotes                   # When to quote filenames (always, auto, never)
     --hyperlink                # Display entries as hyperlinks
     --group-directories-first  # Sort directories before other files
     --git-ignore               # Ignore files mentioned in '.gitignore'

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -23,7 +23,7 @@ __eza() {
         --colo{,u}r="[When to use terminal colours]:(when):(always auto automatic never)" \
         --colo{,u}r-scale"[Highlight levels of file sizes distinctly]" \
         --icons="[When to display icons]:(when):(always auto automatic never)" \
-        --no-quotes"[Don't quote filenames with spaces]" \
+        --quotes="[When to quote filenames]: (when): (always auto automatic never) \
         --hyperlink"[Display entries as hyperlinks]" \
         --group-directories-first"[Sort directories before other files]" \
         --git-ignore"[Ignore files mentioned in '.gitignore']" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -96,8 +96,11 @@ The default value is ‘`automatic`’.
 
 `automatic` or `auto` will display icons only when the standard output is connected to a real terminal. If `eza` is ran while in a `tty`, or the output of `eza` is either redirected to a file or piped into another program, icons will not be used. Setting this option to ‘`always`’ causes `eza` to always display icons, while ‘`never`’ disables the use of icons.
 
-`--no-quotes`
-: Don't quote file names with spaces.
+`--quotes=WHEN` 
+: When to quote file names. Default is `auto` which is only when there are spaces in the name.
+
+Valid settings are `always`, `automatic`(`auto` for short), or `never`
+`always` will quote every file name, `never` will never quote any file name, and `automatic` will only quote file names when there are spaces in the name.
 
 `--hyperlink`
 : Display entries as hyperlinks
@@ -302,6 +305,15 @@ For more information on the format of these environment variables, see the [eza_
 
 Overrides any `--git` or `--git-repos` argument
 
+## `EZA_QUOTING_STYLE`
+
+Options are 'never' | 'always' | 'auto'
+
+'never' is equivalent to the `ls`' `-N` option or `QUOTING_STYLE=literal` option, where file names are never quoted
+
+'auto' is the default, and equivalent to the `ls`' `-Q` option or `QUOTING_STYLE=shell-escape` option, where file names are quoted when they contain spaces.
+
+'always' is equivalent to the `ls` `QUOTING_STYLE=shell-escape-always` option, where all file names are quoted.
 
 EXIT STATUSES
 =============

--- a/src/options/file_name.rs
+++ b/src/options/file_name.rs
@@ -88,13 +88,28 @@ impl ShowIcons {
 
 impl QuoteStyle {
     pub fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {
-        if matches.has(&flags::NO_QUOTES)? {
-            Ok(Self::NoQuotes)
+        if let Ok(env) = std::env::var("EZA_QUOTE_STYLE") {
+            match env.as_str() {
+                "always" => return Ok(Self::Always),
+                "never" => return Ok(Self::Never),
+                &_ => return Ok(Self::Auto),
+            };
+        } else if matches.get(&flags::QUOTES)?.is_some() {
+        // prioritize the command line flag over the environment variable 
+            let word = matches.get(&flags::QUOTES)?.unwrap();
+            match word.to_str() {
+                Some("always") => return Ok(Self::Always),
+                Some("never") => return Ok(Self::Never),
+                Some("auto") => return Ok(Self::Auto),
+                None => return Err(OptionsError::BadArgument(&flags::QUOTES, word.into())),
+                _ => return Err(OptionsError::BadArgument(&flags::QUOTES, word.into())),
+            }
         } else {
-            Ok(Self::QuoteSpaces)
-        }
+            return Ok(Self::Auto);
+        };
     }
 }
+
 
 impl EmbedHyperlinks {
     fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -14,11 +14,10 @@ pub static TREE:        Arg = Arg { short: Some(b'T'), long: "tree",        take
 pub static CLASSIFY:    Arg = Arg { short: Some(b'F'), long: "classify",    takes_value: TakesValue::Forbidden };
 pub static DEREF_LINKS: Arg = Arg { short: Some(b'X'), long: "dereference", takes_value: TakesValue::Forbidden };
 pub static WIDTH:       Arg = Arg { short: Some(b'w'), long: "width",       takes_value: TakesValue::Necessary(None) };
-pub static NO_QUOTES:   Arg = Arg { short: None,       long: "no-quotes",   takes_value: TakesValue::Forbidden };
+pub static QUOTES:      Arg = Arg { short: None,       long: "quotes",      takes_value: TakesValue::Necessary(Some(WHEN)) };
 
 pub static COLOR:  Arg = Arg { short: None, long: "color",  takes_value: TakesValue::Optional(Some(WHEN)) };
 pub static COLOUR: Arg = Arg { short: None, long: "colour", takes_value: TakesValue::Optional(Some(WHEN)) };
-const WHEN: &[&str] = &["always", "auto", "never"];
 
 pub static COLOR_SCALE:  Arg = Arg { short: None, long: "color-scale",  takes_value: TakesValue::Forbidden };
 pub static COLOUR_SCALE: Arg = Arg { short: None, long: "colour-scale", takes_value: TakesValue::Forbidden };
@@ -35,9 +34,6 @@ pub static GIT_IGNORE:  Arg = Arg { short: None, long: "git-ignore",           t
 pub static DIRS_FIRST:  Arg = Arg { short: None, long: "group-directories-first",  takes_value: TakesValue::Forbidden };
 pub static ONLY_DIRS:   Arg = Arg { short: Some(b'D'), long: "only-dirs", takes_value: TakesValue::Forbidden };
 pub static ONLY_FILES:  Arg = Arg { short: Some(b'f'), long: "only-files", takes_value: TakesValue::Forbidden };
-const SORTS: Values = &[ "name", "Name", "size", "extension",
-                         "Extension", "modified", "changed", "accessed",
-                         "created", "inode", "type", "none" ];
 
 // display options
 pub static BINARY:      Arg = Arg { short: Some(b'b'), long: "binary",      takes_value: TakesValue::Forbidden };
@@ -59,8 +55,6 @@ pub static TIME_STYLE:  Arg = Arg { short: None,       long: "time-style",  take
 pub static HYPERLINK:   Arg = Arg { short: None,       long: "hyperlink",   takes_value: TakesValue::Forbidden };
 pub static MOUNTS:      Arg = Arg { short: Some(b'M'), long: "mounts",      takes_value: TakesValue::Forbidden };
 pub static SMART_GROUP: Arg = Arg { short: None,       long: "smart-group", takes_value: TakesValue::Forbidden };
-const TIMES: Values = &["modified", "changed", "accessed", "created"];
-const TIME_STYLES: Values = &["default", "long-iso", "full-iso", "iso", "relative"];
 
 // suppressing columns
 pub static NO_PERMISSIONS: Arg = Arg { short: None, long: "no-permissions", takes_value: TakesValue::Forbidden };
@@ -77,11 +71,16 @@ pub static EXTENDED:          Arg = Arg { short: Some(b'@'), long: "extended",  
 pub static OCTAL:             Arg = Arg { short: Some(b'o'), long: "octal-permissions",    takes_value: TakesValue::Forbidden };
 pub static SECURITY_CONTEXT:  Arg = Arg { short: Some(b'Z'), long: "context",              takes_value: TakesValue::Forbidden };
 
+const TIMES:       Values = &["modified", "changed", "accessed", "created"];
+const TIME_STYLES: Values = &["default", "long-iso", "full-iso", "iso", "relative"];
+const WHEN:        Values = &["always", "auto", "never"];
+const SORTS:       Values = &[ "name", "Name", "size", "extension", "Extension", "modified", "changed", "accessed", "created", "inode", "type", "none" ];
+
 pub static ALL_ARGS: Args = Args(&[
     &VERSION, &HELP,
 
     &ONE_LINE, &LONG, &GRID, &ACROSS, &RECURSE, &TREE, &CLASSIFY, &DEREF_LINKS,
-    &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE, &WIDTH, &NO_QUOTES,
+    &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE, &WIDTH, &QUOTES,
 
     &ALL, &ALMOST_ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
     &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS, &ONLY_FILES,

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -31,7 +31,7 @@ pub fn escape(
         }
     }
 
-    if quote_style != QuoteStyle::NoQuotes && needs_quotes {
+    if quote_style != QuoteStyle::Never && needs_quotes || quote_style == QuoteStyle::Always {
         bits.insert(0, quote_bit.clone());
         bits.push(quote_bit);
     }

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -121,11 +121,11 @@ pub enum EmbedHyperlinks {
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub enum QuoteStyle {
     /// Don't ever quote file names.
-    NoQuotes,
-
-    /// Use single quotes for file names that contain spaces and no single quotes
-    /// Use double quotes for file names that contain single quotes.
-    QuoteSpaces,
+    Never,
+    /// Quote file names that contain spaces
+    Auto,
+    /// Always quote file names.
+    Always,
 }
 
 /// A **file name** holds all the information necessary to display the name
@@ -227,7 +227,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
                     if !target.name.is_empty() {
                         let target_options = Options {
                             classify: Classify::JustFilenames,
-                            quote_style: QuoteStyle::QuoteSpaces,
+                            quote_style: QuoteStyle::Auto,
                             show_icons: ShowIcons::Never,
                             embed_hyperlinks: EmbedHyperlinks::Off,
                             is_a_tty: self.options.is_a_tty,


### PR DESCRIPTION
#584

Got me thinking about the different quoting styles that LS supports, and I think it's reasonable to offer some of this. Also, I am not a fan of the `--no-x` flags. I think it makes much more sense to offer an ENV var solution for `NEVER` and default it to `auto` and then offer a way to pass it in the command line. Idk who would want all their filenames quoted but hey, it's an option for LS.

It would obviously remain defaulted to `auto`, so the only thing that would break would be the `--no-quotes` flag would have to either be `--quotes=never` or the `EZA_QUOTING_STYLE=never` would have to be set.

Also: for anyone testing this, we are still waiting on #569 to get merged to fix the width/spacing issue