### PR TITLE
fix: duplicates in shell completions

### DIFF
--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -9,7 +9,7 @@ complete -c eza -s G -l grid -d "Display entries in a grid"
 complete -c eza -s x -l across -d "Sort the grid across, rather than downwards"
 complete -c eza -s R -l recurse -d "Recurse into directories"
 complete -c eza -s T -l tree -d "Recurse into directories as a tree"
-complete -c eza -s X -l dereference -d "Dereference symbolic links when displaying information"
+complete -c eza -s X -l dereference -d "Dereference symbolic links when displaying file information"
 complete -c eza -s F -l classify -d "Display type indicator by file names"
 complete -c eza -l color \
     -l colour -d "When to use terminal colours" -x -a "
@@ -91,7 +91,6 @@ complete -c eza -s t -l time -d "Which timestamp field to list" -x -a "
     accessed\t'Display accessed time'
     created\t'Display created time'
 "
-complete -c eza -s X -l dereference -d "dereference symlinks for file information"
 complete -c eza -s m -l modified -d "Use the modified timestamp field"
 complete -c eza -s n -l numeric -d "List numeric user and group IDs."
 complete -c eza -l changed -d "Use the changed timestamp field"

--- a/completions/nush/eza.nu
+++ b/completions/nush/eza.nu
@@ -7,7 +7,7 @@ export extern "eza" [
     --across(-x)               # Sort the grid across, rather than downwards
     --recurse(-R)              # Recurse into directories
     --tree(-T)                 # Recurse into directories as a tree
-    --dereference(-X)          # Dereference symbolic links when displaying information
+    --dereference(-X)          # Dereference symbolic links when displaying file information
     --classify(-F)             # Display type indicator by file names
     --color                    # When to use terminal colours
     --colour                   # When to use terminal colours
@@ -37,7 +37,6 @@ export extern "eza" [
     --inode(-i)                # List each file's inode number
     --blocksize(-S)            # List each file's size of allocated file system blocks
     --time(-t) -d              # Which timestamp field to list
-    --dereference(-X)          # dereference symlinks for file information
     --modified(-m)             # Use the modified timestamp field
     --numeric(-n)              # List numeric user and group IDs.
     --changed                  # Use the changed timestamp field

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -18,7 +18,7 @@ __eza() {
         {-x,--across}"[Sort the grid across, rather than downwards]" \
         {-R,--recurse}"[Recurse into directories]" \
         {-T,--tree}"[Recurse into directories as a tree]" \
-        {-X,--dereference}"[Dereference symbolic links when displaying information]" \
+        {-X,--dereference}"[Dereference symbolic links when displaying file information]" \
         {-F,--classify}"[Display type indicator by file names]:(when):(always auto automatic never)" \
         --colo{,u}r="[When to use terminal colours]:(when):(always auto automatic never)" \
         --colo{,u}r-scale"[highlight levels of 'field' distinctly]:(fields):(all age size)" \
@@ -58,7 +58,6 @@ __eza() {
         --no-time"[Suppress the time field]" \
         {-u,--accessed}"[Use the accessed timestamp field]" \
         {-U,--created}"[Use the created timestamp field]" \
-        {-X,--dereference}"[dereference symlinks for file information]" \
         --git"[List each file's Git status, if tracked]" \
         --no-git"[Suppress Git status]" \
         --git-repos"[List each git-repos status and branch name]" \


### PR DESCRIPTION
I realized there are duplicated entries in shell completions. They had different description, so I merged their description and removed the extra one.

I also realized that the bash completion is lacking a lot, but that is out of the scope of this PR.


I used the following to double check for duplicates. Perhaps these can be used to create automated tests for the repo. Note that they are all in Bash/Zsh syntax and not Fish and Nushell:

For Zsh:
```sh
cat zsh/_eza \
  | grep -P '^\s*[{-]' \
  | sed -E 's/".+$//g' \
  | sed -E 's/(^ *)|(} *$)|(\{)//g' \
  | sort \
  | uniq -c \
  | sort
```

For Bash:
```sh
cat bash/eza \
  | grep '^\s*-' \
  | sed -E 's/(^\s*)|\)//g' \
  | tr '|' '\n' \
  | sort \
  | uniq -c \
  | sort
```

For Nushell:
```sh
cat nush/eza.nu \
  | sed -E 's/(^\s*)|( *# .+)|\)|^[^-]+$//g' \
  | tr '(' '\n' \
  | sort \
  | uniq -c \
  | sort
```
