### PR TITLE
fix: removes trailing `/*` from --ignore-glob

### DIFF
--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -94,6 +94,17 @@ impl FileFilter {
         }
     }
 
+    /// checks if a dirname, when appended with a `/` matches any
+    /// of the ignore patterns provided as argument.
+    ///
+    /// this only exists since when creating the patterns, any glob
+    /// that ends with `/` or `/*` will keep the `/` on the pattern,
+    /// and when listing directories, we display them without any `/`
+    pub fn should_skip_expansion(&self, dirname: &str) -> bool {
+        let dirname_with_slash = format!("{dirname}/");
+        self.ignore_patterns.is_ignored(&dirname_with_slash)
+    }
+
     /// Remove every file in the given vector that does *not* pass the
     /// filter predicate for file names specified on the command-line.
     ///

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -286,7 +286,11 @@ impl<'a> Render<'a> {
 
                 let mut dir = None;
                 if let Some(r) = self.recurse {
-                    if file.is_directory() && r.tree && !r.is_too_deep(depth.0) {
+                    if file.is_directory()
+                        && r.tree
+                        && !r.is_too_deep(depth.0)
+                        && !self.filter.should_skip_expansion(&file.name)
+                    {
                         trace!("matching on to_dir");
                         match file.to_dir() {
                             Ok(d) => {


### PR DESCRIPTION
This PR removes trailing `/` or `/*` and should fix #865. 

Where globs ending with those patterns would not match any directory, as the default listing doesn't include an ending `/`.

As mentioned [here](https://github.com/eza-community/eza/issues/865#issuecomment-1973675841), the pattern generated by a glob that ends either in `/` or `/*`, such as `node_modules/*` or `node_modules/*` would not match as the default listing of directories don't include those characters.

##### Description
I added a [line at](https://github.com/eza-community/eza/blob/main/src/fs/filter.rs#L325) that goes as follows:

```rs
let input = input.trim_end_matches("/*").trim_end_matches('/');
```
Removing both patterns when they exists at the end of the glob. Here is a screenshot of it working:

![image](https://github.com/eza-community/eza/assets/43209783/4e060fca-05f3-489a-a6c7-97932c679ca8)


##### How Has This Been Tested?

Should I write new unit tests for this specific case?
