### PR TITLE
Avoid `unwrap()` by changing filter-then-map to `filter_map`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -204,8 +204,7 @@ fn get_files_in_dir(paths: &mut Vec<PathBuf>, path: PathBuf) {
                 vec![path]
             }
             Ok(d) => d
-                .filter(std::result::Result::is_ok)
-                .map(|entry| entry.unwrap().path())
+                .filter_map(|entry| entry.ok().map(|e| e.path()))
                 .collect::<Vec<PathBuf>>(),
         }
     } else {


### PR DESCRIPTION
This tries to improve #778 by removing an avoidable `.unwrap()`.

I also considered getting the `.path()` in a separate `.map()` on the iterator, not sure what's best:
```rs
.filter_map(|entry| entry.ok())
.map(|entry| entry.path())
```