### PR TITLE
fix: calculate width correctly when using grid icons & classify

### DIFF
--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -83,7 +83,13 @@ impl<'a> Render<'a> {
                 (
                     EmbedHyperlinks::Off,
                     ShowIcons::Always(spacing) | ShowIcons::Automatic(spacing),
-                ) => filename.bare_width() + 1 + (spacing as usize) + space_filename_offset,
+                ) => {
+                    filename.bare_width()
+                        + classification_width
+                        + 1
+                        + (spacing as usize)
+                        + space_filename_offset
+                }
                 (EmbedHyperlinks::Off, _) => *contents.width(),
             };
 


### PR DESCRIPTION
Resolves #578. This just adds the `classification_width` in one case that was left out for the approximate calculation of width in grid view. as mentioned [here](https://github.com/eza-community/eza/pull/583#issuecomment-1788921591) 