### PR TITLE
Migration from ansiterm to nu_ansi_term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,22 +42,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_colours"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1558bd2075d341b9ca698ec8eb6fcc55a746b1fc4255585aad5b141d918a80"
-
-[[package]]
-name = "ansiterm"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab587f5395da16dd2e6939adf53dede583221b320cadfb94e02b5b7b9bf24cc"
-dependencies = [
- "ansi_colours",
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,7 +373,6 @@ name = "eza"
 version = "0.18.7"
 dependencies = [
  "ansi-width",
- "ansiterm",
  "chrono",
  "criterion",
  "git2",
@@ -398,6 +381,7 @@ dependencies = [
  "locale",
  "log",
  "natord",
+ "nu-ansi-term",
  "number_prefix",
  "once_cell",
  "palette",
@@ -686,6 +670,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+dependencies = [
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-traits"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,7 @@ name = "eza"
 
 
 [dependencies]
-ansi-width = "0.1.0"
-ansiterm = { version = "0.12.2", features = ["ansi_colours"] }
+nu-ansi-term = "0.49.0"
 chrono = { version = "0.4.34", default-features = false, features = ["clock"] }
 glob = "0.3"
 libc = "0.2"
@@ -92,6 +91,7 @@ timeago = { version = "0.4.2", default-features = false }
 unicode-width = "0.1"
 zoneinfo_compiled = "0.5.1"
 rayon = "1.9.0"
+ansi-width = "0.1.0"
 
 [dependencies.git2]
 version = "0.18"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::OsStr;
 
-use ansiterm::{ANSIString, Colour};
+use nu_ansi_term::{AnsiString as ANSIString, Color as Colour};
 
 /// Sets the internal logger, changing the log level based on the value of an
 /// environment variable.

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use std::io::{self, stdin, ErrorKind, IsTerminal, Read, Write};
 use std::path::{Component, PathBuf};
 use std::process::exit;
 
-use ansiterm::{ANSIStrings, Style};
+use nu_ansi_term::{AnsiStrings as ANSIStrings, Style};
 
 use crate::fs::feature::git::GitCache;
 use crate::fs::filter::GitIgnore;
@@ -52,11 +52,6 @@ fn main() {
     }
 
     logger::configure(env::var_os(vars::EZA_DEBUG).or_else(|| env::var_os(vars::EXA_DEBUG)));
-
-    #[cfg(windows)]
-    if let Err(e) = ansiterm::enable_ansi_support() {
-        warn!("Failed to enable ANSI support: {}", e);
-    }
 
     let stdout_istty = io::stdout().is_terminal();
 

--- a/src/output/cell.rs
+++ b/src/output/cell.rs
@@ -3,7 +3,7 @@
 use std::iter::Sum;
 use std::ops::{Add, Deref, DerefMut};
 
-use ansiterm::{ANSIString, ANSIStrings, Style};
+use nu_ansi_term::{AnsiString as ANSIString, AnsiStrings as ANSIStrings, Style};
 use unicode_width::UnicodeWidthStr;
 
 /// An individual cell that holds text in a table, used in the details and
@@ -158,7 +158,7 @@ impl TextCellContents {
     pub fn width(&self) -> DisplayWidth {
         self.0
             .iter()
-            .map(|anstr| DisplayWidth::from(&**anstr))
+            .map(|anstr| DisplayWidth::from(anstr.as_str()))
             .sum()
     }
 

--- a/src/output/color_scale.rs
+++ b/src/output/color_scale.rs
@@ -1,6 +1,6 @@
-use ansiterm::{Colour, Style};
 use log::trace;
-use palette::{FromColor, Oklab, Srgb};
+use nu_ansi_term::{Color as Colour, Style};
+use palette::{FromColor, LinSrgb, Oklab, Srgb};
 
 use crate::{
     fs::{dir_action::RecurseOptions, feature::git::GitCache, fields::Size, DotFilter, File},
@@ -203,13 +203,43 @@ impl Extremes {
 }
 
 fn adjust_luminance(color: Colour, x: f32, min_l: f32) -> Colour {
-    let color = Srgb::from_components(color.into_rgb()).into_linear();
+    let rgb_color = match color {
+        Colour::Rgb(r, g, b) => LinSrgb::new(
+            f32::from(r) / 255.0,
+            f32::from(g) / 255.0,
+            f32::from(b) / 255.0,
+        ),
 
-    let mut lab: Oklab = Oklab::from_color(color);
+        Colour::Black => LinSrgb::new(0.0, 0.0, 0.0),
+
+        Colour::Green | Colour::LightGreen => LinSrgb::new(0.0, 1.0, 0.0),
+
+        Colour::Yellow | Colour::LightYellow => LinSrgb::new(1.0, 1.0, 0.0),
+
+        Colour::Blue | Colour::LightBlue => LinSrgb::new(0.0, 0.0, 1.0),
+
+        Colour::Magenta | Colour::LightMagenta => LinSrgb::new(1.0, 0.0, 1.0),
+
+        Colour::Cyan | Colour::LightCyan => LinSrgb::new(0.0, 1.0, 1.0),
+
+        Colour::White => LinSrgb::new(1.0, 1.0, 1.0),
+
+        Colour::LightGray => LinSrgb::new(0.5, 0.5, 0.5),
+
+        Colour::LightRed | Colour::Red => LinSrgb::new(1.0, 0.0, 0.0),
+
+        Colour::DarkGray => LinSrgb::new(0.25, 0.25, 0.25),
+
+        Colour::LightPurple | Colour::Purple => LinSrgb::new(0.5, 0.0, 0.5),
+
+        _ => LinSrgb::new(1.0, 1.0, 1.0),
+    };
+
+    let mut lab: Oklab = Oklab::from_color(rgb_color);
     lab.l = (min_l + (1.0 - min_l) * (-4.0 * (1.0 - x)).exp()).clamp(0.0, 1.0);
 
     let adjusted_rgb: Srgb<f32> = Srgb::from_color(lab);
-    Colour::RGB(
+    Colour::Rgb(
         (adjusted_rgb.red * 255.0).round() as u8,
         (adjusted_rgb.green * 255.0).round() as u8,
         (adjusted_rgb.blue * 255.0).round() as u8,

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -63,8 +63,8 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use std::vec::IntoIter as VecIntoIter;
 
-use ansiterm::Style;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use nu_ansi_term::Style;
+use rayon::prelude::*;
 
 use log::*;
 

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -1,5 +1,5 @@
 use super::file_name::QuoteStyle;
-use ansiterm::{ANSIString, Style};
+use nu_ansi_term::{AnsiString as ANSIString, Style};
 
 pub fn escape(
     string: String,

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::path::Path;
 
-use ansiterm::{ANSIString, Style};
+use nu_ansi_term::{AnsiString as ANSIString, Style};
 use path_clean;
 use unicode_width::UnicodeWidthStr;
 

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -2,7 +2,9 @@
 
 use std::io::{self, Write};
 
-use term_grid::{Direction, Filling, Grid, GridOptions};
+use ansi_width;
+use grid::{Direction, Filling, Grid, GridOptions};
+use term_grid as grid;
 
 use crate::fs::feature::git::GitCache;
 use crate::fs::filter::FileFilter;

--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -1,4 +1,4 @@
-use ansiterm::Style;
+use nu_ansi_term::Style;
 use phf::{phf_map, Map};
 
 use crate::fs::File;

--- a/src/output/lines.rs
+++ b/src/output/lines.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use ansiterm::ANSIStrings;
+use nu_ansi_term::AnsiStrings as ANSIStrings;
 
 use crate::fs::filter::FileFilter;
 use crate::fs::File;

--- a/src/output/render/blocks.rs
+++ b/src/output/render/blocks.rs
@@ -1,5 +1,5 @@
-use ansiterm::Style;
 use locale::Numeric as NumericLocale;
+use nu_ansi_term::Style;
 use number_prefix::Prefix;
 
 use crate::fs::fields as f;
@@ -72,8 +72,8 @@ pub trait Colours {
 
 #[cfg(test)]
 pub mod test {
-    use ansiterm::Colour::*;
-    use ansiterm::Style;
+    use nu_ansi_term::Color::*;
+    use nu_ansi_term::Style;
 
     use super::Colours;
     use crate::fs::fields as f;
@@ -103,7 +103,7 @@ pub mod test {
                 SizeFormat::JustBytes,
                 &NumericLocale::english()
             )
-        )
+        );
     }
 
     #[test]
@@ -121,7 +121,7 @@ pub mod test {
                 SizeFormat::DecimalBytes,
                 &NumericLocale::english()
             )
-        )
+        );
     }
 
     #[test]
@@ -139,7 +139,7 @@ pub mod test {
                 SizeFormat::BinaryBytes,
                 &NumericLocale::english()
             )
-        )
+        );
     }
 
     #[test]
@@ -157,6 +157,6 @@ pub mod test {
                 SizeFormat::JustBytes,
                 &NumericLocale::english()
             )
-        )
+        );
     }
 }

--- a/src/output/render/filetype.rs
+++ b/src/output/render/filetype.rs
@@ -1,4 +1,4 @@
-use ansiterm::{ANSIString, Style};
+use nu_ansi_term::{AnsiString as ANSIString, Style};
 
 use crate::fs::fields as f;
 

--- a/src/output/render/flags.rs
+++ b/src/output/render/flags.rs
@@ -1,4 +1,4 @@
-use ansiterm::Style;
+use nu_ansi_term::Style;
 
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;

--- a/src/output/render/flags_bsd.rs
+++ b/src/output/render/flags_bsd.rs
@@ -1,4 +1,4 @@
-use ansiterm::Style;
+use nu_ansi_term::Style;
 use std::ffi::CStr;
 
 #[cfg(target_os = "netbsd")]

--- a/src/output/render/flags_windows.rs
+++ b/src/output/render/flags_windows.rs
@@ -1,7 +1,7 @@
 use crate::fs::fields as f;
 use crate::output::table::FlagsFormat;
 use crate::output::TextCell;
-use ansiterm::Style;
+use nu_ansi_term::Style;
 
 // See https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants
 const FILE_ATTRIBUTE_READONLY: u32 = 0x0000_0001; // R

--- a/src/output/render/git.rs
+++ b/src/output/render/git.rs
@@ -1,4 +1,4 @@
-use ansiterm::{ANSIString, Style};
+use nu_ansi_term::{AnsiString as ANSIString, Style};
 
 use crate::fs::fields as f;
 use crate::output::cell::{DisplayWidth, TextCell};
@@ -98,8 +98,8 @@ pub mod test {
     use crate::fs::fields as f;
     use crate::output::cell::{DisplayWidth, TextCell};
 
-    use ansiterm::Colour::*;
-    use ansiterm::Style;
+    use nu_ansi_term::Color::*;
+    use nu_ansi_term::Style;
 
     struct TestColours;
 
@@ -142,7 +142,7 @@ pub mod test {
             contents: vec![Fixed(90).paint("-"), Fixed(90).paint("-")].into(),
         };
 
-        assert_eq!(expected, stati.render(&TestColours))
+        assert_eq!(expected, stati.render(&TestColours));
     }
 
     #[test]
@@ -157,6 +157,6 @@ pub mod test {
             contents: vec![Fixed(91).paint("N"), Fixed(92).paint("M")].into(),
         };
 
-        assert_eq!(expected, stati.render(&TestColours))
+        assert_eq!(expected, stati.render(&TestColours));
     }
 }

--- a/src/output/render/groups.rs
+++ b/src/output/render/groups.rs
@@ -1,4 +1,4 @@
-use ansiterm::Style;
+use nu_ansi_term::Style;
 use uzers::{Groups, Users};
 
 use crate::fs::fields as f;
@@ -85,8 +85,8 @@ pub mod test {
     use crate::output::cell::TextCell;
     use crate::output::table::{GroupFormat, UserFormat};
 
-    use ansiterm::Colour::*;
-    use ansiterm::Style;
+    use nu_ansi_term::Color::*;
+    use nu_ansi_term::Style;
     use uzers::mock::MockUsers;
     use uzers::os::unix::GroupExt;
     use uzers::{Group, User};

--- a/src/output/render/inode.rs
+++ b/src/output/render/inode.rs
@@ -1,4 +1,4 @@
-use ansiterm::Style;
+use nu_ansi_term::Style;
 
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
@@ -14,7 +14,7 @@ pub mod test {
     use crate::fs::fields as f;
     use crate::output::cell::TextCell;
 
-    use ansiterm::Colour::*;
+    use nu_ansi_term::Color::*;
 
     #[test]
     fn blocklessness() {

--- a/src/output/render/links.rs
+++ b/src/output/render/links.rs
@@ -1,6 +1,6 @@
-use ansiterm::Style;
 #[cfg(unix)]
 use locale::Numeric as NumericLocale;
+use nu_ansi_term::Style;
 
 #[cfg(unix)]
 use crate::fs::fields as f;
@@ -33,10 +33,10 @@ pub mod test {
     #[cfg(unix)]
     use crate::output::cell::{DisplayWidth, TextCell};
 
-    use ansiterm::Colour::*;
-    use ansiterm::Style;
     #[cfg(unix)]
     use locale;
+    use nu_ansi_term::Color::*;
+    use nu_ansi_term::Style;
 
     struct TestColours;
 

--- a/src/output/render/octal.rs
+++ b/src/output/render/octal.rs
@@ -1,4 +1,4 @@
-use ansiterm::Style;
+use nu_ansi_term::Style;
 
 use crate::fs::fields as f;
 use crate::output::cell::TextCell;
@@ -56,7 +56,7 @@ pub mod test {
     use crate::fs::fields as f;
     use crate::output::cell::TextCell;
 
-    use ansiterm::Colour::*;
+    use nu_ansi_term::Color::*;
 
     #[test]
     fn normal_folder() {

--- a/src/output/render/permissions.rs
+++ b/src/output/render/permissions.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use ansiterm::{ANSIString, Style};
+use nu_ansi_term::{AnsiString as ANSIString, Style};
 
 use crate::fs::fields as f;
 use crate::output::cell::{DisplayWidth, TextCell};
@@ -190,8 +190,8 @@ pub mod test {
     use crate::fs::fields as f;
     use crate::output::cell::TextCellContents;
 
-    use ansiterm::Colour::*;
-    use ansiterm::Style;
+    use nu_ansi_term::Color::*;
+    use nu_ansi_term::Style;
 
     struct TestColours;
 
@@ -242,7 +242,7 @@ pub mod test {
             Fixed(11).paint("-"),
         ]);
 
-        assert_eq!(expected, bits.render(&TestColours, false).into())
+        assert_eq!(expected, bits.render(&TestColours, false).into());
     }
 
     #[test]
@@ -274,7 +274,7 @@ pub mod test {
             Fixed(109).paint("x"),
         ]);
 
-        assert_eq!(expected, bits.render(&TestColours, true).into())
+        assert_eq!(expected, bits.render(&TestColours, true).into());
     }
 
     #[test]
@@ -306,7 +306,7 @@ pub mod test {
             Fixed(111).paint("t"),
         ]);
 
-        assert_eq!(expected, bits.render(&TestColours, true).into())
+        assert_eq!(expected, bits.render(&TestColours, true).into());
     }
 
     #[test]
@@ -338,6 +338,6 @@ pub mod test {
             Fixed(111).paint("T"),
         ]);
 
-        assert_eq!(expected, bits.render(&TestColours, true).into())
+        assert_eq!(expected, bits.render(&TestColours, true).into());
     }
 }

--- a/src/output/render/securityctx.rs
+++ b/src/output/render/securityctx.rs
@@ -1,4 +1,4 @@
-use ansiterm::Style;
+use nu_ansi_term::Style;
 
 use crate::fs::fields as f;
 use crate::output::cell::{DisplayWidth, TextCell};

--- a/src/output/render/size.rs
+++ b/src/output/render/size.rs
@@ -1,5 +1,5 @@
-use ansiterm::Style;
 use locale::Numeric as NumericLocale;
+use nu_ansi_term::Style;
 use number_prefix::Prefix;
 
 use crate::fs::fields as f;
@@ -131,9 +131,9 @@ pub mod test {
     use crate::output::cell::{DisplayWidth, TextCell};
     use crate::output::table::SizeFormat;
 
-    use ansiterm::Colour::*;
-    use ansiterm::Style;
     use locale::Numeric as NumericLocale;
+    use nu_ansi_term::Color::*;
+    use nu_ansi_term::Style;
     use number_prefix::Prefix;
 
     struct TestColours;
@@ -161,7 +161,7 @@ pub mod test {
                 &NumericLocale::english(),
                 None
             )
-        )
+        );
     }
 
     #[test]
@@ -180,7 +180,7 @@ pub mod test {
                 &NumericLocale::english(),
                 None
             )
-        )
+        );
     }
 
     #[test]
@@ -199,7 +199,7 @@ pub mod test {
                 &NumericLocale::english(),
                 None
             )
-        )
+        );
     }
 
     #[test]
@@ -218,7 +218,7 @@ pub mod test {
                 &NumericLocale::english(),
                 None
             )
-        )
+        );
     }
 
     #[test]
@@ -245,6 +245,6 @@ pub mod test {
                 &NumericLocale::english(),
                 None
             )
-        )
+        );
     }
 }

--- a/src/output/render/times.rs
+++ b/src/output/render/times.rs
@@ -1,8 +1,8 @@
 use crate::output::cell::TextCell;
 use crate::output::time::TimeFormat;
 
-use ansiterm::Style;
 use chrono::prelude::*;
+use nu_ansi_term::Style;
 
 pub trait Render {
     fn render(self, style: Style, time_offset: FixedOffset, time_format: TimeFormat) -> TextCell;

--- a/src/output/render/users.rs
+++ b/src/output/render/users.rs
@@ -1,4 +1,4 @@
-use ansiterm::Style;
+use nu_ansi_term::Style;
 use uzers::Users;
 
 use crate::fs::fields as f;
@@ -49,8 +49,8 @@ pub mod test {
     use crate::output::cell::TextCell;
     use crate::output::table::UserFormat;
 
-    use ansiterm::Colour::*;
-    use ansiterm::Style;
+    use nu_ansi_term::Color::*;
+    use nu_ansi_term::Style;
     use uzers::mock::MockUsers;
     use uzers::User;
 

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -1,5 +1,5 @@
-use ansiterm::Colour::*;
-use ansiterm::Style;
+use nu_ansi_term::Color::*;
+use nu_ansi_term::Style;
 use std::default::Default;
 
 use crate::output::color_scale::{ColorScaleMode, ColorScaleOptions};

--- a/src/theme/lsc.rs
+++ b/src/theme/lsc.rs
@@ -1,8 +1,8 @@
 use std::iter::Peekable;
 use std::ops::FnMut;
 
-use ansiterm::Colour::*;
-use ansiterm::{Colour, Style};
+use nu_ansi_term::Color::*;
+use nu_ansi_term::{Color as Colour, Style};
 
 // Parsing the LS_COLORS environment variable into a map of names to Style values.
 //
@@ -75,7 +75,7 @@ where
                     iter.next().and_then(|s| s.parse().ok()),
                     iter.next().and_then(|s| s.parse().ok()),
                 ) {
-                    return Some(RGB(r, g, b));
+                    return Some(Rgb(r, g, b));
                 }
             }
         }
@@ -120,13 +120,13 @@ impl<'var> Pair<'var> {
                 "37" => style = style.fg(White),
                 // Bright foreground colours
                 "90" => style = style.fg(DarkGray),
-                "91" => style = style.fg(BrightRed),
-                "92" => style = style.fg(BrightGreen),
-                "93" => style = style.fg(BrightYellow),
-                "94" => style = style.fg(BrightBlue),
-                "95" => style = style.fg(BrightPurple),
-                "96" => style = style.fg(BrightCyan),
-                "97" => style = style.fg(BrightGray),
+                "91" => style = style.fg(LightRed),
+                "92" => style = style.fg(LightGreen),
+                "93" => style = style.fg(LightYellow),
+                "94" => style = style.fg(LightBlue),
+                "95" => style = style.fg(LightPurple),
+                "96" => style = style.fg(LightCyan),
+                "97" => style = style.fg(LightGray),
                 "38" => {
                     if let Some(c) = parse_into_high_colour(&mut iter) {
                         style = style.fg(c);
@@ -144,13 +144,13 @@ impl<'var> Pair<'var> {
                 "47" => style = style.on(White),
                 // Bright background colours
                 "100" => style = style.on(DarkGray),
-                "101" => style = style.on(BrightRed),
-                "102" => style = style.on(BrightGreen),
-                "103" => style = style.on(BrightYellow),
-                "104" => style = style.on(BrightBlue),
-                "105" => style = style.on(BrightPurple),
-                "106" => style = style.on(BrightCyan),
-                "107" => style = style.on(BrightGray),
+                "101" => style = style.on(LightRed),
+                "102" => style = style.on(LightGreen),
+                "103" => style = style.on(LightYellow),
+                "104" => style = style.on(LightBlue),
+                "105" => style = style.on(LightPurple),
+                "106" => style = style.on(LightCyan),
+                "107" => style = style.on(LightGray),
                 "48" => {
                     if let Some(c) = parse_into_high_colour(&mut iter) {
                         style = style.on(c);
@@ -167,7 +167,7 @@ impl<'var> Pair<'var> {
 #[cfg(test)]
 mod ansi_test {
     use super::*;
-    use ansiterm::Style;
+    use nu_ansi_term::Style;
 
     macro_rules! test {
         ($name:ident: $input:expr => $result:expr) => {
@@ -211,10 +211,10 @@ mod ansi_test {
     test!(hibo:  "48;5;1;1"  => Style::default().on(Fixed(1)).bold());
     test!(hiund: "4;48;5;1"  => Style::default().on(Fixed(1)).underline());
 
-    test!(rgb:   "38;2;255;100;0"     => Style::default().fg(RGB(255, 100, 0)));
-    test!(rgbi:  "38;2;255;100;0;3"   => Style::default().fg(RGB(255, 100, 0)).italic());
-    test!(rgbbg: "48;2;255;100;0"     => Style::default().on(RGB(255, 100, 0)));
-    test!(rgbbi: "48;2;255;100;0;3"   => Style::default().on(RGB(255, 100, 0)).italic());
+    test!(rgb:   "38;2;255;100;0"     => Style::default().fg(Rgb(255, 100, 0)));
+    test!(rgbi:  "38;2;255;100;0;3"   => Style::default().fg(Rgb(255, 100, 0)).italic());
+    test!(rgbbg: "48;2;255;100;0"     => Style::default().on(Rgb(255, 100, 0)));
+    test!(rgbbi: "48;2;255;100;0;3"   => Style::default().on(Rgb(255, 100, 0)).italic());
 
     test!(fgbg:  "38;5;121;48;5;212"  => Fixed(121).on(Fixed(212)));
     test!(bgfg:  "48;5;121;38;5;212"  => Fixed(212).on(Fixed(121)));

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1,4 +1,4 @@
-use ansiterm::Style;
+use nu_ansi_term::Style;
 
 use crate::fs::File;
 use crate::info::filetype::FileType;
@@ -424,7 +424,7 @@ fn apply_overlay(mut base: Style, overlay: Style) -> Style {
 mod customs_test {
     use super::*;
     use crate::theme::ui_styles::UiStyles;
-    use ansiterm::Colour::*;
+    use nu_ansi_term::Color::*;
 
     macro_rules! test {
         ($name:ident:  ls $ls:expr, exa $exa:expr  =>  colours $expected:ident -> $process_expected:expr) => {

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -1,4 +1,4 @@
-use ansiterm::Style;
+use nu_ansi_term::Style;
 
 use crate::theme::lsc::Pair;
 


### PR DESCRIPTION
As with the seemingly stalled PR #744 only rebased to the upstream main branch. Should pass pass all the automated testing, and seems to behave the same in the cursory manual sanity checks I threw at it.