### PR TITLE
fix(cargo): update shlex to 1.3.0 due to vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "similar"


### PR DESCRIPTION
See https://rustsec.org/advisories/RUSTSEC-2024-0006 for details.