### PR TITLE
fix: bugfix to resolve absolute paths that are not symlinks

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -344,7 +344,7 @@ impl<'dir> File<'dir> {
     pub fn absolute_path(&self) -> Option<&PathBuf> {
         self.absolute_path
             .get_or_init(|| {
-                if self.link_target().is_broken() {
+                if self.is_link() && self.link_target().is_broken() {
                     // workaround for broken symlinks to get absolute path for parent and then
                     // append name of file; std::fs::canonicalize requires all path components
                     // (including the last one) to exist


### PR DESCRIPTION
In 4799a4924998e31bf1f501a2c6c0f006d1e427d3 a check for broken symlinks was introduced, but failed to check if a given argument actually **is** a symlink. This change simply adds that check.



<!--- Provide a general summary of your changes in the Title above -->

<!--- Make sure you've read CONTRIBUTING.md and CODE_OF_CONDUCT.md -->
<!---  -->
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
##### Description
Closes #887 but could also be the cause for other bugs, where absolute paths are needed.

##### How Has This Been Tested?
Ran `cargo test`  for existing tests and verified the correct output for `eza --hyperlink *PATTERN*` manually, see:
![image](https://github.com/eza-community/eza/assets/2018510/2dfe4138-adc3-43a0-833c-e1b33f25b427)

