### PR TITLE
feat(github): extend deny check in audit workflow to all

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,8 +4,10 @@ on:
     - cron: '0 0 * * *'
   push:
     paths:
+      - '.github/workflows/audit.yml'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      - 'deny.toml'
 jobs:
   security_audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-deny
       - name: Scan for vulnerabilities
-        run: cargo deny check advisories
+        run: cargo deny check

--- a/deny.toml
+++ b/deny.toml
@@ -39,7 +39,7 @@ targets = [
 # If true, metadata will be collected with `--all-features`. Note that this can't
 # be toggled off if true, if you want to conditionally enable `--all-features` it
 # is recommended to pass `--all-features` on the cmd line instead
-all-features = false
+all-features = true
 # If true, metadata will be collected with `--no-default-features`. The same
 # caveat with `all-features` applies
 no-default-features = false


### PR DESCRIPTION
At the moment the audit workflow only checks the `advisories` but not
`bans`, `licenses`, or `sources`. This removes said limitation.
