### PR TITLE
feat: add filetype and icon for .hh extension

### DIFF
--- a/src/info/filetype.rs
+++ b/src/info/filetype.rs
@@ -329,6 +329,7 @@ const EXTENSION_TYPES: Map<&'static str, FileType> = phf_map! {
     "gvy"        => FileType::Source, // Groovy
     "h"          => FileType::Source, // C/C++ header
     "h++"        => FileType::Source, // C/C++ header
+    "hh"         => FileType::Source, // C/C++ header
     "hpp"        => FileType::Source, // C/C++ header
     "hs"         => FileType::Source, // Haskell
     "htc"        => FileType::Source, // JavaScript

--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -496,6 +496,7 @@ const EXTENSION_ICONS: Map<&'static str, char> = phf_map! {
     "heics"          => Icons::VIDEO,            // 
     "heif"           => Icons::IMAGE,            // 
     "hex"            => '\u{f12a7}',             // 󱊧
+    "hh"             => Icons::LANG_CPP,         // 
     "hpp"            => Icons::LANG_CPP,         // 
     "hs"             => Icons::LANG_HASKELL,     // 
     "htm"            => Icons::HTML5,            // 


### PR DESCRIPTION
Support `.hh` as an additional C/C++ extension. (Note that `.cc` is already supported.)