### PR TITLE
feat(env): adding an env variable to override size format

### DIFF
--- a/src/options/vars.rs
+++ b/src/options/vars.rs
@@ -64,6 +64,8 @@ pub static EZA_MIN_LUMINANCE: &str = "EZA_MIN_LUMINANCE";
 /// Any explicit use of `--icons=WHEN` overrides this behavior.
 pub static EZA_ICONS_AUTO: &str = "EZA_ICONS_AUTO";
 
+pub static EZA_SIZE_STYLE: &str = "EZA_SIZE_STYLE";
+
 /// Mockable wrapper for `std::env::var_os`.
 pub trait Vars {
     fn get(&self, name: &'static str) -> Option<OsString>;


### PR DESCRIPTION
The env variable is EZA_SIZE_STYLE as proposed in eza-community/eza#657