### PR TITLE
feat: Make hyperlinks useable inside a WSL environment

### DIFF
--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -396,9 +396,13 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
                 #[cfg(target_os = "windows")]
                 let abs_path = abs_path.strip_prefix("\\\\?\\").unwrap_or(&abs_path);
 
-                bits.push(ANSIString::from(format!(
-                    "{HYPERLINK_START}file://{abs_path}{HYPERLINK_END}"
-                )));
+                let hyperlink = if let Ok(distro_name) = std::env::var("WSL_DISTRO_NAME") {
+                    format!("{HYPERLINK_START}file://wsl$/{distro_name}{abs_path}{HYPERLINK_END}")
+                } else {
+                    format!("{HYPERLINK_START}file://{abs_path}{HYPERLINK_END}")
+                };
+
+                bits.push(ANSIString::from(hyperlink));
 
                 display_hyperlink = true;
             }


### PR DESCRIPTION
Modification of the --hyperlink parameter so that it also works in a WSL environment

If the environment variable "$WSL_DISTRO_NAME" is set, the hyperlink is modified so that the file/folder can be opened directly via Windows Explorer.

To open a file in a WSL environmen the link must be as follows: file://wsl$/${WSL_DISTRO_NAME}/{abs_path}