### PR TITLE
feat(icons): adding more haskell related icons

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -151,6 +151,8 @@ const DIRECTORY_ICONS: Map<&'static str, char> = phf_map! {
     "Videos"              => '\u{f03d}',            // 
     "xbps.d"              => Icons::FOLDER_CONFIG,  // 
     "xorg.conf.d"         => Icons::FOLDER_CONFIG,  // 
+    "hi"                  => Icons::BINARY,         // 
+    "cabal"               => Icons::LANG_HASKELL,   // 
 };
 
 /// Mapping from full filenames to file icon. This mapping should also contain


### PR DESCRIPTION
As I work on haskell for school I added some files that missed their icons such as
- .hi files which are binaries that reprensetes types for the compiler or binaries that arent supposedto be read for game high scores
- .cabal files that are used to configure cabal projects