### PR TITLE
fix: change windows-only imports to be windows-only

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,4 @@
-#[cfg_attr(target_os = "netbsd", allow(unused_imports))]
-#[cfg_attr(target_os = "freebsd", allow(unused_imports))]
+#[cfg(target_os = "windows")]
 pub use self::cell::{DisplayWidth, TextCell, TextCellContents};
 pub use self::escape::escape;
 


### PR DESCRIPTION
Apparently this line is required for the Windows build, but leads to warnings on systems that build the eza port with a port of rust 1.77.2, which at this time seems to be limited to the BSDs.

Rather than selectively suppress the warning, I suggest to only include this line where needed.