### PR TITLE
fix(docs): Escape ` in zsh completions

### DIFF
--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -29,7 +29,7 @@ __eza() {
         --group-directories-first"[Sort directories before other files]" \
         --git-ignore"[Ignore files mentioned in '.gitignore']" \
         {-a,--all}"[Show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories]" \
-        {-A,--almost-all}"[Equivalent to --all; included for compatibility with 'ls -A']" \
+        {-A,--almost-all}"[Equivalent to --all; included for compatibility with \'ls -A\']" \
         {-d,--list-dirs}"[List directories like regular files]" \
         {-D,--only-dirs}"[List only directories]" \
         {-f,--only-files}"[List only files]" \


### PR DESCRIPTION
- fixes #631 