### PR TITLE
fix: Snap requires a base

### DIFF
--- a/snap/.gitignore
+++ b/snap/.gitignore
@@ -1,1 +1,0 @@
-.snapcraft

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: eza
+base: core22
 version: 'latest'
 summary: Replacement for 'ls' written in Rust
 description: |
@@ -6,7 +7,12 @@ description: |
   many types of files, such as whether you are the owner, or in the owning
   group. It also has extra features not present in the original ls, such as
   viewing the Git status for a directory, or recursing into directories with a
-  tree view. eza is written in Rust, and it’s small, fast, and portable.
+  tree view. eza is written in Rust, and it's small, fast, and portable.
+issues: https://github.com/eza-community/eza/issues
+source-code: https://github.com/eza-community/eza
+contact: christina@cafkafk.com
+website: https://eza.rocks/
+license: MIT
 grade: stable
 confinement: classic
 apps:


### PR DESCRIPTION
Snap requires a `base` so I set it to `core22` and add some missing optional metadata for `website`, `contact`, `issues`, `source-code`, and `license`.

Also removed the `.gitignore` file since else `snapcraft` complains about that.