### PR TITLE
docs(README): use 3 columns for packaging status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you want to pass arguments this way, use e.g. `nix run github:eza-community/e
 eza is available for Windows, macOS and Linux. Platform and distribution
 specific installation instructions can be found in [INSTALL.md](INSTALL.md).
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/eza.svg)](https://repology.org/project/eza/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/eza.svg?columns=3)](https://repology.org/project/eza/versions)
 
 ---
 


### PR DESCRIPTION
This puts the packages into 3 columns instead of just one.
It allows an easier overview and reduces the amount of scrolling.