### PR TITLE
feat: Add an option to warn if there are hidden or gitignored files

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -585,7 +585,7 @@ impl<'dir> File<'dir> {
                 let mut size = 0;
                 let mut blocks = 0;
                 for file in dir
-                    .files(super::DotFilter::Dotfiles, None, false, false, true)
+                    .files(super::DotFilter::Dotfiles, None, false, false, true, None)
                     .flatten()
                 {
                     match file.recursive_directory_size() {
@@ -687,7 +687,7 @@ impl<'dir> File<'dir> {
         match Dir::read_dir(self.path.clone()) {
             // . & .. are skipped, if the returned iterator has .next(), it's not empty
             Ok(has_files) => has_files
-                .files(super::DotFilter::Dotfiles, None, false, false, false)
+                .files(super::DotFilter::Dotfiles, None, false, false, false, None)
                 .next()
                 .is_none(),
             Err(_) => false,

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -7,6 +7,7 @@ use std::os::unix::fs::MetadataExt;
 
 use crate::fs::DotFilter;
 use crate::fs::File;
+use crate::output::hidden_count::WarnHiddenMode;
 
 /// Flags used to manage the **file filter** process
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -68,6 +69,9 @@ pub struct FileFilter {
 
     /// Whether to ignore Git-ignored patterns.
     pub git_ignore: GitIgnore,
+
+    /// Print a warning if there are hidden or Git-ignored items that were not printed.
+    pub warn_hidden: WarnHiddenMode,
 }
 
 impl FileFilter {

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -4,6 +4,7 @@ use crate::fs::filter::{
     FileFilter, FileFilterFlags, GitIgnore, IgnorePatterns, SortCase, SortField,
 };
 use crate::fs::DotFilter;
+use crate::output::hidden_count::WarnHiddenMode;
 
 use crate::options::parser::MatchedFlags;
 use crate::options::{flags, OptionsError};
@@ -32,6 +33,7 @@ impl FileFilter {
             dot_filter:       DotFilter::deduce(matches)?,
             ignore_patterns:  IgnorePatterns::deduce(matches)?,
             git_ignore:       GitIgnore::deduce(matches)?,
+            warn_hidden:      WarnHiddenMode::deduce(matches)?,
         });
     }
 }

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -26,6 +26,7 @@ pub static COLOUR_SCALE: Arg = Arg { short: None, long: "colour-scale", takes_va
 // filtering and sorting options
 pub static ALL:         Arg = Arg { short: Some(b'a'), long: "all",         takes_value: TakesValue::Forbidden };
 pub static ALMOST_ALL:  Arg = Arg { short: Some(b'A'), long: "almost-all",  takes_value: TakesValue::Forbidden };
+pub static WARN_HIDDEN: Arg = Arg { short: Some(b'W'), long: "warn-hidden", takes_value: TakesValue::Forbidden };
 pub static LIST_DIRS:   Arg = Arg { short: Some(b'd'), long: "list-dirs",   takes_value: TakesValue::Forbidden };
 pub static LEVEL:       Arg = Arg { short: Some(b'L'), long: "level",       takes_value: TakesValue::Necessary(None) };
 pub static REVERSE:     Arg = Arg { short: Some(b'r'), long: "reverse",     takes_value: TakesValue::Forbidden };
@@ -83,7 +84,7 @@ pub static ALL_ARGS: Args = Args(&[
     &ONE_LINE, &LONG, &GRID, &ACROSS, &RECURSE, &TREE, &CLASSIFY, &DEREF_LINKS,
     &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE, &WIDTH, &NO_QUOTES,
 
-    &ALL, &ALMOST_ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
+    &ALL, &ALMOST_ALL, &WARN_HIDDEN, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
     &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS, &ONLY_FILES,
 
     &BINARY, &BYTES, &GROUP, &NUMERIC, &HEADER, &ICONS, &INODE, &LINKS, &MODIFIED, &CHANGED,

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -32,6 +32,7 @@ DISPLAY OPTIONS
 FILTERING AND SORTING OPTIONS
   -a, --all                  show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories
   -A, --almost-all           equivalent to --all; included for compatibility with `ls -A`
+  -W, --warn-hidden          print a message showing the number of hidden and ignored items. Use this twice to print a message, regardless of if any files are hidden
   -d, --list-dirs            list directories as files; don't list their contents
   -L, --level DEPTH          limit the depth of recursion
   -r, --reverse              reverse the sort order

--- a/src/options/hidden_count.rs
+++ b/src/options/hidden_count.rs
@@ -1,0 +1,18 @@
+use crate::output::hidden_count::WarnHiddenMode;
+
+use crate::options::parser::MatchedFlags;
+use crate::options::{flags, OptionsError};
+
+impl WarnHiddenMode {
+    pub fn deduce(matches: &MatchedFlags<'_>) -> Result<Self, OptionsError> {
+        match (matches.count(&flags::WARN_HIDDEN), matches.is_strict()) {
+            (0, _) => Ok(WarnHiddenMode::Never),
+            (1, _) => Ok(WarnHiddenMode::Auto),
+            (2, _) | (_, false) => Ok(WarnHiddenMode::Always),
+            (_, true) => Err(OptionsError::Conflict(
+                &flags::WARN_HIDDEN,
+                &flags::WARN_HIDDEN,
+            )),
+        }
+    }
+}

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -80,6 +80,7 @@ mod file_name;
 mod filter;
 #[rustfmt::skip] // this module becomes unreadable with rustfmt
 mod flags;
+mod hidden_count;
 mod theme;
 mod view;
 

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -77,6 +77,7 @@ use crate::fs::filter::FileFilter;
 use crate::fs::{Dir, File};
 use crate::output::cell::TextCell;
 use crate::output::file_name::Options as FileStyle;
+use crate::output::hidden_count::HiddenCount;
 use crate::output::table::{Options as TableOptions, Row as TableRow, Table};
 use crate::output::tree::{TreeDepth, TreeParams, TreeTrunk};
 use crate::theme::Theme;
@@ -159,6 +160,7 @@ impl<'a> Render<'a> {
         };
         let mut pool = Pool::new(n_cpus);
         let mut rows = Vec::new();
+        let mut hidden_count = HiddenCount::new(self.filter.warn_hidden);
 
         if let Some(ref table) = self.opts.table {
             match (self.git, self.dir) {
@@ -192,6 +194,7 @@ impl<'a> Render<'a> {
                 &mut rows,
                 &self.files,
                 TreeDepth::root(),
+                hidden_count.as_mut(),
             );
 
             for row in self.iterate_with_table(table.unwrap(), rows) {
@@ -204,11 +207,15 @@ impl<'a> Render<'a> {
                 &mut rows,
                 &self.files,
                 TreeDepth::root(),
+                hidden_count.as_mut(),
             );
 
             for row in self.iterate(rows) {
                 writeln!(w, "{}", row.strings())?;
             }
+        }
+        if let Some(warn_line) = hidden_count.and_then(|hc| hc.render()) {
+            writeln!(w, "{warn_line}")?;
         }
 
         Ok(())
@@ -236,6 +243,7 @@ impl<'a> Render<'a> {
         rows: &mut Vec<Row>,
         src: &[File<'dir>],
         depth: TreeDepth,
+        mut hidden_count: Option<&mut HiddenCount>,
     ) {
         use crate::fs::feature::xattr;
         use std::sync::{Arc, Mutex};
@@ -348,6 +356,7 @@ impl<'a> Render<'a> {
                     self.git_ignoring,
                     egg.file.deref_links,
                     egg.file.is_recursive_size(),
+                    hidden_count.as_deref_mut(),
                 ) {
                     match file_to_add {
                         Ok(f) => {
@@ -374,7 +383,14 @@ impl<'a> Render<'a> {
                         ));
                     }
 
-                    self.add_files_to_table(pool, table, rows, &files, depth.deeper());
+                    self.add_files_to_table(
+                        pool,
+                        table,
+                        rows,
+                        &files,
+                        depth.deeper(),
+                        hidden_count.as_deref_mut(),
+                    );
                     continue;
                 }
             }

--- a/src/output/hidden_count.rs
+++ b/src/output/hidden_count.rs
@@ -1,0 +1,53 @@
+use ansiterm::Colour;
+
+#[derive(Debug)]
+pub struct HiddenCount {
+    /// Whether to show all counts regardless of how many hidden and/or ignored items there are
+    always_print: bool,
+    hidden: usize,
+    ignored: usize,
+}
+
+impl HiddenCount {
+    pub fn new(mode: WarnHiddenMode) -> Option<HiddenCount> {
+        let always_print = match mode {
+            WarnHiddenMode::Never => return None,
+            WarnHiddenMode::Auto => false,
+            WarnHiddenMode::Always => true,
+        };
+
+        Some(HiddenCount {
+            always_print,
+            hidden: 0,
+            ignored: 0,
+        })
+    }
+
+    pub fn inc_hidden(&mut self) {
+        self.hidden += 1;
+    }
+
+    pub fn inc_ignored(&mut self) {
+        self.ignored += 1;
+    }
+
+    pub fn render(&self) -> Option<String> {
+        let warn_string = match (self.always_print, self.hidden, self.ignored) {
+            (false, 0, 0) => None,
+            (false, hidden, 0) => Some(format!("...and {hidden} hidden items")),
+            (false, 0, ignored) => Some(format!("...and {ignored} ignored items")),
+            (false, hidden, ignored) => {
+                Some(format!("...and {hidden} hidden, {ignored} ignored items"))
+            }
+            (true, hidden, ignored) => Some(format!("{hidden} hidden and {ignored} ignored items")),
+        };
+        warn_string.map(|s| Colour::BrightRed.paint(s).to_string())
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+pub enum WarnHiddenMode {
+    Never,
+    Auto,
+    Always,
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -5,6 +5,7 @@ pub mod details;
 pub mod file_name;
 pub mod grid;
 pub mod grid_details;
+pub mod hidden_count;
 pub mod icons;
 pub mod lines;
 pub mod render;


### PR DESCRIPTION
I have added a new option, `--warn-hidden`, to print a warning message if there were any files hidden, or ignored because of a .gitignore, from the printed file list. To do this, there is a new type, `WarnHidden`, which is passed through functions that explore the file tree and counts the number of times files have been hidden or ignored, and can print a message if so. The option can be specified twice to print a message with the number of hidden files, regardless of if there were any.

The implementation for the tree view is not yet complete, it prints a single message after the entire tree, rather than adding a line in each directory in the tree, as I would like it to.

Resolves #589