### PR TITLE
docs: add target arch to deb PPA installation for strict apt environments

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,6 +54,7 @@ sudo chmod 644 /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.lis
 sudo apt update
 sudo apt install -y eza
 ```
+_Note_: In strict apt environments, you may need to add the target: `echo "deb [arch=amd64 signed-by=...` 
 
 ### Nix (Linux, MacOS)
 


### PR DESCRIPTION
As was recommended in #810, could be helpful to others in that situation/environment. 
