### PR TITLE
refactor: use `#[default]` attribute instead of custom impl for enums

### DIFF
--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -203,7 +203,7 @@ impl<'dir, 'ig> Iterator for Files<'dir, 'ig> {
 /// Usually files in Unix use a leading dot to be hidden or visible, but two
 /// entries in particular are “extra-hidden”: `.` and `..`, which only become
 /// visible after an extra `-a` option.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
 pub enum DotFilter {
     /// Shows files, dotfiles, and `.` and `..`.
     DotfilesAndDots,
@@ -212,13 +212,8 @@ pub enum DotFilter {
     Dotfiles,
 
     /// Just show files, hiding anything beginning with a dot.
+    #[default]
     JustFiles,
-}
-
-impl Default for DotFilter {
-    fn default() -> Self {
-        Self::JustFiles
-    }
 }
 
 impl DotFilter {

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -69,9 +69,10 @@ enum LinkStyle {
 }
 
 /// Whether to append file class characters to the file names.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
 pub enum Classify {
     /// Just display the file names, without any characters.
+    #[default]
     JustFilenames,
 
     /// Always add a character after the file name depending on what class of
@@ -80,12 +81,6 @@ pub enum Classify {
 
     // Like previous, but only when output is going to a terminal, not otherwise.
     AutomaticAddFileIndicators,
-}
-
-impl Default for Classify {
-    fn default() -> Self {
-        Self::JustFilenames
-    }
 }
 
 /// When displaying a directory name, there needs to be some way to handle

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -230,10 +230,11 @@ impl Column {
 
 /// Formatting options for file sizes.
 #[allow(clippy::enum_variant_names)]
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
 pub enum SizeFormat {
     /// Format the file size using **decimal** prefixes, such as “kilo”,
     /// “mega”, or “giga”.
+    #[default]
     DecimalBytes,
 
     /// Format the file size using **binary** prefixes, such as “kibi”,
@@ -260,12 +261,6 @@ pub enum GroupFormat {
     Regular,
     /// Show ":" if user-group value is the same
     Smart,
-}
-
-impl Default for SizeFormat {
-    fn default() -> Self {
-        Self::DecimalBytes
-    }
 }
 
 /// The types of a file’s time fields. These three fields are standard
@@ -308,18 +303,13 @@ impl TimeType {
 }
 
 /// How display file flags.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
 pub enum FlagsFormat {
     /// Display flags as comma seperated descriptions
+    #[default]
     Long,
     /// Display flags as single character abbreviations (Windows only)
     Short,
-}
-
-impl Default for FlagsFormat {
-    fn default() -> Self {
-        Self::Long
-    }
 }
 
 impl FlagsFormat {


### PR DESCRIPTION
Just a small refactor, should have no effect except for saving a few lines of code.