### PR TITLE
feat: create EZA_ICONS_AUTO environment variable

### DIFF
--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -304,9 +304,9 @@ Overrides any `--git` or `--git-repos` argument
 
 ## `EZA_ICONS_AUTO`
 
-If set to `true`, automates the same behavior as `--icons` or `--icons=auto`. Useful for if you always want to have icons enabled.
+If set, automates the same behavior as using `--icons` or `--icons=auto`. Useful for if you always want to have icons enabled.
 
-Any use of the `--icons=WHEN` flag overrides this. 
+Any explicit use of the `--icons=WHEN` flag overrides this behavior. 
 
 
 EXIT STATUSES

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -302,6 +302,12 @@ For more information on the format of these environment variables, see the [eza_
 
 Overrides any `--git` or `--git-repos` argument
 
+## `EZA_ICONS_AUTO`
+
+If set to `true`, automates the same behavior as `--icons` or `--icons=auto`. Useful for if you always want to have icons enabled.
+
+Any use of the `--icons=WHEN` flag overrides this. 
+
 
 EXIT STATUSES
 =============

--- a/src/options/file_name.rs
+++ b/src/options/file_name.rs
@@ -1,7 +1,6 @@
 use crate::options::parser::MatchedFlags;
 use crate::options::vars::{self, Vars};
 use crate::options::{flags, NumberSource, OptionsError};
-use std::ffi::OsString;
 
 use crate::output::file_name::{Classify, EmbedHyperlinks, Options, QuoteStyle, ShowIcons};
 
@@ -46,9 +45,7 @@ impl ShowIcons {
             Automatic,
         }
 
-        let force_icons = vars
-            .get(vars::EZA_ICONS_AUTO)
-            .eq(&Some(OsString::from("true")));
+        let force_icons = vars.get(vars::EZA_ICONS_AUTO).is_some();
         let mode_opt = matches.get(&flags::ICONS)?;
         if !force_icons && !matches.has(&flags::ICONS)? && mode_opt.is_none() {
             return Ok(Self::Never);

--- a/src/options/file_name.rs
+++ b/src/options/file_name.rs
@@ -1,6 +1,7 @@
 use crate::options::parser::MatchedFlags;
 use crate::options::vars::{self, Vars};
 use crate::options::{flags, NumberSource, OptionsError};
+use std::ffi::OsString;
 
 use crate::output::file_name::{Classify, EmbedHyperlinks, Options, QuoteStyle, ShowIcons};
 
@@ -45,8 +46,11 @@ impl ShowIcons {
             Automatic,
         }
 
+        let force_icons = vars
+            .get(vars::EZA_ICONS_AUTO)
+            .eq(&Some(OsString::from("true")));
         let mode_opt = matches.get(&flags::ICONS)?;
-        if !matches.has(&flags::ICONS)? && mode_opt.is_none() {
+        if !force_icons && !matches.has(&flags::ICONS)? && mode_opt.is_none() {
             return Ok(Self::Never);
         }
 

--- a/src/options/vars.rs
+++ b/src/options/vars.rs
@@ -55,6 +55,8 @@ pub static EZA_ICON_SPACING: &str = "EZA_ICON_SPACING";
 pub static EXA_OVERRIDE_GIT: &str = "EXA_OVERRIDE_GIT";
 pub static EZA_OVERRIDE_GIT: &str = "EZA_OVERRIDE_GIT";
 
+pub static EZA_ICONS_AUTO: &str = "EZA_ICONS_AUTO";
+
 /// Mockable wrapper for `std::env::var_os`.
 pub trait Vars {
     fn get(&self, name: &'static str) -> Option<OsString>;

--- a/src/options/vars.rs
+++ b/src/options/vars.rs
@@ -55,6 +55,8 @@ pub static EZA_ICON_SPACING: &str = "EZA_ICON_SPACING";
 pub static EXA_OVERRIDE_GIT: &str = "EXA_OVERRIDE_GIT";
 pub static EZA_OVERRIDE_GIT: &str = "EZA_OVERRIDE_GIT";
 
+/// Environment variable used to automate the same behavior as `--icons=auto` if set.
+/// Any explicit use of `--icons=WHEN` overrides this behavior.
 pub static EZA_ICONS_AUTO: &str = "EZA_ICONS_AUTO";
 
 /// Mockable wrapper for `std::env::var_os`.


### PR DESCRIPTION
Adds support for a new `EZA_ICONS_AUTO` environment variable that, if set, automates the same behavior as using `--icons` or `--icons=auto`. Any explicit use of `--icons=WHEN` overrides this behavior.

This is just a feature I thought I'd try implementing for my own use because I like having icons always on and figured it could be useful for others. This is also my first ever open source Rust project contribution so please feel free to give feedback!