### PR TITLE
feat: adding icons for graphql extensions

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -38,6 +38,7 @@ impl Icons {
     const GIST_SECRET: char     = '\u{eafa}';  // 
     const GIT: char             = '\u{f1d3}';  // 
     const GRADLE: char          = '\u{e660}';  // 
+    const GRAPHQL: char         = '\u{e662}';  // 
     const GRUNT: char           = '\u{e611}';  // 
     const GULP: char            = '\u{e610}';  // 
     const HTML5: char           = '\u{f13b}';  // 
@@ -453,7 +454,9 @@ const EXTENSION_ICONS: Map<&'static str, char> = phf_map! {
     "git"            => Icons::GIT,              // 
     "go"             => Icons::LANG_GO,          // 
     "gpg"            => Icons::SHIELD_LOCK,      // 󰦝
+    "gql"            => Icons::GRAPHQL,          // 
     "gradle"         => Icons::GRADLE,           // 
+    "graphql"        => Icons::GRAPHQL,          // 
     "groovy"         => Icons::LANG_GROOVY,      // 
     "gsheet"         => Icons::SHEET,            // 
     "gslides"        => Icons::SLIDE,            // 


### PR DESCRIPTION
This PR adds icons for both `.gql` and `.graphql` extensions.

<!---  -->
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
##### Description
I followed the alphabetical order of the icons. And just added two more icons to the list, you can check them in the screenshot below:

![Graphql Icons](https://github.com/eza-community/eza/assets/43209783/6617996b-779a-428a-8220-dc351a32228d)

This closes #552 

##### How Has This Been Tested?
I tested locally against a directory of graphql files. I ran the local tests with cargo and everything was ok.
