### PR TITLE
fix(output): quote symbolic links correctly when their destinations contain spaces

### DIFF
--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -8,6 +8,7 @@ pub fn escape(
     bad: Style,
     quote_style: QuoteStyle,
 ) {
+    let bits_starting_length = bits.len();
     let needs_quotes = string.contains(' ') || string.contains('\'');
     let quote_bit = good.paint(if string.contains('\'') { "\"" } else { "\'" });
 
@@ -32,7 +33,7 @@ pub fn escape(
     }
 
     if quote_style != QuoteStyle::NoQuotes && needs_quotes {
-        bits.insert(0, quote_bit.clone());
+        bits.insert(bits_starting_length, quote_bit.clone());
         bits.push(quote_bit);
     }
 }


### PR DESCRIPTION
There's an issue with the way symlinks are quoted when their destination has spaces in the name.

Below is a set of test cases that demonstrates the problem:
```
λ eza -l bug-test
.rw-r--r-- 0 zacc  9 Dec 17:53 'file with spaces'
lrwxrwxrwx - zacc  9 Dec 17:54 'symlink-to-dest-with-spaces -> /tmp/file with spaces' # <-- this one
lrwxrwxrwx - zacc  9 Dec 17:53 symlink-without-spaces -> /tmp/test
lrwxrwxrwx - zacc  9 Dec 18:24 ''symlink with spaces to dest with spaces' -> /tmp/file with spaces' # <-- and this one
lrwxrwxrwx - zacc  9 Dec 17:53 'symlink with spaces' -> /tmp/test
```

In `symlink-to-dest-with-spaces`, the link has no spaces, but the destination does. `eza` quoted the entire link display, instead of just the destination.

In `symlink with spaces to dest with spaces`, the link and destination have spaces. `eza` quoted the link and then also the entire link display, instead of quoting each separately.

The issue is caused by the fact that the `escape` function always inserts the starting quote at the very beginning of the finished string, instead of only inserting it before the new part.

It seems to have been introduced in #318.