### PR TITLE
fix: crash using --git-repos on unreadable dir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -199,10 +199,14 @@ fn git_repos(_options: &Options, _args: &[&OsStr]) -> bool {
 #[cfg(feature = "git")]
 fn get_files_in_dir(paths: &mut Vec<PathBuf>, path: PathBuf) {
     let temp_paths = if path.is_dir() {
-        path.read_dir()
-            .unwrap()
-            .map(|entry| entry.unwrap().path())
-            .collect::<Vec<PathBuf>>()
+        match path.read_dir() {
+            Err(_) => {
+                vec![path]
+            }
+            Ok(d) => d
+                .map(|entry| entry.unwrap().path())
+                .collect::<Vec<PathBuf>>(),
+        }
     } else {
         vec![path]
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,6 +204,7 @@ fn get_files_in_dir(paths: &mut Vec<PathBuf>, path: PathBuf) {
                 vec![path]
             }
             Ok(d) => d
+                .filter(std::result::Result::is_ok)
                 .map(|entry| entry.unwrap().path())
                 .collect::<Vec<PathBuf>>(),
         }


### PR DESCRIPTION
This patch fixes the crash when the --git-repos flag is used on an directory that doesn't have read permissions.

Fixes: #767