### PR TITLE
Color Setting for Icons

### DIFF
--- a/man/eza_colors.5.md
+++ b/man/eza_colors.5.md
@@ -285,6 +285,9 @@ LIST OF CODES
 `sc`
 : a regular file that is source code
 
+`ic`
+: the icon (this is optional, if not set the icon color matches the file name's)
+
 `Sn`
 : No security context on a file
 

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -510,5 +510,7 @@ pub trait Colours: FiletypeColours {
     /// The style to paint a directory that has a filesystem mounted on it.
     fn mount_point(&self) -> Style;
 
+    fn icon(&self) -> Option<Style>;
+
     fn colour_file(&self, file: &File<'_>) -> Style;
 }

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -203,7 +203,10 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
         };
 
         if let Some(spaces_count) = spaces_count_opt {
-            let style = iconify_style(self.style());
+            let style = iconify_style(match self.colours.icon() {
+                Some(style) => style,
+                None => self.style(),
+            });
             let file_icon = icon_for_file(self.file).to_string();
             bits.push(style.paint(file_icon));
             bits.push(style.paint(" ".repeat(spaces_count as usize)));

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -203,10 +203,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
         };
 
         if let Some(spaces_count) = spaces_count_opt {
-            let style = iconify_style(match self.colours.icon() {
-                Some(style) => style,
-                None => self.style(),
-            });
+            let style = iconify_style(self.colours.icon().unwrap_or_else(|| self.style()));
             let file_icon = icon_for_file(self.file).to_string();
             bits.push(style.paint(file_icon));
             bits.push(style.paint(" ".repeat(spaces_count as usize)));

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -116,6 +116,8 @@ impl UiStyles {
             flags: Style::default(),
             header: Style::default().underline(),
 
+            icon: None,
+
             symlink_path: Cyan.normal(),
             control_char: Red.normal(),
             broken_symlink: Red.normal(),

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -372,6 +372,10 @@ impl FileNameColours for Theme {
     fn executable_file(&self)     -> Style { self.ui.filekinds.executable }
     fn mount_point(&self)         -> Style { self.ui.filekinds.mount_point }
 
+    fn icon(&self) -> Option<Style> {
+        self.ui.icon.map_or(None, |icon| Some(icon))
+    }
+
     fn colour_file(&self, file: &File<'_>) -> Style {
         self.exts
             .get_style(file, self)

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -372,9 +372,7 @@ impl FileNameColours for Theme {
     fn executable_file(&self)     -> Style { self.ui.filekinds.executable }
     fn mount_point(&self)         -> Style { self.ui.filekinds.mount_point }
 
-    fn icon(&self) -> Option<Style> {
-        self.ui.icon.map_or(None, |icon| Some(icon))
-    }
+    fn icon(&self)          -> Option<Style> { self.ui.icon }
 
     fn colour_file(&self, file: &File<'_>) -> Style {
         self.exts

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -25,6 +25,8 @@ pub struct UiStyles {
     pub octal:        Style,          // oc
     pub flags:        Style,          // ff
 
+    pub icon:         Option<Style>,  // ic
+
     pub symlink_path:         Style,  // lp
     pub control_char:         Style,  // cc
     pub broken_symlink:       Style,  // or

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -257,6 +257,9 @@ impl UiStyles {
             "hd" => self.header                         = pair.to_style(),
             "oc" => self.octal                          = pair.to_style(),
             "ff" => self.flags                          = pair.to_style(),
+
+            "ic" => self.icon                           = Some(pair.to_style()),
+
             "lp" => self.symlink_path                   = pair.to_style(),
             "cc" => self.control_char                   = pair.to_style(),
             "bO" => self.broken_path_overlay            = pair.to_style(),


### PR DESCRIPTION
In the discussion https://github.com/orgs/eza-community/discussions/891 the user asks about the ability to make the icon color different from the file name color. I took a peek into the code and actually ended up implementing this functionality.

So this adds the `EZA_COLORS` variable `ic` for icon which ends up as an `Option<Style>` in the `UiStyle` with `None` as default. The logic in the `FileName.paint` is adjusted to apply the icon style when the value is `Some` and otherwise fall back to the usual behavior, namely that the icon color matches the file name color.

![Screenshot from 2024-03-21 21-39-48](https://github.com/eza-community/eza/assets/49617392/cc026163-7e9b-4709-9ded-6c4faeff624d)