### PR TITLE
fix(completions): add color-scale-mode to bash and fish

### DIFF
--- a/completions/bash/eza
+++ b/completions/bash/eza
@@ -54,7 +54,7 @@ _eza() {
         --*)
             # colo[u]r isn’t parsed correctly so we filter these options out and add them by hand
             parse_help=$(eza --help | grep -oE ' (--[[:alnum:]@-]+)' | tr -d ' ' | grep -v '\--colo')
-            completions=$(echo '--color --colour --color-scale --colour-scale' "$parse_help")
+            completions=$(echo '--color --colour --color-scale --colour-scale --color-scale-mode --colour-scale-mode' "$parse_help")
             mapfile -t COMPREPLY < <(compgen -W "$completions" -- "$cur")
             ;;
 

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -25,6 +25,7 @@ complete -c eza -l color-scale \
     size\t''
 "
 complete -c eza -l color-scale-mode \
+    -l colour-scale-mode \
     -d "Use gradient or fixed colors in --color-scale" -x -a "
     fixed\t'Highlight based on fixed colors'
     gradient\t'Highlight based \'field\' in relation to other files'


### PR DESCRIPTION
- add --color-scale-mode to the bash completions
- add --colour-scale-mode to the bash and fish completions

Closes #707