### PR TITLE
build: add FreeBSD / NetBSD / OpenBSD to CI.

### DIFF
--- a/.github/workflows/unit-tests-bsd.yml
+++ b/.github/workflows/unit-tests-bsd.yml
@@ -1,4 +1,4 @@
-name: Unit tests BSD
+name: Unit tests (BSD)
 
 on:
   push:
@@ -72,3 +72,27 @@ jobs:
             cargo fmt --check
             cargo clippy -- -D warnings
             cargo hack test
+
+  unit-tests-openbsd:
+      runs-on: ubuntu-22.04
+      timeout-minutes: 20
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            submodules: recursive
+        - name: Compile
+          uses: vmactions/openbsd-vm@v1
+          with:
+            release: '7.4'
+            usesh: true
+            prepare: |
+              pkg_add rust rust-rustfmt rust-clippy git
+              cargo install cargo-hack
+              git config --global --add safe.directory /home/runner/work/eza/eza
+            run: |
+              set -e
+              export CARGO_TERM_COLOR="always"
+              export RUSTFLAGS="--deny warnings"
+              cargo fmt --check
+              cargo clippy -- -D warnings
+              cargo hack test

--- a/.github/workflows/unit-tests-bsd.yml
+++ b/.github/workflows/unit-tests-bsd.yml
@@ -21,6 +21,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  unit-tests-freebsd:
+      runs-on: ubuntu-22.04
+      timeout-minutes: 20
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            submodules: recursive
+        - name: Compile
+          uses: vmactions/freebsd-vm@v1
+          with:
+            release: '14.0'
+            usesh: true
+            prepare: |
+              pkg install -y rust git
+              cargo install cargo-hack
+              git config --global --add safe.directory /home/runner/work/eza/eza
+            run: |
+              set -e
+              export CARGO_TERM_COLOR="always"
+              export RUSTFLAGS="--deny warnings"
+              cargo fmt --check
+              cargo clippy -- -D warnings
+              cargo hack test
+
   unit-tests-netbsd:
     runs-on: ubuntu-22.04
     timeout-minutes: 20

--- a/.github/workflows/unit-tests-bsd.yml
+++ b/.github/workflows/unit-tests-bsd.yml
@@ -1,0 +1,50 @@
+name: Unit tests BSD
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/unit-tests-bsd.yml'
+      - 'src/**'
+      - 'Cargo.*'
+      - build.rs
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/unit-tests-bsd.yml'
+      - 'src/**'
+      - 'Cargo.*'
+      - build.rs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests-netbsd:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Compile
+        uses: vmactions/netbsd-vm@v1
+        with:
+          release: '9.3'
+          usesh: true
+          prepare: |
+            PATH="/root/.cargo/bin:/usr/pkg/sbin:/usr/pkg/bin:$PATH"
+            PKG_PATH="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/9.3/All/"
+            export PATH PKG_PATH
+            /usr/sbin/pkg_add pkgin
+            pkgin -y install rust git
+            cargo install cargo-hack
+            git config --global --add safe.directory /home/runner/work/eza/eza
+          run: |
+            set -e
+            export CARGO_TERM_COLOR="always"
+            export RUSTFLAGS="--deny warnings"
+            cargo fmt --check
+            cargo clippy -- -D warnings
+            cargo hack test

--- a/src/fs/feature/xattr.rs
+++ b/src/fs/feature/xattr.rs
@@ -112,7 +112,7 @@ mod extended_attrs {
         }
     }
 
-    #[cfg(any(target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     mod os {
         use libc::{c_char, c_void, size_t, ssize_t};
 
@@ -283,7 +283,7 @@ mod extended_attrs {
             let start = index + 1;
             let end = start + item_length;
             if end <= length {
-                result.push(OsStr::from_bytes(&buffer[start..end]).to_owned())
+                result.push(OsStr::from_bytes(&buffer[start..end]).to_owned());
             }
             index = end;
         }
@@ -473,7 +473,7 @@ mod extended_attrs {
             if let Some(name) = attr_name.to_str() {
                 let attr_name =
                     CString::new(name).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-                let value = get_attribute(&path, &attr_name, follow_symlinks, getter)?;
+                let value = get_attribute(path, &attr_name, follow_symlinks, getter)?;
                 attrs.push(Attribute {
                     name: format!("{namespace}::{name}"),
                     value,


### PR DESCRIPTION
Add support for building in FreeBSD / NetBSD / OpenBSD via [vmactions](https://github.com/vmactions) in the CI.

While here also address the following warnings in the CI

```
   error: unneeded sub `cfg` when there is only one condition
     --> src/fs/feature/xattr.rs:115:11
      |
  115 |     #[cfg(any(target_os = "linux"))]
      |           ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `target_os = "linux"`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#non_minimal_cfg
      = note: `-D clippy::non-minimal-cfg` implied by `-D warnings`
  
  error: this expression creates a reference which is immediately dereferenced by the compiler
     --> src/fs/feature/xattr.rs:476:43
      |
  476 |                 let value = get_attribute(&path, &attr_name, follow_symlinks, getter)?;
      |                                           ^^^^^ help: change this to: `path`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
      = note: `-D clippy::needless-borrow` implied by `-D warnings`
```