### PR TITLE
Do not pre-compute MountInfo to reduce readlink calls

### DIFF
--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use ansiterm::{ANSIString, Style};
 use unicode_width::UnicodeWidthStr;
 
-use crate::fs::mounts::MountedFs;
 use crate::fs::{File, FileTarget};
 use crate::output::cell::TextCellContents;
 use crate::output::escape;
@@ -49,7 +48,6 @@ impl Options {
                 None
             },
             mount_style: MountStyle::JustDirectoryNames,
-            mounted_fs: file.mount_point_info(),
         }
     }
 }
@@ -143,9 +141,6 @@ pub struct FileName<'a, 'dir, C> {
     link_style: LinkStyle,
 
     pub options: Options,
-
-    /// The filesystem details for a mounted filesystem.
-    mounted_fs: Option<&'a MountedFs>,
 
     /// How to handle displaying a mounted filesystem.
     mount_style: MountStyle,
@@ -244,7 +239,6 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
                             target: None,
                             link_style: LinkStyle::FullLinkPaths,
                             options: target_options,
-                            mounted_fs: None,
                             mount_style: MountStyle::JustDirectoryNames,
                         };
 
@@ -284,15 +278,15 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
             }
         }
 
-        if let (MountStyle::MountInfo, Some(mount_details)) =
-            (self.mount_style, self.mounted_fs.as_ref())
-        {
-            // This is a filesystem mounted on the directory, output its details
-            bits.push(Style::default().paint(" ["));
-            bits.push(Style::default().paint(mount_details.source.clone()));
-            bits.push(Style::default().paint(" ("));
-            bits.push(Style::default().paint(mount_details.fstype.clone()));
-            bits.push(Style::default().paint(")]"));
+        if self.mount_style == MountStyle::MountInfo {
+            if let Some(mount_details) = self.file.mount_point_info() {
+                // This is a filesystem mounted on the directory, output its details
+                bits.push(Style::default().paint(" ["));
+                bits.push(Style::default().paint(mount_details.source.clone()));
+                bits.push(Style::default().paint(" ("));
+                bits.push(Style::default().paint(mount_details.fstype.clone()));
+                bits.push(Style::default().paint(")]"));
+            }
         }
 
         bits.into()


### PR DESCRIPTION
More speedups! In my [previous PR](https://github.com/eza-community/eza/pull/833) I mentioned being baffled by the `readlink` and `getcwd` and I figured out where they came from: `File::mount_point_info`, which calls `std::fs::canonicalize`. The easy fix was to not call that when it's not necessary, which turns out to be most of the time!

Here's a benchmark:
```
❯ hyperfine -L eza eza-old,eza-new "./{eza} -R"
Benchmark 1: ./eza-old -R
  Time (mean ± σ):     744.0 ms ±   9.3 ms    [User: 275.2 ms, System: 465.3 ms]
  Range (min … max):   734.2 ms … 766.0 ms    10 runs
 
Benchmark 2: ./eza-new -R
  Time (mean ± σ):     313.3 ms ±   3.0 ms    [User: 142.2 ms, System: 169.4 ms]
  Range (min … max):   309.7 ms … 318.8 ms    10 runs
 
Summary
  ./eza-new -R ran
    2.37 ± 0.04 times faster than ./eza-old -R
```