### PR TITLE
fix(docs): move `--smart-group` to long view options

### DIFF
--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -118,9 +118,6 @@ The default value is `none`
 `absolute` mode highlights based on file modification time relative to the past year.
 `relative` mode highlights based on file modification time in relation to other files. `none` disables highlighting.
 
-`--smart-group`
-: Only show group if it has a different name from owner
-
 FILTERING AND SORTING OPTIONS
 =============================
 
@@ -181,6 +178,9 @@ These options are available when running with `--long` (`-l`):
 
 `-g`, `--group`
 : List each file’s group.
+
+`--smart-group`
+: Only show group if it has a different name from owner
 
 `-h`, `--header`
 : Add a header row to each column.

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -27,7 +27,6 @@ DISPLAY OPTIONS
   --no-quotes                don't quote file names with spaces
   --hyperlink                display entries as hyperlinks
   -w, --width COLS           set screen width in columns
-  --smart-group              only show group if it has a different name from owner
 
 
 FILTERING AND SORTING OPTIONS
@@ -55,6 +54,7 @@ LONG VIEW OPTIONS
   -b, --binary               list file sizes with binary prefixes
   -B, --bytes                list file sizes in bytes, without any prefixes
   -g, --group                list each file's group
+  --smart-group              only show group if it has a different name from owner
   -h, --header               add a header row to each column
   -H, --links                list each file's number of hard links
   -i, --inode                list each file's inode number


### PR DESCRIPTION
`--smart-group` is only applicable if `--group` is given.
Move its description to be after `--group` in the "LONG VIEW OPTIONS" section.