### PR TITLE
ci: refactor pre-commit-hooks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -201,23 +201,32 @@
 
         # For `nix flake check`
         checks = {
-          pre-commit-check = pre-commit-hooks.lib.${system}.run {
-            src = ./.;
-            hooks = {
-              convco.enable = true;
-              alejandra.enable = true;
-              deadnix.enable = true;
-              rustfmt.enable = true;
-              shellcheck.enable = true;
-              taplo.enable = true;
+          pre-commit-check = let
+            # some treefmt formatters are not supported in pre-commit-hooks we filter them out for now.
+            toFilter =
+              # This is a nice hack to not have to manually filter we should keep in mind for a future refactor.
+              # (builtins.attrNames pre-commit-hooks.packages.${system})
+              ["yamlfmt"];
+            filterFn = n: _v: (!builtins.elem n toFilter);
+            treefmtFormatters = pkgs.lib.mapAttrs (_n: v: {inherit (v) enable;}) (pkgs.lib.filterAttrs filterFn (import ./treefmt.nix).programs);
+          in
+            pre-commit-hooks.lib.${system}.run {
+              src = ./.;
+              hooks =
+                treefmtFormatters
+                // {
+                  convco.enable = true; # not in treefmt
+                };
             };
-          };
           formatting = treefmtEval.config.build.check self;
           build = packages.check;
-          default = packages.default;
-          test = packages.test;
+          inherit
+            (packages)
+            default
+            test
+            trycmd
+            ;
           lint = packages.clippy;
-          trycmd = packages.trycmd;
         };
       }
     );

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -2,9 +2,10 @@
   projectRootFile = "Cargo.toml";
   programs = {
     alejandra.enable = true; # nix
+    statix.enable = true; # nix static analysis
+    deadnix.enable = true; # find dead nix code
     rustfmt.enable = true; # rust
     shellcheck.enable = true; # bash/shell
-    deadnix.enable = true; # find dead nix code
     taplo.enable = true; # toml
     yamlfmt.enable = true; # yaml
   };


### PR DESCRIPTION
The pre-commit-hooks now use the treefmt formatter list. The `toFilter` list is used to filer the formatters not supported by treefmt.

I also added the statix formatter. iirc I also did this in #462 