### PR TITLE
Reuse FileType from DirEntry

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -8,6 +8,7 @@
 
 #[cfg(unix)]
 use std::collections::HashMap;
+use std::fs::FileType;
 use std::io;
 #[cfg(unix)]
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
@@ -74,12 +75,15 @@ pub struct File<'dir> {
     /// path (following a symlink).
     pub path: PathBuf,
 
+    /// The cached filetype for this file
+    pub filetype: OnceLock<Option<std::fs::FileType>>,
+
     /// A cached `metadata` (`stat`) call for this file.
     ///
     /// This too is queried multiple times, and is *not* cached by the OS, as
     /// it could easily change between invocations — but exa is so short-lived
     /// it’s better to just cache it.
-    pub metadata: std::fs::Metadata,
+    pub metadata: OnceLock<io::Result<std::fs::Metadata>>,
 
     /// A reference to the directory that contains this file, if any.
     ///
@@ -122,7 +126,8 @@ impl<'dir> File<'dir> {
         filename: FN,
         deref_links: bool,
         total_size: bool,
-    ) -> io::Result<File<'dir>>
+        filetype: Option<std::fs::FileType>,
+    ) -> File<'dir>
     where
         PD: Into<Option<&'dir Dir>>,
         FN: Into<Option<String>>,
@@ -131,11 +136,7 @@ impl<'dir> File<'dir> {
         let name = filename.into().unwrap_or_else(|| File::filename(&path));
         let ext = File::ext(&path);
 
-        debug!("Statting file {:?}", &path);
-        let metadata = std::fs::symlink_metadata(&path)?;
         let is_all_all = false;
-        let extended_attributes = OnceLock::new();
-        let absolute_path = OnceLock::new();
         let recursive_size = if total_size {
             RecursiveSize::Unknown
         } else {
@@ -144,24 +145,32 @@ impl<'dir> File<'dir> {
 
         debug!("deref_links {}", deref_links);
 
+        let filetype = match filetype {
+            Some(f) => OnceLock::from(Some(f)),
+            None => OnceLock::new(),
+        };
+
+        debug!("deref_links {}", deref_links);
+
         let mut file = File {
             name,
             ext,
             path,
-            metadata,
             parent_dir,
             is_all_all,
             deref_links,
             recursive_size,
-            extended_attributes,
-            absolute_path,
+            filetype,
+            metadata: OnceLock::new(),
+            extended_attributes: OnceLock::new(),
+            absolute_path: OnceLock::new(),
         };
 
         if total_size {
             file.recursive_size = file.recursive_directory_size();
         }
 
-        Ok(file)
+        file
     }
 
     fn new_aa(
@@ -169,15 +178,11 @@ impl<'dir> File<'dir> {
         parent_dir: &'dir Dir,
         name: &'static str,
         total_size: bool,
-    ) -> io::Result<File<'dir>> {
+    ) -> File<'dir> {
         let ext = File::ext(&path);
 
-        debug!("Statting file {:?}", &path);
-        let metadata = std::fs::symlink_metadata(&path)?;
         let is_all_all = true;
         let parent_dir = Some(parent_dir);
-        let extended_attributes = OnceLock::new();
-        let absolute_path = OnceLock::new();
         let recursive_size = if total_size {
             RecursiveSize::Unknown
         } else {
@@ -188,31 +193,28 @@ impl<'dir> File<'dir> {
             name: name.into(),
             ext,
             path,
-            metadata,
             parent_dir,
             is_all_all,
             deref_links: false,
-            extended_attributes,
-            absolute_path,
             recursive_size,
+            metadata: OnceLock::new(),
+            absolute_path: OnceLock::new(),
+            extended_attributes: OnceLock::new(),
+            filetype: OnceLock::new(),
         };
 
         if total_size {
             file.recursive_size = file.recursive_directory_size();
         }
 
-        Ok(file)
+        file
     }
 
-    pub fn new_aa_current(parent_dir: &'dir Dir, total_size: bool) -> io::Result<File<'dir>> {
+    pub fn new_aa_current(parent_dir: &'dir Dir, total_size: bool) -> File<'dir> {
         File::new_aa(parent_dir.path.clone(), parent_dir, ".", total_size)
     }
 
-    pub fn new_aa_parent(
-        path: PathBuf,
-        parent_dir: &'dir Dir,
-        total_size: bool,
-    ) -> io::Result<File<'dir>> {
+    pub fn new_aa_parent(path: PathBuf, parent_dir: &'dir Dir, total_size: bool) -> File<'dir> {
         File::new_aa(path, parent_dir, "..", total_size)
     }
 
@@ -267,6 +269,21 @@ impl<'dir> File<'dir> {
         }
     }
 
+    fn filetype(&self) -> Option<&std::fs::FileType> {
+        self.filetype
+            .get_or_init(|| self.metadata().as_ref().ok().map(|md| md.file_type()))
+            .as_ref()
+    }
+
+    pub fn metadata(&self) -> Result<&std::fs::Metadata, &io::Error> {
+        self.metadata
+            .get_or_init(|| {
+                debug!("Statting file {:?}", &self.path);
+                std::fs::symlink_metadata(&self.path)
+            })
+            .as_ref()
+    }
+
     /// Get the extended attributes of a file path on demand.
     pub fn extended_attributes(&self) -> &Vec<Attribute> {
         self.extended_attributes
@@ -275,7 +292,7 @@ impl<'dir> File<'dir> {
 
     /// Whether this file is a directory on the filesystem.
     pub fn is_directory(&self) -> bool {
-        self.metadata.is_dir()
+        self.filetype().map_or(false, std::fs::FileType::is_dir)
     }
 
     /// Whether this file is a directory, or a symlink pointing to a directory.
@@ -308,7 +325,7 @@ impl<'dir> File<'dir> {
     /// Whether this file is a regular file on the filesystem — that is, not a
     /// directory, a link, or anything else treated specially.
     pub fn is_file(&self) -> bool {
-        self.metadata.is_file()
+        self.filetype().map_or(false, std::fs::FileType::is_file)
     }
 
     /// Whether this file is both a regular file *and* executable for the
@@ -317,36 +334,42 @@ impl<'dir> File<'dir> {
     #[cfg(unix)]
     pub fn is_executable_file(&self) -> bool {
         let bit = modes::USER_EXECUTE;
-        self.is_file() && (self.metadata.permissions().mode() & bit) == bit
+        if self.is_file() {
+            return false;
+        }
+        let Ok(md) = self.metadata() else {
+            return false;
+        };
+        (md.permissions().mode() & bit) == bit
     }
 
     /// Whether this file is a symlink on the filesystem.
     pub fn is_link(&self) -> bool {
-        self.metadata.file_type().is_symlink()
+        self.filetype().map_or(false, FileType::is_symlink)
     }
 
     /// Whether this file is a named pipe on the filesystem.
     #[cfg(unix)]
     pub fn is_pipe(&self) -> bool {
-        self.metadata.file_type().is_fifo()
+        self.filetype().map_or(false, FileTypeExt::is_fifo)
     }
 
     /// Whether this file is a char device on the filesystem.
     #[cfg(unix)]
     pub fn is_char_device(&self) -> bool {
-        self.metadata.file_type().is_char_device()
+        self.filetype().map_or(false, FileTypeExt::is_char_device)
     }
 
     /// Whether this file is a block device on the filesystem.
     #[cfg(unix)]
     pub fn is_block_device(&self) -> bool {
-        self.metadata.file_type().is_block_device()
+        self.filetype().map_or(false, FileTypeExt::is_block_device)
     }
 
     /// Whether this file is a socket on the filesystem.
     #[cfg(unix)]
     pub fn is_socket(&self) -> bool {
-        self.metadata.file_type().is_socket()
+        self.filetype().map_or(false, FileTypeExt::is_socket)
     }
 
     /// Determine the full path resolving all symbolic links on demand.
@@ -435,7 +458,8 @@ impl<'dir> File<'dir> {
                     parent_dir: None,
                     path,
                     ext,
-                    metadata,
+                    filetype: OnceLock::from(Some(metadata.file_type())),
+                    metadata: OnceLock::from(Ok(metadata)),
                     name,
                     is_all_all: false,
                     deref_links: self.deref_links,
@@ -482,7 +506,7 @@ impl<'dir> File<'dir> {
     /// more attentively.
     #[cfg(unix)]
     pub fn links(&self) -> f::Links {
-        let count = self.metadata.nlink();
+        let count = self.metadata().map_or(0, MetadataExt::nlink);
 
         f::Links {
             count,
@@ -493,7 +517,7 @@ impl<'dir> File<'dir> {
     /// This file’s inode.
     #[cfg(unix)]
     pub fn inode(&self) -> f::Inode {
-        f::Inode(self.metadata.ino())
+        f::Inode(self.metadata().map_or(0, MetadataExt::ino))
     }
 
     /// This actual size the file takes up on disk, in bytes.
@@ -512,7 +536,7 @@ impl<'dir> File<'dir> {
             // Note that metadata.blocks returns the number of blocks
             // for 512 byte blocks according to the POSIX standard
             // even though the physical block size may be different.
-            f::Blocksize::Some(self.metadata.blocks() * 512)
+            f::Blocksize::Some(self.metadata().map_or(0, |md| md.blocks() * 512))
         } else {
             // directory or symlinks
             f::Blocksize::None
@@ -529,7 +553,7 @@ impl<'dir> File<'dir> {
                 _ => None,
             };
         }
-        Some(f::User(self.metadata.uid()))
+        Some(f::User(self.metadata().map_or(0, MetadataExt::uid)))
     }
 
     /// The ID of the group that owns this file.
@@ -541,7 +565,7 @@ impl<'dir> File<'dir> {
                 _ => None,
             };
         }
-        Some(f::Group(self.metadata.gid()))
+        Some(f::Group(self.metadata().map_or(0, MetadataExt::gid)))
     }
 
     /// This file’s size, if it’s a regular file.
@@ -566,7 +590,7 @@ impl<'dir> File<'dir> {
             self.recursive_size
                 .map_or(f::Size::None, |bytes, _| f::Size::Some(bytes))
         } else if self.is_char_device() || self.is_block_device() {
-            let device_id = self.metadata.rdev();
+            let device_id = self.metadata().map_or(0, MetadataExt::rdev);
 
             // MacOS and Linux have different arguments and return types for the
             // functions major and minor.  On Linux the try_into().unwrap() and
@@ -580,7 +604,7 @@ impl<'dir> File<'dir> {
                 minor: unsafe { libc::minor(device_id.try_into().unwrap()) } as u32,
             })
         } else if self.is_file() {
-            f::Size::Some(self.metadata.len())
+            f::Size::Some(self.metadata().map_or(0, std::fs::Metadata::len))
         } else {
             // symlink
             f::Size::None
@@ -596,7 +620,7 @@ impl<'dir> File<'dir> {
         if self.is_directory() {
             f::Size::None
         } else {
-            f::Size::Some(self.metadata.len())
+            f::Size::Some(self.metadata().map_or(0, std::fs::Metadata::len))
         }
     }
 
@@ -606,17 +630,17 @@ impl<'dir> File<'dir> {
     #[cfg(unix)]
     fn recursive_directory_size(&self) -> RecursiveSize {
         if self.is_directory() {
-            let key = (self.metadata.dev(), self.metadata.ino());
+            let key = (
+                self.metadata().map_or(0, MetadataExt::dev),
+                self.metadata().map_or(0, MetadataExt::ino),
+            );
             if let Some(size) = DIRECTORY_SIZE_CACHE.lock().unwrap().get(&key) {
                 return RecursiveSize::Some(size.0, size.1);
             }
             Dir::read_dir(self.path.clone()).map_or(RecursiveSize::Unknown, |dir| {
                 let mut size = 0;
                 let mut blocks = 0;
-                for file in dir
-                    .files(super::DotFilter::Dotfiles, None, false, false, true)
-                    .flatten()
-                {
+                for file in dir.files(super::DotFilter::Dotfiles, None, false, false, true) {
                     match file.recursive_directory_size() {
                         RecursiveSize::Some(bytes, blks) => {
                             size += bytes;
@@ -624,8 +648,8 @@ impl<'dir> File<'dir> {
                         }
                         RecursiveSize::Unknown => {}
                         RecursiveSize::None => {
-                            size += file.metadata.size();
-                            blocks += file.metadata.blocks();
+                            size += file.metadata().map_or(0, MetadataExt::size);
+                            blocks += file.metadata().map_or(0, MetadataExt::blocks);
                         }
                     }
                 }
@@ -653,7 +677,8 @@ impl<'dir> File<'dir> {
     /// of a directory when `total_size` is used.
     #[inline]
     pub fn length(&self) -> u64 {
-        self.recursive_size.unwrap_bytes_or(self.metadata.len())
+        self.recursive_size
+            .unwrap_bytes_or(self.metadata().map_or(0, std::fs::Metadata::len))
     }
 
     /// Is the file is using recursive size calculation
@@ -674,7 +699,7 @@ impl<'dir> File<'dir> {
     #[cfg(unix)]
     pub fn is_empty_dir(&self) -> bool {
         if self.is_directory() {
-            if self.metadata.nlink() > 2 {
+            if self.metadata().map_or(0, MetadataExt::nlink) > 2 {
                 // Directories will have a link count of two if they do not have any subdirectories.
                 // The '.' entry is a link to itself and the '..' is a link to the parent directory.
                 // A subdirectory will have a link to its parent directory increasing the link count
@@ -745,9 +770,9 @@ impl<'dir> File<'dir> {
                 _ => None,
             };
         }
-        self.metadata
-            .modified()
+        self.metadata()
             .ok()
+            .and_then(|md| md.modified().ok())
             .and_then(Self::systemtime_to_naivedatetime)
     }
 
@@ -760,7 +785,11 @@ impl<'dir> File<'dir> {
                 _ => None,
             };
         }
-        NaiveDateTime::from_timestamp_opt(self.metadata.ctime(), self.metadata.ctime_nsec() as u32)
+        let md = self.metadata();
+        NaiveDateTime::from_timestamp_opt(
+            md.map_or(0, MetadataExt::ctime),
+            md.map_or(0, |md| md.ctime_nsec() as u32),
+        )
     }
 
     #[cfg(windows)]
@@ -776,9 +805,9 @@ impl<'dir> File<'dir> {
                 _ => None,
             };
         }
-        self.metadata
-            .accessed()
+        self.metadata()
             .ok()
+            .and_then(|md| md.accessed().ok())
             .and_then(Self::systemtime_to_naivedatetime)
     }
 
@@ -790,10 +819,8 @@ impl<'dir> File<'dir> {
                 _ => None,
             };
         }
-        self.metadata
-            .created()
-            .ok()
-            .and_then(Self::systemtime_to_naivedatetime)
+        let btime = self.metadata().ok()?.created().ok()?;
+        Self::systemtime_to_naivedatetime(btime)
     }
 
     /// This file’s ‘type’.
@@ -845,7 +872,7 @@ impl<'dir> File<'dir> {
                 _ => None,
             };
         }
-        let bits = self.metadata.mode();
+        let bits = self.metadata().map_or(0, MetadataExt::mode);
         let has_bit = |bit| bits & bit == bit;
 
         Some(f::Permissions {
@@ -868,19 +895,19 @@ impl<'dir> File<'dir> {
     }
 
     #[cfg(windows)]
-    pub fn attributes(&self) -> f::Attributes {
-        let bits = self.metadata.file_attributes();
+    pub fn attributes(&self) -> Option<f::Attributes> {
+        let bits = self.metadata().ok()?.file_attributes();
         let has_bit = |bit| bits & bit == bit;
 
         // https://docs.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants
-        f::Attributes {
+        Some(f::Attributes {
             directory: has_bit(0x10),
             archive: has_bit(0x20),
             readonly: has_bit(0x1),
             hidden: has_bit(0x2),
             system: has_bit(0x4),
             reparse_point: has_bit(0x400),
-        }
+        })
     }
 
     /// This file’s security context field.
@@ -930,12 +957,16 @@ impl<'dir> File<'dir> {
         use std::os::netbsd::fs::MetadataExt;
         #[cfg(target_os = "openbsd")]
         use std::os::openbsd::fs::MetadataExt;
-        f::Flags(self.metadata.st_flags())
+        f::Flags(
+            self.metadata()
+                .map(MetadataExt::st_flags)
+                .unwrap_or_default(),
+        )
     }
 
     #[cfg(windows)]
     pub fn flags(&self) -> f::Flags {
-        f::Flags(self.metadata.file_attributes())
+        f::Flags(self.metadata().map_or(0, |md| md.file_attributes()))
     }
 
     #[cfg(not(any(

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -274,7 +274,10 @@ impl SortField {
             Self::Size          => a.length().cmp(&b.length()),
 
             #[cfg(unix)]
-            Self::FileInode     => a.metadata.ino().cmp(&b.metadata.ino()),
+            Self::FileInode     => {
+                a.metadata().map_or(0, MetadataExt::ino)
+                    .cmp(&b.metadata().map_or(0, MetadataExt::ino))
+            }
             Self::ModifiedDate  => a.modified_time().cmp(&b.modified_time()),
             Self::AccessedDate  => a.accessed_time().cmp(&b.accessed_time()),
             Self::ChangedDate   => a.changed_time().cmp(&b.changed_time()),

--- a/src/output/color_scale.rs
+++ b/src/output/color_scale.rs
@@ -170,7 +170,6 @@ fn update_information_recursively(
                 Ok(dir) => {
                     let files: Vec<File<'_>> = dir
                         .files(dot_filter, git, git_ignoring, false, false)
-                        .flatten()
                         .collect();
 
                     update_information_recursively(

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -330,7 +330,7 @@ impl<'a> Render<'a> {
 
         for (tree_params, egg) in depth.iterate_over(file_eggs.into_iter()) {
             let mut files = Vec::new();
-            let mut errors = egg.errors;
+            let errors = egg.errors;
 
             if let (Some(ref mut t), Some(row)) = (table.as_mut(), egg.table_row.as_ref()) {
                 t.add_widths(row);
@@ -362,14 +362,7 @@ impl<'a> Render<'a> {
                     egg.file.deref_links,
                     egg.file.is_recursive_size(),
                 ) {
-                    match file_to_add {
-                        Ok(f) => {
-                            files.push(f);
-                        }
-                        Err((path, e)) => {
-                            errors.push((e, Some(path)));
-                        }
-                    }
+                    files.push(file_to_add);
                 }
 
                 self.filter

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -497,7 +497,7 @@ impl<'a> Table<'a> {
         Some(f::PermissionsPlus {
             file_type: file.type_char(),
             #[cfg(windows)]
-            attributes: file.attributes(),
+            attributes: file.attributes()?,
             xattrs,
         })
     }


### PR DESCRIPTION
This is a draft because I made this PR more to spark some conversation than to actually change the code. It could still be merged if I clean it up but (spoiler alert) the improvement is very small for now. So here goes.

> **Note**: I also have to double check the `deref_links` logic. I'm pretty sure I got that wrong, but it wasn't my focus for now. And the error handling is sloppy too.

`eza` is super fancy, but sometimes quite slow. As seen in some issues and discussions:

- https://github.com/eza-community/eza/issues/830
- https://github.com/orgs/eza-community/discussions/816 (this PR is based on some ideas I posted there)

(and probably some more, I've only started tracking this recently)

**This is not necessarily a problem**: as I understand it, `eza` is meant for fancy output first and fast output second. It fulfills the promise of being fancy very well and that fanciness sets it apart from e.g. GNU (and uutils) `ls`. Still, the fact that complains are coming in shows that people would like `eza` to be faster.

Now, I've done a bunch of work on uutils `ls`, including performance work, so I figured I'd share some of my experience. In my experience, it's quite hard to get `ls`-like programs to a low number of syscalls. If you want to try this for yourself, compare these commands (on Linux):

```bash
strace -c eza
strace -c ls
```

Here's the top of both, first `eza`:
```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 30,10    0,000584           9        59        59 readlink
 25,57    0,000496           8        60           statx
 25,46    0,000494           8        59           getcwd
  8,45    0,000164          16        10           read
```
and then GNU `ls`:
```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
  0,00    0,000000           0         2           read
  0,00    0,000000           0         8           write
  0,00    0,000000           0         7           close
  0,00    0,000000           0        13           mmap
```
You can see that `eza` spends a lot of time on syscalls that's probably not necessary!

So, I set out to see if I could reduce that with a similar technique as we used in uutils `ls`: retrieving metadata and filetype only when necessary. In code, it's similar to how the extended attributes and canonicalized name are computed with a `OnceLock`. Now there are two options:
- we create a file from a filename, in which case we have to get the metadata always, or
- we create a file from a `DirEntry`, which already contains a `FileType`, so if we have that, we can often skip getting the metadata.

So I implemented that and the number of statx calls from running `eza` on its own repository went from 33 to... 23. Not quite what I had hoped. Turns out that's because on every regular file, `eza` wants to know whether the file is executable, which requires the full metadata. Removing that check drops the statx calls to 0, which I think would lead to a measurable speedup, but I've left that out of this PR, because that would change `eza`'s behaviour.

This all raises some interesting questions (which are probably worth spinning off into an issue):
- What are all the `readlink`/`getcwd` calls for? They take up a _lot_ of time and are probably unnecessary.
- Can we redesign the theme code such that we can avoid checks that have no influence on the style. For example, only check that a file is executable if a custom style is set for executable files. This would speed up `eza` even more with `--color=never`.
- Should there be a setting which avoids doing expensive coloring beyond the simple filetype? With the previous point this could be implemented quite easily with a theme that only does the cheap checks.

Hope this all makes sense :)