### PR TITLE
fix: classification width should be taken into account with -F=auto

### DIFF
--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -48,15 +48,17 @@ impl<'a> Render<'a> {
             let filename = self.file_style.for_file(file, self.theme);
 
             // Calculate classification width
-            let classification_width =
-                if let Classify::AddFileIndicators = filename.options.classify {
-                    match filename.classify_char(file) {
-                        Some(s) => s.len(),
-                        None => 0,
-                    }
-                } else {
-                    0
-                };
+            let classification_width = if matches!(
+                filename.options.classify,
+                Classify::AddFileIndicators | Classify::AutomaticAddFileIndicators
+            ) {
+                match filename.classify_char(file) {
+                    Some(s) => s.len(),
+                    None => 0,
+                }
+            } else {
+                0
+            };
             let space_filename_offset = match self.file_style.quote_style {
                 QuoteStyle::QuoteSpaces if file.name.contains(' ') => 2,
                 QuoteStyle::NoQuotes => 0,


### PR DESCRIPTION
Fixes https://github.com/eza-community/eza/issues/845

I'm hoping that the next version of `uutils-term-grid` will make these manual calculations unnecessary. That should keep future bugs like this to a minimum.