### PR TITLE
fix: don't panic when printing to stdout/stderr fails

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,6 +1,7 @@
 //! Debug error logging.
 
 use std::ffi::OsStr;
+use std::io::{self, Write};
 
 use ansiterm::{ANSIString, Colour};
 
@@ -22,7 +23,7 @@ pub fn configure<T: AsRef<OsStr>>(ev: Option<T>) {
 
     let result = log::set_logger(GLOBAL_LOGGER);
     if let Err(e) = result {
-        eprintln!("Failed to initialise logger: {e}");
+        let _ = writeln!(io::stderr(), "Failed to initialise logger: {e}");
     }
 }
 
@@ -41,7 +42,8 @@ impl log::Log for Logger {
         let level = level(record.level());
         let close = Colour::Fixed(243).paint("]");
 
-        eprintln!(
+        let _ = writeln!(
+            io::stderr(),
             "{}{} {}{} {}",
             open,
             level,
@@ -52,7 +54,7 @@ impl log::Log for Logger {
     }
 
     fn flush(&self) {
-        // no need to flush with ‘eprintln!’.
+        // no need to flush with ‘writeln!’.
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ fn main() {
                 }
 
                 Err(e) => {
-                    eprintln!("{e}");
+                    let _ = writeln!(io::stderr(), "{e}");
                     trace!("exa.run: exit RUNTIME_ERROR");
                     exit(exits::RUNTIME_ERROR);
                 }
@@ -123,18 +123,18 @@ fn main() {
         }
 
         OptionsResult::Help(help_text) => {
-            print!("{help_text}");
+            let _ = write!(io::stdout(), "{help_text}");
         }
 
         OptionsResult::Version(version_str) => {
-            print!("{version_str}");
+            let _ = write!(io::stdout(), "{version_str}");
         }
 
         OptionsResult::InvalidOptions(error) => {
-            eprintln!("eza: {error}");
+            let _ = writeln!(io::stderr(), "eza: {error}");
 
             if let Some(s) = error.suggestion() {
-                eprintln!("{s}");
+                let _ = writeln!(io::stderr(), "{s}");
             }
 
             exit(exits::OPTIONS_ERROR);
@@ -273,7 +273,7 @@ impl<'args> Exa<'args> {
                         match f.to_dir() {
                             Ok(d) => dirs.push(d),
                             Err(e) if e.kind() == ErrorKind::PermissionDenied => {
-                                eprintln!("{file_path:?}: {e}");
+                                writeln!(io::stderr(), "{file_path:?}: {e}")?;
                                 exit(exits::PERMISSION_DENIED);
                             }
                             Err(e) => writeln!(io::stderr(), "{file_path:?}: {e}")?,


### PR DESCRIPTION
`println!`, `eprintln!` etc. all panic when printing to a standard stream fails.
```sh
$ eza --help > /dev/full
thread 'main' panicked at library/std/src/io/stdio.rs:1019:9:
failed printing to stdout: No space left on device (os error 28)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted (core dumped)
``` 
```sh
$ eza --nonexistent-option 2> /dev/full
Aborted (core dumped)
```

This PR makes `eza` ignore these errors instead.