### PR TITLE
feat: Use fsharp icon for fsproj files (similar to cs/csproj)

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -445,6 +445,7 @@ const EXTENSION_ICONS: Map<&'static str, char> = phf_map! {
     "for"            => Icons::LANG_FORTRAN,     // 󱈚
     "fs"             => Icons::LANG_FSHARP,      // 
     "fsi"            => Icons::LANG_FSHARP,      // 
+    "fsproj"         => Icons::LANG_FSHARP,      // 
     "fsx"            => Icons::LANG_FSHARP,      // 
     "gdoc"           => Icons::DOCUMENT,         // 
     "gem"            => Icons::LANG_RUBY,        // 


### PR DESCRIPTION
By using the same icon for `fsproj` files as `fs` (and other fsharp files) we use the same behaviour as for csharp files (`csproj` files also use the same icon as `cs` files).