### PR TITLE
feat: abort on panic (saving 0.1 M)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ lto = true
 strip = true
 opt-level = 3
 codegen-units = 1
+panic = 'abort'
 
 [[bench]]
 name = "my_benchmark"


### PR DESCRIPTION
Signed-off-by: Christina Sørensen <christina@cafkafk.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Make sure you've read CONTRIBUTING.md and CODE_OF_CONDUCT.md -->
<!---  -->
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
##### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Consider including potentalally useful screenshots of your feature in action -->
This adds:
```toml
[profile.release]
panic = 'abort'
```

Saving `0.1` megs by making the binary 1.7M -> 1.6M

##### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

