### PR TITLE
Icon Overrides via Environment

### DIFF
--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -55,7 +55,10 @@ impl Definitions {
         let exa = vars
             .get_with_fallback(vars::EZA_COLORS, vars::EXA_COLORS)
             .map(|e| e.to_string_lossy().to_string());
-        Self { ls, exa }
+        let icons = vars
+            .get(vars::EZA_ICONS)
+            .map(|e| e.to_string_lossy().to_string());
+        Self { ls, exa, icons }
     }
 }
 

--- a/src/options/vars.rs
+++ b/src/options/vars.rs
@@ -26,6 +26,8 @@ pub static NO_COLOR: &str = "NO_COLOR";
 pub static EXA_COLORS: &str = "EXA_COLORS";
 pub static EZA_COLORS: &str = "EZA_COLORS";
 
+pub static EZA_ICONS: &str = "EZA_ICONS";
+
 /// Environment variable used to switch on strict argument checking, such as
 /// complaining if an argument was specified twice, or if two conflict.
 /// This is meant to be so you don’t accidentally introduce the wrong

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -202,7 +202,13 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
 
         if let Some(spaces_count) = spaces_count_opt {
             let style = iconify_style(self.style());
-            let file_icon = icon_for_file(self.file).to_string();
+            let custom_icon = match self.file.ext.as_deref() {
+                Some(ext) => self.colours.custom_icons(ext.as_ref()),
+                None => None,
+            };
+            let file_icon = custom_icon
+                .unwrap_or_else(|| icon_for_file(self.file))
+                .to_string();
             bits.push(style.paint(file_icon));
             bits.push(style.paint(" ".repeat(spaces_count as usize)));
         }

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -509,4 +509,6 @@ pub trait Colours: FiletypeColours {
     fn mount_point(&self) -> Style;
 
     fn colour_file(&self, file: &File<'_>) -> Style;
+
+    fn custom_icons(&self, ext: &str) -> Option<char>;
 }

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -1,5 +1,6 @@
 use nu_ansi_term::Color::*;
 use nu_ansi_term::Style;
+use std::collections::HashMap;
 use std::default::Default;
 
 use crate::output::color_scale::{ColorScaleMode, ColorScaleOptions};
@@ -120,6 +121,8 @@ impl UiStyles {
             control_char: Red.normal(),
             broken_symlink: Red.normal(),
             broken_path_overlay: Style::default().underline(),
+
+            custom_icons: HashMap::new(),
         }
     }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -129,6 +129,14 @@ impl Definitions {
             });
         }
 
+        if let Some(icons) = &self.icons {
+            LSColors(icons).each_pair(|pair| {
+                colours
+                    .custom_icons
+                    .insert(pair.key.to_string(), pair.value.chars().next().unwrap());
+            });
+        }
+
         (exts, use_default_filetypes)
     }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -46,6 +46,7 @@ pub enum UseColours {
 pub struct Definitions {
     pub ls: Option<String>,
     pub exa: Option<String>,
+    pub icons: Option<String>,
 }
 
 pub struct Theme {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -386,6 +386,10 @@ impl FileNameColours for Theme {
             .get_style(file, self)
             .unwrap_or(self.ui.filekinds.normal)
     }
+
+    fn custom_icons(&self, ext: &str) -> Option<char> {
+        self.ui.custom_icons.get(ext).cloned()
+    }
 }
 
 #[rustfmt::skip]

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -388,7 +388,7 @@ impl FileNameColours for Theme {
     }
 
     fn custom_icons(&self, ext: &str) -> Option<char> {
-        self.ui.custom_icons.get(ext).cloned()
+        self.ui.custom_icons.get(ext).copied()
     }
 }
 

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -1,4 +1,5 @@
 use nu_ansi_term::Style;
+use std::collections::HashMap;
 
 use crate::theme::lsc::Pair;
 
@@ -29,6 +30,8 @@ pub struct UiStyles {
     pub control_char:         Style,  // cc
     pub broken_symlink:       Style,  // or
     pub broken_path_overlay:  Style,  // bO
+
+    pub custom_icons: HashMap<String, char>,
 }
 
 #[rustfmt::skip]


### PR DESCRIPTION
This adds setting custom icons via a new environment variable `EZA_ICONS`. At the root this works with a `HashMap<String, char>` in `UiStyles.custom_icons` which is accessed in `FileName.paint` via `FileNameColours.custom_icons`.

![Screenshot from 2024-03-30 18-04-22](https://github.com/eza-community/eza/assets/49617392/a984e142-10c3-4552-a353-a5ebce36c7ce)

This is still very rudimentary, only handles extensions, no docs, no tests, just to get things rolling, thus the draft.

Resolves #909
