### PR TITLE
feat(time_display): use /etc/timezone for time display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e23185c0e21df6ed832a12e2bda87c7d1def6842881fb634a8511ced741b0d76"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,9 +413,11 @@ version = "0.16.3"
 dependencies = [
  "ansiterm",
  "chrono",
+ "chrono-tz",
  "criterion",
  "git2",
  "glob",
+ "iana-time-zone",
  "libc",
  "locale",
  "log",
@@ -507,16 +531,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -780,6 +804,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "partition-identity"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +834,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
  "phf_shared",
 ]
 
@@ -1481,10 +1524,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,8 @@ name = "eza"
 [dependencies]
 ansiterm = { version = "0.12.2", features = ["ansi_colours"] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
+chrono-tz = "0.8.4"
+iana-time-zone = "0.1.58"
 glob = "0.3"
 libc = "0.2"
 locale = "0.2"

--- a/src/output/render/times.rs
+++ b/src/output/render/times.rs
@@ -5,12 +5,15 @@ use ansiterm::Style;
 use chrono::prelude::*;
 
 pub trait Render {
-    fn render(self, style: Style, time_offset: FixedOffset, time_format: TimeFormat) -> TextCell;
+    fn render(self, style: Style, time_format: TimeFormat) -> TextCell;
 }
 
 impl Render for Option<NaiveDateTime> {
-    fn render(self, style: Style, time_offset: FixedOffset, time_format: TimeFormat) -> TextCell {
+    fn render(self, style: Style, time_format: TimeFormat) -> TextCell {
+        let timezone_str = iana_time_zone::get_timezone().unwrap();
+        let timezone: chrono_tz::Tz = timezone_str.parse().unwrap();
         let datestamp = if let Some(time) = self {
+            let time_offset = timezone.offset_from_utc_datetime(&time).fix();
             time_format.format(&DateTime::<FixedOffset>::from_naive_utc_and_offset(
                 time,
                 time_offset,

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -330,9 +330,6 @@ impl Default for TimeTypes {
 ///
 /// Any environment field should be able to be mocked up for test runs.
 pub struct Environment {
-    /// The computer’s current time offset, determined from time zone.
-    time_offset: FixedOffset,
-
     /// Localisation rules for formatting numbers.
     numeric: locale::Numeric,
 
@@ -348,8 +345,6 @@ impl Environment {
     }
 
     fn load_all() -> Self {
-        let time_offset = *Local::now().offset();
-
         let numeric =
             locale::Numeric::load_user_locale().unwrap_or_else(|_| locale::Numeric::english());
 
@@ -357,7 +352,6 @@ impl Environment {
         let users = Mutex::new(UsersCache::new());
 
         Self {
-            time_offset,
             numeric,
             #[cfg(unix)]
             users,
@@ -528,7 +522,6 @@ impl<'a> Table<'a> {
                 } else {
                     self.theme.ui.date
                 },
-                self.env.time_offset,
                 self.time_format.clone(),
             ),
         }

--- a/src/output/time.rs
+++ b/src/output/time.rs
@@ -175,4 +175,34 @@ mod test {
             .all(|string| UnicodeWidthStr::width(string.as_str()) == max_month_width)
         );
     }
+
+    #[test]
+    fn display_timestamp_correctly_in_timezone_with_dst() {
+        let timezone_str = "Europe/Berlin";
+        let timezone: chrono_tz::Tz = timezone_str.parse().unwrap();
+        let time = DateTime::<Utc>::from_timestamp(1685867700, 0)
+            .unwrap()
+            .naive_utc();
+
+        let fixed_offset = timezone.offset_from_utc_datetime(&time).fix();
+        let real_converted = DateTime::<FixedOffset>::from_naive_utc_and_offset(time, fixed_offset);
+        let formatted = full(&real_converted);
+        let expected = "2023-06-04 10:35:00.000000000 +0200";
+        assert_eq!(expected, formatted);
+    }
+
+    #[test]
+    fn display_timestamp_correctly_in_timezone_without_dst() {
+        let timezone_str = "Europe/Berlin";
+        let timezone: chrono_tz::Tz = timezone_str.parse().unwrap();
+        let time = DateTime::<Utc>::from_timestamp(1699090500, 0)
+            .unwrap()
+            .naive_utc();
+
+        let fixed_offset = timezone.offset_from_utc_datetime(&time).fix();
+        let real_converted = DateTime::<FixedOffset>::from_naive_utc_and_offset(time, fixed_offset);
+        let formatted = full(&real_converted);
+        let expected = "2023-11-04 10:35:00.000000000 +0100";
+        assert_eq!(expected, formatted);
+    }
 }


### PR DESCRIPTION
When a file timestamp is updated under daylight saving time, and displayed when it is not, the wrong time offset is displayed (and vice versa).

Fixes issue #653 .