### PR TITLE
Fix offset widths in grid mode with utf8 filenames

### DIFF
--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::path::Path;
 
 use ansiterm::{ANSIString, Style};
+use unicode_width::UnicodeWidthStr;
 
 use crate::fs::mounts::MountedFs;
 use crate::fs::{File, FileTarget};
@@ -443,8 +444,8 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
     }
 
     /// For grid's use, to cover the case of hyperlink escape sequences
-    pub fn bare_width(&self) -> usize {
-        self.file.name.len()
+    pub fn bare_utf8_width(&self) -> usize {
+        UnicodeWidthStr::width(self.file.name.as_str())
     }
 }
 

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -71,20 +71,20 @@ impl<'a> Render<'a> {
                     EmbedHyperlinks::On,
                     ShowIcons::Always(spacing) | ShowIcons::Automatic(spacing),
                 ) => {
-                    filename.bare_width()
+                    filename.bare_utf8_width()
                         + classification_width
                         + 1
                         + (spacing as usize)
                         + space_filename_offset
                 }
                 (EmbedHyperlinks::On, ShowIcons::Never) => {
-                    filename.bare_width() + classification_width + space_filename_offset
+                    filename.bare_utf8_width() + classification_width + space_filename_offset
                 }
                 (
                     EmbedHyperlinks::Off,
                     ShowIcons::Always(spacing) | ShowIcons::Automatic(spacing),
                 ) => {
-                    filename.bare_width()
+                    filename.bare_utf8_width()
                         + classification_width
                         + 1
                         + (spacing as usize)

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -190,13 +190,13 @@ impl<'a> Render<'a> {
                     filename.options.show_icons,
                 ) {
                     (EmbedHyperlinks::On, ShowIcons::Automatic(spacing)) => {
-                        filename.bare_width() + 1 + (spacing as usize) + space_filename_offset
+                        filename.bare_utf8_width() + 1 + (spacing as usize) + space_filename_offset
                     }
                     (EmbedHyperlinks::On, ShowIcons::Always(spacing)) => {
-                        filename.bare_width() + 1 + (spacing as usize) + space_filename_offset
+                        filename.bare_utf8_width() + 1 + (spacing as usize) + space_filename_offset
                     }
                     (EmbedHyperlinks::On, ShowIcons::Never) => {
-                        filename.bare_width() + space_filename_offset
+                        filename.bare_utf8_width() + space_filename_offset
                     }
                     (EmbedHyperlinks::Off, _) => *contents.width(),
                 };


### PR DESCRIPTION
When UTF-8 characters were present in the filename (cyrilic characters or french accents for example) the bare_width function returned the size of the ascii string.

Using UnicodeWidthStr::width to get the width fixes the issue.

Fixes #566