### PR TITLE
feat: Decode com.apple.ResourceFork extended attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +412,7 @@ dependencies = [
  "libc",
  "locale",
  "log",
+ "macbinary",
  "natord",
  "num_cpus",
  "number_prefix",
@@ -653,6 +669,19 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "macbinary"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3b20f06e85c883de160086c2e2b45524ff19888271eccd593c8956d1fc1687"
+dependencies = [
+ "crc",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_bytes",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "matches"
@@ -1059,6 +1088,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,9 @@ windows-sys = { version = "0.52.0", features = [
   "Win32_Foundation",
 ] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+macbinary = { version = "0.2.1" }
+
 [build-dependencies]
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 


### PR DESCRIPTION
```
~/src/rust/eza/target/debug/eza -l@
drwx------     - rminsk 26 Nov  2023 com.apple.launchd.U5S1fYnhl5
.rw-r--r--@    0 rminsk  7 Jan 23:15 has_icon
                                     ├── com.apple.FinderInfo: "\0\0\0\0\0\0\0\0\u{4}"
                                     ├── com.apple.ResourceFork: <[{"type": 'icns', "id": -16455, "length": 96924}]>
                                     └── com.apple.provenance: [01, 00, 00, a3, f3, 84, 32, 0e, f8, 0b, 5a]
```