### PR TITLE
Port grid and grid-details to new uutils-term-grid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "ansi-width"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219e3ce6f2611d83b51ec2098a12702112c29e57203a6b0a0929b2cddb486608"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "ansi_colours"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +388,7 @@ dependencies = [
 name = "eza"
 version = "0.18.5"
 dependencies = [
+ "ansi-width",
  "ansiterm",
  "chrono",
  "criterion",
@@ -1321,11 +1331,11 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uutils_term_grid"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b389452a568698688dda38802068378a16c15c4af9b153cdd99b65391292bbc7"
+checksum = "f89defb4adb4ba5703a57abc879f96ddd6263a444cacc446db90bf2617f141fb"
 dependencies = [
- "unicode-width",
+ "ansi-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ name = "eza"
 
 
 [dependencies]
+ansi-width = "0.1.0"
 ansiterm = { version = "0.12.2", features = ["ansi_colours"] }
 chrono = { version = "0.4.34", default-features = false, features = ["clock"] }
 glob = "0.3"
@@ -85,7 +86,7 @@ once_cell = "1.19.0"
 percent-encoding = "2.3.1"
 phf = { version = "0.11.2", features = ["macros"] }
 plist = { version = "1.6.0", default-features = false }
-uutils_term_grid = "0.3"
+uutils_term_grid = "0.6.0"
 terminal_size = "0.3.0"
 timeago = { version = "0.4.2", default-features = false }
 unicode-width = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,7 +449,6 @@ impl<'args> Exa<'args> {
             }
 
             (Mode::GridDetails(ref opts), Some(console_width)) => {
-                let grid = &opts.grid;
                 let details = &opts.details;
                 let row_threshold = opts.row_threshold;
 
@@ -463,7 +462,6 @@ impl<'args> Exa<'args> {
                     files,
                     theme,
                     file_style,
-                    grid,
                     details,
                     filter,
                     row_threshold,

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -64,10 +64,8 @@ impl Mode {
 
             if flag.is_some() && flag.unwrap().matches(&flags::GRID) {
                 let _ = matches.has(&flags::GRID)?;
-                let grid = grid::Options::deduce(matches)?;
                 let row_threshold = RowThreshold::deduce(vars)?;
                 let grid_details = grid_details::Options {
-                    grid,
                     details,
                     row_threshold,
                 };

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -427,14 +427,6 @@ impl<'a> Render<'a> {
         }
     }
 
-    pub fn render_file(&self, cells: TableRow, name: TextCell, tree: TreeParams) -> Row {
-        Row {
-            cells: Some(cells),
-            name,
-            tree,
-        }
-    }
-
     pub fn iterate_with_table(&'a self, table: Table<'a>, rows: Vec<Row>) -> TableIter<'a> {
         TableIter {
             tree_trunk: TreeTrunk::default(),

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -1,14 +1,11 @@
 use std::io::{self, Write};
 
-use term_grid as tg;
+use term_grid::{Direction, Filling, Grid, GridOptions};
 
 use crate::fs::filter::FileFilter;
 use crate::fs::File;
-use crate::output::file_name::{Classify, Options as FileStyle};
-use crate::output::file_name::{EmbedHyperlinks, ShowIcons};
+use crate::output::file_name::Options as FileStyle;
 use crate::theme::Theme;
-
-use super::file_name::QuoteStyle;
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub struct Options {
@@ -16,11 +13,11 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn direction(self) -> tg::Direction {
+    pub fn direction(self) -> Direction {
         if self.across {
-            tg::Direction::LeftToRight
+            Direction::LeftToRight
         } else {
-            tg::Direction::TopToBottom
+            Direction::TopToBottom
         }
     }
 }
@@ -36,85 +33,29 @@ pub struct Render<'a> {
 
 impl<'a> Render<'a> {
     pub fn render<W: Write>(mut self, w: &mut W) -> io::Result<()> {
-        let mut grid = tg::Grid::new(tg::GridOptions {
-            direction: self.opts.direction(),
-            filling: tg::Filling::Spaces(2),
-        });
-
-        grid.reserve(self.files.len());
-
         self.filter.sort_files(&mut self.files);
-        for file in &self.files {
-            let filename = self.file_style.for_file(file, self.theme);
 
-            // Calculate classification width
-            let classification_width = if matches!(
-                filename.options.classify,
-                Classify::AddFileIndicators | Classify::AutomaticAddFileIndicators
-            ) {
-                match filename.classify_char(file) {
-                    Some(s) => s.len(),
-                    None => 0,
-                }
-            } else {
-                0
-            };
-            let space_filename_offset = match self.file_style.quote_style {
-                QuoteStyle::QuoteSpaces if file.name.contains(' ') => 2,
-                QuoteStyle::NoQuotes => 0,
-                QuoteStyle::QuoteSpaces => 0, // Default case
-            };
-            let contents = filename.paint();
-            let width = match (
-                filename.options.embed_hyperlinks,
-                filename.options.show_icons,
-            ) {
-                (
-                    EmbedHyperlinks::On,
-                    ShowIcons::Always(spacing) | ShowIcons::Automatic(spacing),
-                ) => {
-                    filename.bare_utf8_width()
-                        + classification_width
-                        + 1
-                        + (spacing as usize)
-                        + space_filename_offset
-                }
-                (EmbedHyperlinks::On, ShowIcons::Never) => {
-                    filename.bare_utf8_width() + classification_width + space_filename_offset
-                }
-                (
-                    EmbedHyperlinks::Off,
-                    ShowIcons::Always(spacing) | ShowIcons::Automatic(spacing),
-                ) => {
-                    filename.bare_utf8_width()
-                        + classification_width
-                        + 1
-                        + (spacing as usize)
-                        + space_filename_offset
-                }
-                (EmbedHyperlinks::Off, _) => *contents.width(),
-            };
+        let cells = self
+            .files
+            .iter()
+            .map(|file| {
+                self.file_style
+                    .for_file(file, self.theme)
+                    .paint()
+                    .strings()
+                    .to_string()
+            })
+            .collect();
 
-            grid.add(tg::Cell {
-                contents: contents.strings().to_string(),
-                // with hyperlink escape sequences,
-                // the actual *contents.width() is larger than actually needed, so we take only the filename
-                width,
-            });
-        }
+        let grid = Grid::new(
+            cells,
+            GridOptions {
+                filling: Filling::Spaces(2),
+                direction: self.opts.direction(),
+                width: self.console_width,
+            },
+        );
 
-        if let Some(display) = grid.fit_into_width(self.console_width) {
-            write!(w, "{display}")
-        } else {
-            // File names too long for a grid - drop down to just listing them!
-            // This isn’t *quite* the same as the lines view, which also
-            // displays full link paths.
-            for file in &self.files {
-                let name_cell = self.file_style.for_file(file, self.theme).paint();
-                writeln!(w, "{}", name_cell.strings())?;
-            }
-
-            Ok(())
-        }
+        write!(w, "{grid}")
     }
 }

--- a/tests/gen/long_time_style_custom_non_recent_empty_nix.stderr
+++ b/tests/gen/long_time_style_custom_non_recent_empty_nix.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'Custom timestamp format is empty, please supply a chrono format string after the plus sign.', src/options/view.rs:349:21
+thread 'main' panicked at 'Custom timestamp format is empty, please supply a chrono format string after the plus sign.', src/options/view.rs:347:21
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/gen/long_time_style_custom_non_recent_none_nix.stderr
+++ b/tests/gen/long_time_style_custom_non_recent_none_nix.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'Custom timestamp format is empty, please supply a chrono format string after the plus sign.', src/options/view.rs:347:47
+thread 'main' panicked at 'Custom timestamp format is empty, please supply a chrono format string after the plus sign.', src/options/view.rs:345:47
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/gen/long_time_style_custom_recent_empty_nix.stderr
+++ b/tests/gen/long_time_style_custom_recent_empty_nix.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'Custom timestamp format for recent files is empty, please supply a chrono format string at the second line.', src/options/view.rs:363:25
+thread 'main' panicked at 'Custom timestamp format for recent files is empty, please supply a chrono format string at the second line.', src/options/view.rs:361:25
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
This will require a small addition to uutils-term-grid: https://github.com/uutils/uutils-term-grid/pull/37, hence it's still a draft. It also needs a bit more cleanup. I think that with the `ansi-width` crate, which I both added as a direct dependency and as a transitive dependency, most of the `TextCell` code could be removed, but I'll take it bit by bit and start with the grid layouts only.

Here's a summary:
- All of the width calculations are gone, because `ansi-width` can just compute the right width.
- The grid-details layout had to be rewritten because I remove `fit_to_columns` from `uutils-term-grid`, because I didn't think that it fit the purpose of the library. Luckily, the new implementation is much shorter and, I think, much clearer. It just renders a table and throws the rows in a grid. The most complicated part is that I had to implement the header myself.
- There's a couple of seemingly unrelated deleted functions that are now no longer used.