### PR TITLE
fix: Improved width calculation for alignment

### DIFF
--- a/src/output/cell.rs
+++ b/src/output/cell.rs
@@ -158,7 +158,13 @@ impl TextCellContents {
     pub fn width(&self) -> DisplayWidth {
         self.0
             .iter()
-            .map(|anstr| DisplayWidth::from(&**anstr))
+            .map(|anstr| {
+                if anstr.contains('\u{1b}') {
+                    DisplayWidth::from(0)
+                } else {
+                    DisplayWidth::from(&**anstr)
+                }
+            })
             .sum()
     }
 

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -4,11 +4,8 @@ use term_grid as tg;
 
 use crate::fs::filter::FileFilter;
 use crate::fs::File;
-use crate::output::file_name::{Classify, Options as FileStyle};
-use crate::output::file_name::{EmbedHyperlinks, ShowIcons};
+use crate::output::file_name::Options as FileStyle;
 use crate::theme::Theme;
-
-use super::file_name::QuoteStyle;
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub struct Options {
@@ -46,60 +43,11 @@ impl<'a> Render<'a> {
         self.filter.sort_files(&mut self.files);
         for file in &self.files {
             let filename = self.file_style.for_file(file, self.theme);
-
-            // Calculate classification width
-            let classification_width = if matches!(
-                filename.options.classify,
-                Classify::AddFileIndicators | Classify::AutomaticAddFileIndicators
-            ) {
-                match filename.classify_char(file) {
-                    Some(s) => s.len(),
-                    None => 0,
-                }
-            } else {
-                0
-            };
-            let space_filename_offset = match self.file_style.quote_style {
-                QuoteStyle::QuoteSpaces if file.name.contains(' ') => 2,
-                QuoteStyle::NoQuotes => 0,
-                QuoteStyle::QuoteSpaces => 0, // Default case
-            };
             let contents = filename.paint();
-            let width = match (
-                filename.options.embed_hyperlinks,
-                filename.options.show_icons,
-            ) {
-                (
-                    EmbedHyperlinks::On,
-                    ShowIcons::Always(spacing) | ShowIcons::Automatic(spacing),
-                ) => {
-                    filename.bare_utf8_width()
-                        + classification_width
-                        + 1
-                        + (spacing as usize)
-                        + space_filename_offset
-                }
-                (EmbedHyperlinks::On, ShowIcons::Never) => {
-                    filename.bare_utf8_width() + classification_width + space_filename_offset
-                }
-                (
-                    EmbedHyperlinks::Off,
-                    ShowIcons::Always(spacing) | ShowIcons::Automatic(spacing),
-                ) => {
-                    filename.bare_utf8_width()
-                        + classification_width
-                        + 1
-                        + (spacing as usize)
-                        + space_filename_offset
-                }
-                (EmbedHyperlinks::Off, _) => *contents.width(),
-            };
 
             grid.add(tg::Cell {
                 contents: contents.strings().to_string(),
-                // with hyperlink escape sequences,
-                // the actual *contents.width() is larger than actually needed, so we take only the filename
-                width,
+                width: *contents.width(),
             });
         }
 


### PR DESCRIPTION
Currently, if either hyperlinks or icons are used, grid.rs attempts to use the width of the filename to get the width instead of contents.width(). This causes issues when characters are displayed differently than they appear in the file's name, like newline. This was done because contents.width() currently can't handle ANSI escapes. This commit removes the code in grid.rs which attempts to recalculate the width and instead attempts to make the width function work with ANSI escapes. This was done by not tallying each ANSIString which contains the escape character. This only works as long as none of the files have ANSI escapes in their names and that the paint function keeps escape sequences isolated in their own ANSIString. To account for these situations, a proper function or library to remove ANSI escapes may be needed.

Fixes: #827 