### PR TITLE
fix(xattr): Use `from_utf8_lossy` instead of `from_utf8_unchecked`

### DIFF
--- a/src/fs/feature/xattr.rs
+++ b/src/fs/feature/xattr.rs
@@ -188,11 +188,9 @@ mod lister {
         }
 
         pub fn translate_attribute_data(&self, input: &[u8]) -> String {
-            unsafe {
-                std::str::from_utf8_unchecked(input)
-                    .trim_end_matches('\0')
-                    .into()
-            }
+            std::string::String::from_utf8_lossy(input)
+                .trim_end_matches('\0')
+                .into()
         }
 
         pub fn listxattr_first(&self, c_path: &CString) -> ssize_t {


### PR DESCRIPTION
The use of `std::str::from_utf8_unchecked` when parsing extended attribute values [here in `src/fs/feature/xattrs.rs`](https://github.com/eza-community/eza/blob/9683862a42089a7ffc30948d5c246893056e150a/src/fs/feature/xattr.rs#L190-L196) may lead to undefined behavior as extended attributes are not guaranteed to be valid UTF-8.

This PR provides a temporary solution by using `std::string::String::from_utf8_lossy` to parse values instead, as this will cause invalid sequences to be replaced by `U+FFFD` (i.e. the Unicode replacement character). This will prevent undefined behavior and/or `SIGSEGV` in release builds at the expense of outputting uglier representations of extended attributes. This closes #425.