### PR TITLE
fix: stack overflow when '-laaR' are used

### DIFF
--- a/src/output/color_scale.rs
+++ b/src/output/color_scale.rs
@@ -141,7 +141,11 @@ fn update_information_recursively(
 
         // We don't want to recurse into . and .., but still want to list them, therefore bypass
         // the dot_filter.
-        if file.is_directory() && r.is_some_and(|x| !x.is_too_deep(depth.0)) && file.name != "." && file.name != ".." {
+        if file.is_directory()
+            && r.is_some_and(|x| !x.is_too_deep(depth.0))
+            && file.name != "."
+            && file.name != ".."
+        {
             match file.to_dir() {
                 Ok(dir) => {
                     let files: Vec<File<'_>> = dir

--- a/src/output/color_scale.rs
+++ b/src/output/color_scale.rs
@@ -139,7 +139,9 @@ fn update_information_recursively(
             Extremes::update(size, &mut information.size);
         }
 
-        if file.is_directory() && r.is_some_and(|x| !x.is_too_deep(depth.0)) {
+        // We don't want to recurse into . and .., but still want to list them, therefore bypass
+        // the dot_filter.
+        if file.is_directory() && r.is_some_and(|x| !x.is_too_deep(depth.0)) && file.name != "." && file.name != ".." {
             match file.to_dir() {
                 Ok(dir) => {
                     let files: Vec<File<'_>> = dir


### PR DESCRIPTION
When adding two -a options, you request that dotfiles *and* . and .. are displayed. But the -R triggers the recursion function, which caused the color scalar to recurse into ., causing a stack overflow.

This fixes #753 