### PR TITLE
feat: --ignore-submodule-contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s.
 - **-D**, **--only-dirs**: list only directories
 - **-f**, **--only-files**: list only files
 - **--git-ignore**: ignore files mentioned in `.gitignore`
+- **--ignore-submodule-contents**: do not list contents of submodules
 - **-I**, **--ignore-glob=(globs)**: glob patterns (pipe-separated) of files to ignore
 
 Pass the `--all` option twice to also show the `.` and `..` directories.

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -48,6 +48,7 @@ complete -c eza -l smart-group -d "Only show group if it has a different name fr
 # Filtering and sorting options
 complete -c eza -l group-directories-first -d "Sort directories before other files"
 complete -c eza -l git-ignore -d "Ignore files mentioned in '.gitignore'"
+complete -c eza -l ignore-submodule-contents -d "Do not list contents of submodules"
 complete -c eza -s a -l all -d "Show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories"
 complete -c eza -s A -l almost-all -d "Equivalent to --all; included for compatibility with `ls -A`"
 complete -c eza -s d -l list-dirs -d "List directories like regular files"

--- a/completions/nush/eza.nu
+++ b/completions/nush/eza.nu
@@ -1,62 +1,63 @@
 export extern "eza" [
-    --version(-v)              # Show version of eza
-    --help                     # Show list of command-line options
-    --oneline(-1)              # Display one entry per line
-    --long(-l)                 # Display extended file metadata as a table
-    --grid(-G)                 # Display entries in a grid
-    --across(-x)               # Sort the grid across, rather than downwards
-    --recurse(-R)              # Recurse into directories
-    --tree(-T)                 # Recurse into directories as a tree
-    --dereference(-X)          # Dereference symbolic links when displaying file information
-    --classify(-F)             # Display type indicator by file names
-    --color                    # When to use terminal colours
-    --colour                   # When to use terminal colours
-    --color-scale              # Highlight levels of file sizes distinctly
-    --colour-scale             # Highlight levels of file sizes distinctly
-    --color-scale-mode         # Use gradient or fixed colors in --color-scale
-    --colour-scale-mode        # Use gradient or fixed colors in --colour-scale
-    --icons                    # When to display icons
-    --no-quotes                # Don't quote file names with spaces
-    --hyperlink                # Display entries as hyperlinks
-    --absolute                 # Display entries with their absolute path
-    --group-directories-first  # Sort directories before other files
-    --git-ignore               # Ignore files mentioned in '.gitignore'
-    --all(-a)                  # Show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories
-    --almost-all(-A)           # Equivalent to --all; included for compatibility with `ls -A`
-    --list-dirs(-d)            # List directories like regular files
-    --level(-L): string        # Limit the depth of recursion
-    --width(-w)                # Limits column output of grid, 0 implies auto-width
-    --reverse(-r)              # Reverse the sort order
-    --sort(-s)                 # Which field to sort by
-    --only-dirs(-D)            # List only directories
-    --only-files(-f)           # List only files
-    --binary(-b)               # List file sizes with binary prefixes
-    --bytes(-B)                # List file sizes in bytes, without any prefixes
-    --group(-g)                # List each file's group
-    --header(-h)               # Add a header row to each column
-    --links(-H)                # List each file's number of hard links
-    --inode(-i)                # List each file's inode number
-    --blocksize(-S)            # List each file's size of allocated file system blocks
-    --time(-t) -d              # Which timestamp field to list
-    --modified(-m)             # Use the modified timestamp field
-    --numeric(-n)              # List numeric user and group IDs.
-    --changed                  # Use the changed timestamp field
-    --accessed(-u)             # Use the accessed timestamp field
-    --created(-U)              # Use the created timestamp field
-    --time-style               # How to format timestamps
-    --total-size               # Show recursive directory size (unix only)
-    --no-permissions           # Suppress the permissions field
-    --octal-permissions(-o)    # List each file's permission in octal format
-    --no-filesize              # Suppress the filesize field
-    --no-user                  # Suppress the user field
-    --no-time                  # Suppress the time field
-    --mounts(-M)               # Show mount details
-    --git                      # List each file's Git status, if tracked
-    --no-git                   # Suppress Git status
-    --git-repos                # List each git-repos status and branch name
-    --git-repos-no-status      # List each git-repos branch name (much faster)
-    --extended(-@)             # List each file's extended attributes and sizes
-    --context(-Z)              # List each file's security context
-    --smart-group              # Only show group if it has a different name from owner
-    --stdin                    # When piping to eza. Read file paths from stdin
+    --version(-v)               # Show version of eza
+    --help                      # Show list of command-line options
+    --oneline(-1)               # Display one entry per line
+    --long(-l)                  # Display extended file metadata as a table
+    --grid(-G)                  # Display entries in a grid
+    --across(-x)                # Sort the grid across, rather than downwards
+    --recurse(-R)               # Recurse into directories
+    --tree(-T)                  # Recurse into directories as a tree
+    --dereference(-X)           # Dereference symbolic links when displaying file information
+    --classify(-F)              # Display type indicator by file names
+    --color                     # When to use terminal colours
+    --colour                    # When to use terminal colours
+    --color-scale               # Highlight levels of file sizes distinctly
+    --colour-scale              # Highlight levels of file sizes distinctly
+    --color-scale-mode          # Use gradient or fixed colors in --color-scale
+    --colour-scale-mode         # Use gradient or fixed colors in --colour-scale
+    --icons                     # When to display icons
+    --no-quotes                 # Don't quote file names with spaces
+    --hyperlink                 # Display entries as hyperlinks
+    --absolute                  # Display entries with their absolute path
+    --group-directories-first   # Sort directories before other files
+    --git-ignore                # Ignore files mentioned in '.gitignore'
+    --ignore-submodule-contents # Do not list contents of submodules
+    --all(-a)                   # Show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories
+    --almost-all(-A)            # Equivalent to --all; included for compatibility with `ls -A`
+    --list-dirs(-d)             # List directories like regular files
+    --level(-L): string         # Limit the depth of recursion
+    --width(-w)                 # Limits column output of grid, 0 implies auto-width
+    --reverse(-r)               # Reverse the sort order
+    --sort(-s)                  # Which field to sort by
+    --only-dirs(-D)             # List only directories
+    --only-files(-f)            # List only files
+    --binary(-b)                # List file sizes with binary prefixes
+    --bytes(-B)                 # List file sizes in bytes, without any prefixes
+    --group(-g)                 # List each file's group
+    --header(-h)                # Add a header row to each column
+    --links(-H)                 # List each file's number of hard links
+    --inode(-i)                 # List each file's inode number
+    --blocksize(-S)             # List each file's size of allocated file system blocks
+    --time(-t) -d               # Which timestamp field to list
+    --modified(-m)              # Use the modified timestamp field
+    --numeric(-n)               # List numeric user and group IDs.
+    --changed                   # Use the changed timestamp field
+    --accessed(-u)              # Use the accessed timestamp field
+    --created(-U)               # Use the created timestamp field
+    --time-style                # How to format timestamps
+    --total-size                # Show recursive directory size (unix only)
+    --no-permissions            # Suppress the permissions field
+    --octal-permissions(-o)     # List each file's permission in octal format
+    --no-filesize               # Suppress the filesize field
+    --no-user                   # Suppress the user field
+    --no-time                   # Suppress the time field
+    --mounts(-M)                # Show mount details
+    --git                       # List each file's Git status, if tracked
+    --no-git                    # Suppress Git status
+    --git-repos                 # List each git-repos status and branch name
+    --git-repos-no-status       # List each git-repos branch name (much faster)
+    --extended(-@)              # List each file's extended attributes and sizes
+    --context(-Z)               # List each file's security context
+    --smart-group               # Only show group if it has a different name from owner
+    --stdin                     # When piping to eza. Read file paths from stdin
 ]

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -29,6 +29,7 @@ __eza() {
         --absolute"[Display entries with their absolute path]:(mode):(on follow off)" \
         --group-directories-first"[Sort directories before other files]" \
         --git-ignore"[Ignore files mentioned in '.gitignore']" \
+        --ignore-submodule-contents"[Do not list contents of submodules]" \
         {-a,--all}"[Show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories]" \
         {-A,--almost-all}"[Equivalent to --all; included for compatibility with \'ls -A\']" \
         {-d,--list-dirs}"[List directories like regular files]" \

--- a/devtools/dir-generator.sh
+++ b/devtools/dir-generator.sh
@@ -133,6 +133,22 @@ touch icons/man.1 --date=@0
 touch icons/marked.md --date=@0
 # END test_icons
 
+# BEGIN submodule
+cd git/01 || exit
+git add "*01"
+git commit -m "Initial commit" # git doesn't allow us to create a submodule without a branch
+cd ../.. || exit
+
+mkdir -p with_submodule
+cd with_submodule || exit
+git init
+seq 01 10 | split -l 1 -a 3 -d - file_
+git -c protocol.file.allow=always submodule add ../git/01
+cd .. || exit
+
+ln -s with_submodule with_submodule_symlink
+# END submodule
+
 # BEGIN set date
 touch --date=@0 ./*;
 # END set date

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -157,6 +157,9 @@ Sort fields starting with a capital letter will sort uppercase before lowercase:
 `--git-ignore` [if eza was built with git support]
 : Do not list files that are ignored by Git.
 
+`--ignore-submodule-contents` [if eza was built with git support]
+: Do not list contents of submodules.
+
 `--group-directories-first`
 : List directories before other files.
 

--- a/powertest.yaml
+++ b/powertest.yaml
@@ -143,6 +143,8 @@ commands:
       - "*.toml"
   ? - null
     - --git-ignore
+  ? - null
+    - --ignore-submodule-contents
 
   # Long View Options
   ? - -b

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -5,7 +5,7 @@ use std::ffi::OsStr;
 #[cfg(target_family = "unix")]
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 
 use log::*;
 
@@ -32,7 +32,7 @@ impl GitCache {
         self.repos
             .iter()
             .find(|repo| repo.has_path(index))
-            .map(|repo| repo.search(index, prefix_lookup))
+            .map(|repo| repo.get_status(index, prefix_lookup))
             .unwrap_or_default()
     }
 
@@ -105,17 +105,19 @@ impl FromIterator<PathBuf> for GitCache {
 
 /// A **Git repository** is one we’ve discovered somewhere on the filesystem.
 pub struct GitRepo {
-    /// The queryable contents of the repository: either a `git2` repo, or the
-    /// cached results from when we queried it last time.
-    contents: Mutex<GitContents>,
+    /// All the interesting Git stuff goes through this.
+    repo: Mutex<git2::Repository>,
+
+    /// Cached path->status mapping.
+    statuses: RwLock<Option<GitStatuses>>,
+
+    /// Cached list of the relative paths of all submodules in this repository.
+    /// This is used to optionally ignore submodule contents when listing recursively.
+    relative_submodule_paths: RwLock<Option<Result<Vec<PathBuf>, git2::Error>>>,
 
     /// The working directory of this repository.
     /// This is used to check whether two repositories are the same.
     workdir: PathBuf,
-
-    /// The relative paths of any submodules in this repository.
-    /// This is used to optionally ignore submodule contents when listing recursively.
-    relative_submodule_paths: Option<Vec<PathBuf>>,
 
     /// The path that was originally checked to discover this repository.
     /// This is as important as the extra_paths (it gets checked first), but
@@ -127,20 +129,6 @@ pub struct GitRepo {
     extra_paths: Vec<PathBuf>,
 }
 
-/// A repository’s queried state.
-enum GitContents {
-    /// All the interesting Git stuff goes through this.
-    Before { repo: git2::Repository },
-
-    /// Temporary value used in `repo_to_statuses` so we can move the
-    /// repository out of the `Before` variant.
-    Processing,
-
-    /// The data we’ve extracted from the repository, but only after we’ve
-    /// actually done so.
-    After { statuses: Git },
-}
-
 impl GitRepo {
     /// Searches through this repository for a path (to a file or directory,
     /// depending on the prefix-lookup flag) and returns its Git status.
@@ -149,23 +137,28 @@ impl GitRepo {
     /// Git statuses is only done once, and gets cached so we don’t need to
     /// re-query the entire repository the times after that.
     ///
-    /// The temporary `Processing` enum variant is used after the `git2`
-    /// repository is moved out, but before the results have been moved in!
-    /// See <https://stackoverflow.com/q/45985827/3484614>
-    fn search(&self, index: &Path, prefix_lookup: bool) -> f::Git {
-        use std::mem::replace;
+    /// “Prefix lookup” means that it should report an aggregate status of all
+    /// paths starting with the given prefix (in other words, a directory).
+    fn get_status(&self, index: &Path, prefix_lookup: bool) -> f::Git {
+        {
+            let statuses = self.statuses.read().unwrap();
+            if let Some(ref cached_statuses) = *statuses {
+                debug!("Git repo {:?} has been found in cache", &self.workdir);
+                return cached_statuses.status(index, prefix_lookup);
+            }
+        }
 
-        let mut contents = self.contents.lock().unwrap();
-        if let GitContents::After { ref statuses } = *contents {
+        let mut statuses = self.statuses.write().unwrap();
+        if let Some(ref cached_statuses) = *statuses {
             debug!("Git repo {:?} has been found in cache", &self.workdir);
-            return statuses.status(index, prefix_lookup);
+            return cached_statuses.status(index, prefix_lookup);
         }
 
         debug!("Querying Git repo {:?} for the first time", &self.workdir);
-        let repo = replace(&mut *contents, GitContents::Processing).inner_repo();
-        let statuses = repo_to_statuses(&repo, &self.workdir);
-        let result = statuses.status(index, prefix_lookup);
-        let _processing = replace(&mut *contents, GitContents::After { statuses });
+        let repo = self.repo.lock().unwrap();
+        let new_statuses = repo_to_statuses(&repo, &self.workdir);
+        let result = new_statuses.status(index, prefix_lookup);
+        *statuses = Some(new_statuses);
         result
     }
 
@@ -196,17 +189,11 @@ impl GitRepo {
 
         if let Some(workdir) = repo.workdir() {
             let workdir = workdir.to_path_buf();
-            let relative_submodule_paths = repo.submodules().ok().map(|submodules| {
-                submodules
-                    .iter()
-                    .map(|submodule| submodule.path().to_path_buf())
-                    .collect()
-            });
-            let contents = Mutex::new(GitContents::Before { repo });
             Ok(Self {
-                contents,
+                repo: Mutex::new(repo),
+                statuses: RwLock::new(None),
+                relative_submodule_paths: RwLock::new(None),
                 workdir,
-                relative_submodule_paths,
                 original_path: path,
                 extra_paths: Vec::new(),
             })
@@ -217,39 +204,63 @@ impl GitRepo {
     }
 
     fn has_in_submodule(&self, path: &Path) -> bool {
-        if let Ok(relative_path) = path.strip_prefix(&self.workdir) {
-            if self
-                .relative_submodule_paths
-                .as_ref()
-                .map(|paths| paths.iter().any(|p| relative_path.starts_with(p)))
-                .unwrap_or(false)
-            {
-                return true;
+        fn check_submodule_paths(
+            paths: &[PathBuf],
+            path: &Path,
+            extra_paths: &[PathBuf],
+            workdir: &Path,
+        ) -> bool {
+            if let Ok(relative_path) = path.strip_prefix(workdir) {
+                if paths.iter().any(|p| relative_path.starts_with(p)) {
+                    return true;
+                }
+            }
+
+            extra_paths.iter().any(|extra_path| {
+                if let Ok(relative_path) = path.strip_prefix(extra_path) {
+                    paths.iter().any(|p| relative_path.starts_with(p))
+                } else {
+                    false
+                }
+            })
+        }
+
+        {
+            let relative_submodule_paths = self.relative_submodule_paths.read().unwrap();
+            match &*relative_submodule_paths {
+                Some(Ok(paths)) => {
+                    return check_submodule_paths(paths, path, &self.extra_paths, &self.workdir);
+                }
+                Some(Err(_)) => return false,
+                None => {}
             }
         }
 
-        self.extra_paths.iter().any(|extra_path| {
-            if let Ok(relative_path) = path.strip_prefix(extra_path) {
-                self.relative_submodule_paths
-                    .as_ref()
-                    .map(|paths| paths.iter().any(|p| relative_path.starts_with(p)))
-                    .unwrap_or(false)
-            } else {
-                false
-            }
-        })
-    }
-}
+        let mut relative_submodule_paths = self.relative_submodule_paths.write().unwrap();
+        match &*relative_submodule_paths {
+            Some(Ok(paths)) => check_submodule_paths(paths, path, &self.extra_paths, &self.workdir),
+            Some(Err(_)) => false,
+            None => {
+                let repo = self.repo.lock().unwrap();
+                let paths_result = repo.submodules().map(|submodules| {
+                    submodules
+                        .iter()
+                        .map(|submodule| submodule.path().to_path_buf())
+                        .collect()
+                });
+                *relative_submodule_paths = Some(paths_result);
 
-impl GitContents {
-    /// Assumes that the repository hasn’t been queried, and extracts it
-    /// (consuming the value) if it has. This is needed because the entire
-    /// enum variant gets replaced when a repo is queried (see above).
-    fn inner_repo(self) -> git2::Repository {
-        if let Self::Before { repo } = self {
-            repo
-        } else {
-            unreachable!("Tried to extract a non-Repository")
+                match &*relative_submodule_paths {
+                    Some(Ok(paths)) => {
+                        check_submodule_paths(paths, path, &self.extra_paths, &self.workdir)
+                    }
+                    Some(Err(e)) => {
+                        error!("Error looking up Git submodules: {:?}", e);
+                        false
+                    }
+                    None => unreachable!(),
+                }
+            }
         }
     }
 }
@@ -258,7 +269,7 @@ impl GitContents {
 /// mapping of files to their Git status.
 /// We will have already used the working directory at this point, so it gets
 /// passed in rather than deriving it from the `Repository` again.
-fn repo_to_statuses(repo: &git2::Repository, workdir: &Path) -> Git {
+fn repo_to_statuses(repo: &git2::Repository, workdir: &Path) -> GitStatuses {
     let mut statuses = Vec::new();
 
     info!("Getting Git statuses for repo with workdir {:?}", workdir);
@@ -283,7 +294,7 @@ fn repo_to_statuses(repo: &git2::Repository, workdir: &Path) -> Git {
         }
     }
 
-    Git { statuses }
+    GitStatuses { statuses }
 }
 
 // The `repo.statuses` call above takes a long time. exa debug output:
@@ -295,11 +306,11 @@ fn repo_to_statuses(repo: &git2::Repository, workdir: &Path) -> Git {
 // look any faster.
 
 /// Container of Git statuses for all the files in this folder’s Git repository.
-struct Git {
+struct GitStatuses {
     statuses: Vec<(PathBuf, git2::Status)>,
 }
 
-impl Git {
+impl GitStatuses {
     /// Get either the file or directory status for the given path.
     /// “Prefix lookup” means that it should report an aggregate status of all
     /// paths starting with the given prefix (in other words, a directory).

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -35,6 +35,14 @@ impl GitCache {
             .map(|repo| repo.search(index, prefix_lookup))
             .unwrap_or_default()
     }
+
+    pub fn has_in_submodule(&self, path: &Path) -> bool {
+        self.repos
+            .iter()
+            .find(|repo| repo.has_path(path))
+            .map(|repo| repo.has_in_submodule(path))
+            .unwrap_or(false)
+    }
 }
 
 use std::iter::FromIterator;
@@ -104,6 +112,10 @@ pub struct GitRepo {
     /// The working directory of this repository.
     /// This is used to check whether two repositories are the same.
     workdir: PathBuf,
+
+    /// The relative paths of any submodules in this repository.
+    /// This is used to optionally ignore submodule contents when listing recursively.
+    relative_submodule_paths: Option<Vec<PathBuf>>,
 
     /// The path that was originally checked to discover this repository.
     /// This is as important as the extra_paths (it gets checked first), but
@@ -184,10 +196,17 @@ impl GitRepo {
 
         if let Some(workdir) = repo.workdir() {
             let workdir = workdir.to_path_buf();
+            let relative_submodule_paths = repo.submodules().ok().map(|submodules| {
+                submodules
+                    .iter()
+                    .map(|submodule| submodule.path().to_path_buf())
+                    .collect()
+            });
             let contents = Mutex::new(GitContents::Before { repo });
             Ok(Self {
                 contents,
                 workdir,
+                relative_submodule_paths,
                 original_path: path,
                 extra_paths: Vec::new(),
             })
@@ -195,6 +214,30 @@ impl GitRepo {
             warn!("Repository has no workdir?");
             Err(path)
         }
+    }
+
+    fn has_in_submodule(&self, path: &Path) -> bool {
+        if let Ok(relative_path) = path.strip_prefix(&self.workdir) {
+            if self
+                .relative_submodule_paths
+                .as_ref()
+                .map(|paths| paths.iter().any(|p| relative_path.starts_with(p)))
+                .unwrap_or(false)
+            {
+                return true;
+            }
+        }
+
+        self.extra_paths.iter().any(|extra_path| {
+            if let Ok(relative_path) = path.strip_prefix(extra_path) {
+                self.relative_submodule_paths
+                    .as_ref()
+                    .map(|paths| paths.iter().any(|p| relative_path.starts_with(p)))
+                    .unwrap_or(false)
+            } else {
+                false
+            }
+        })
     }
 }
 

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -229,7 +229,12 @@ impl GitRepo {
             let relative_submodule_paths = self.relative_submodule_paths.read().unwrap();
             match &*relative_submodule_paths {
                 Some(Ok(paths)) => {
-                    return check_submodule_paths(paths, path, &self.extra_paths, &self.original_path);
+                    return check_submodule_paths(
+                        paths,
+                        path,
+                        &self.extra_paths,
+                        &self.original_path,
+                    );
                 }
                 Some(Err(_)) => return false,
                 None => {}
@@ -238,7 +243,9 @@ impl GitRepo {
 
         let mut relative_submodule_paths = self.relative_submodule_paths.write().unwrap();
         match &*relative_submodule_paths {
-            Some(Ok(paths)) => check_submodule_paths(paths, path, &self.extra_paths, &self.original_path),
+            Some(Ok(paths)) => {
+                check_submodule_paths(paths, path, &self.extra_paths, &self.original_path)
+            }
             Some(Err(_)) => false,
             None => {
                 let repo = self.repo.lock().unwrap();

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -208,9 +208,9 @@ impl GitRepo {
             paths: &[PathBuf],
             path: &Path,
             extra_paths: &[PathBuf],
-            workdir: &Path,
+            original_path: &Path,
         ) -> bool {
-            if let Ok(relative_path) = path.strip_prefix(workdir) {
+            if let Ok(relative_path) = path.strip_prefix(original_path) {
                 if paths.iter().any(|p| relative_path.starts_with(p)) {
                     return true;
                 }
@@ -229,7 +229,7 @@ impl GitRepo {
             let relative_submodule_paths = self.relative_submodule_paths.read().unwrap();
             match &*relative_submodule_paths {
                 Some(Ok(paths)) => {
-                    return check_submodule_paths(paths, path, &self.extra_paths, &self.workdir);
+                    return check_submodule_paths(paths, path, &self.extra_paths, &self.original_path);
                 }
                 Some(Err(_)) => return false,
                 None => {}
@@ -238,7 +238,7 @@ impl GitRepo {
 
         let mut relative_submodule_paths = self.relative_submodule_paths.write().unwrap();
         match &*relative_submodule_paths {
-            Some(Ok(paths)) => check_submodule_paths(paths, path, &self.extra_paths, &self.workdir),
+            Some(Ok(paths)) => check_submodule_paths(paths, path, &self.extra_paths, &self.original_path),
             Some(Err(_)) => false,
             None => {
                 let repo = self.repo.lock().unwrap();
@@ -252,7 +252,7 @@ impl GitRepo {
 
                 match &*relative_submodule_paths {
                     Some(Ok(paths)) => {
-                        check_submodule_paths(paths, path, &self.extra_paths, &self.workdir)
+                        check_submodule_paths(paths, path, &self.extra_paths, &self.original_path)
                     }
                     Some(Err(e)) => {
                         error!("Error looking up Git submodules: {:?}", e);

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -156,9 +156,9 @@ impl GitRepo {
 
         debug!("Querying Git repo {:?} for the first time", &self.workdir);
         let repo = self.repo.lock().unwrap();
-        let new_statuses = repo_to_statuses(&repo, &self.workdir);
-        let result = new_statuses.status(index, prefix_lookup);
-        *statuses = Some(new_statuses);
+        let statuses = repo_to_statuses(&repo, &self.workdir);
+        let result = statuses.status(index, prefix_lookup);
+        *statuses = Some(statuses);
         result
     }
 
@@ -204,21 +204,26 @@ impl GitRepo {
     }
 
     fn has_in_submodule(&self, path: &Path) -> bool {
-        fn check_submodule_paths(
-            paths: &[PathBuf],
+        fn is_in_submodule(
+            relative_submodule_paths: &[PathBuf],
             path: &Path,
             extra_paths: &[PathBuf],
             original_path: &Path,
         ) -> bool {
             if let Ok(relative_path) = path.strip_prefix(original_path) {
-                if paths.iter().any(|p| relative_path.starts_with(p)) {
+                if relative_submodule_paths
+                    .iter()
+                    .any(|p| relative_path.starts_with(p))
+                {
                     return true;
                 }
             }
 
             extra_paths.iter().any(|extra_path| {
                 if let Ok(relative_path) = path.strip_prefix(extra_path) {
-                    paths.iter().any(|p| relative_path.starts_with(p))
+                    relative_submodule_paths
+                        .iter()
+                        .any(|p| relative_path.starts_with(p))
                 } else {
                     false
                 }
@@ -229,7 +234,7 @@ impl GitRepo {
             let relative_submodule_paths = self.relative_submodule_paths.read().unwrap();
             match &*relative_submodule_paths {
                 Some(Ok(paths)) => {
-                    return check_submodule_paths(
+                    return is_in_submodule(
                         paths,
                         path,
                         &self.extra_paths,
@@ -244,7 +249,7 @@ impl GitRepo {
         let mut relative_submodule_paths = self.relative_submodule_paths.write().unwrap();
         match &*relative_submodule_paths {
             Some(Ok(paths)) => {
-                check_submodule_paths(paths, path, &self.extra_paths, &self.original_path)
+                is_in_submodule(paths, path, &self.extra_paths, &self.original_path)
             }
             Some(Err(_)) => false,
             None => {
@@ -259,7 +264,7 @@ impl GitRepo {
 
                 match &*relative_submodule_paths {
                     Some(Ok(paths)) => {
-                        check_submodule_paths(paths, path, &self.extra_paths, &self.original_path)
+                        is_in_submodule(paths, path, &self.extra_paths, &self.original_path)
                     }
                     Some(Err(e)) => {
                         error!("Error looking up Git submodules: {:?}", e);

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -68,6 +68,9 @@ pub struct FileFilter {
 
     /// Whether to ignore Git-ignored patterns.
     pub git_ignore: GitIgnore,
+
+    /// Whether to ignore submodule contents when listing recursively.
+    pub ignore_submodule_contents: bool,
 }
 
 impl FileFilter {

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,6 +329,16 @@ impl<'args> Exa<'args> {
                 writeln!(&mut self.writer, "{}:", ANSIStrings(&bits))?;
             }
 
+            if self.options.filter.ignore_submodule_contents
+                && self
+                    .git
+                    .as_ref()
+                    .map(|g| g.has_in_submodule(&dir.path))
+                    .unwrap_or(false)
+            {
+                return Ok(exit_status);
+            }
+
             let mut children = Vec::new();
             let git_ignore = self.options.filter.git_ignore == GitIgnore::CheckAndIgnore;
             for file in dir.files(

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,6 +438,7 @@ impl<'args> Exa<'args> {
                 let git_ignoring = self.options.filter.git_ignore == GitIgnore::CheckAndIgnore;
                 let git = self.git.as_ref();
                 let git_repos = self.git_repos;
+                let ignoring_submodule_contents = self.options.filter.ignore_submodule_contents;
                 let r = details::Render {
                     dir,
                     files,
@@ -449,6 +450,7 @@ impl<'args> Exa<'args> {
                     git_ignoring,
                     git,
                     git_repos,
+                    ignoring_submodule_contents,
                 };
                 r.render(&mut self.writer)
             }
@@ -461,6 +463,7 @@ impl<'args> Exa<'args> {
                 let git_ignoring = self.options.filter.git_ignore == GitIgnore::CheckAndIgnore;
                 let git = self.git.as_ref();
                 let git_repos = self.git_repos;
+                let ignoring_submodule_contents = self.options.filter.ignore_submodule_contents;
 
                 let r = grid_details::Render {
                     dir,
@@ -474,6 +477,7 @@ impl<'args> Exa<'args> {
                     git,
                     console_width,
                     git_repos,
+                    ignoring_submodule_contents,
                 };
                 r.render(&mut self.writer)
             }
@@ -485,6 +489,7 @@ impl<'args> Exa<'args> {
                 let git_ignoring = self.options.filter.git_ignore == GitIgnore::CheckAndIgnore;
                 let git = self.git.as_ref();
                 let git_repos = self.git_repos;
+                let ignoring_submodule_contents = self.options.filter.ignore_submodule_contents;
 
                 let r = details::Render {
                     dir,
@@ -497,6 +502,7 @@ impl<'args> Exa<'args> {
                     git_ignoring,
                     git,
                     git_repos,
+                    ignoring_submodule_contents,
                 };
                 r.render(&mut self.writer)
             }

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -27,6 +27,7 @@ impl FileFilter {
         #[rustfmt::skip]
         return Ok(Self {
             list_dirs_first:  matches.has(&flags::DIRS_FIRST)?,
+            ignore_submodule_contents: matches.has(&flags::IGNORE_SUBMODULE_CONTENTS)?,
             flags: filter_flags,
             sort_field:       SortField::deduce(matches)?,
             dot_filter:       DotFilter::deduce(matches)?,

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -38,6 +38,7 @@ pub static REVERSE:     Arg = Arg { short: Some(b'r'), long: "reverse",     take
 pub static SORT:        Arg = Arg { short: Some(b's'), long: "sort",        takes_value: TakesValue::Necessary(Some(SORTS)) };
 pub static IGNORE_GLOB: Arg = Arg { short: Some(b'I'), long: "ignore-glob", takes_value: TakesValue::Necessary(None) };
 pub static GIT_IGNORE:  Arg = Arg { short: None, long: "git-ignore",           takes_value: TakesValue::Forbidden };
+pub static IGNORE_SUBMODULE_CONTENTS: Arg = Arg { short: None, long: "ignore-submodule-contents", takes_value: TakesValue::Forbidden };
 pub static DIRS_FIRST:  Arg = Arg { short: None, long: "group-directories-first",  takes_value: TakesValue::Forbidden };
 pub static ONLY_DIRS:   Arg = Arg { short: Some(b'D'), long: "only-dirs", takes_value: TakesValue::Forbidden };
 pub static ONLY_FILES:  Arg = Arg { short: Some(b'f'), long: "only-files", takes_value: TakesValue::Forbidden };
@@ -93,12 +94,12 @@ pub static ALL_ARGS: Args = Args(&[
     &WIDTH, &NO_QUOTES, &ABSOLUTE,
 
     &ALL, &ALMOST_ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
-    &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS, &ONLY_FILES,
+    &IGNORE_GLOB, &GIT_IGNORE, &IGNORE_SUBMODULE_CONTENTS, &ONLY_DIRS, &ONLY_FILES,
 
     &BINARY, &BYTES, &GROUP, &NUMERIC, &HEADER, &ICONS, &INODE, &LINKS, &MODIFIED, &CHANGED,
     &BLOCKSIZE, &TOTAL_SIZE, &TIME, &ACCESSED, &CREATED, &TIME_STYLE, &HYPERLINK, &MOUNTS,
     &NO_PERMISSIONS, &NO_FILESIZE, &NO_USER, &NO_TIME, &SMART_GROUP,
 
     &GIT, &NO_GIT, &GIT_REPOS, &GIT_REPOS_NO_STAT,
-    &EXTENDED, &OCTAL, &SECURITY_CONTEXT, &STDIN, &FILE_FLAGS
+    &EXTENDED, &OCTAL, &SECURITY_CONTEXT, &STDIN, &FILE_FLAGS,
 ]);

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -8,88 +8,89 @@ static USAGE_PART1: &str = "Usage:
   eza [options] [files...]
 
 META OPTIONS
-  --help                     show list of command-line options
-  -v, --version              show version of eza
+  --help                       show list of command-line options
+  -v, --version                show version of eza
 
 DISPLAY OPTIONS
-  -1, --oneline              display one entry per line
-  -l, --long                 display extended file metadata as a table
-  -G, --grid                 display entries as a grid (default)
-  -x, --across               sort the grid across, rather than downwards
-  -R, --recurse              recurse into directories
-  -T, --tree                 recurse into directories as a tree
-  -X, --dereference          dereference symbolic links when displaying information
-  -F, --classify=WHEN        display type indicator by file names (always, auto, never)
-  --colo[u]r=WHEN            when to use terminal colours (always, auto, never)
-  --colo[u]r-scale           highlight levels of 'field' distinctly(all, age, size)
-  --colo[u]r-scale-mode      use gradient or fixed colors in --color-scale (fixed, gradient)
-  --icons=WHEN               when to display icons (always, auto, never)
-  --no-quotes                don't quote file names with spaces
-  --hyperlink                display entries as hyperlinks
-  --absolute                 display entries with their absolute path (on, follow, off)
-  -w, --width COLS           set screen width in columns
+  -1, --oneline                display one entry per line
+  -l, --long                   display extended file metadata as a table
+  -G, --grid                   display entries as a grid (default)
+  -x, --across                 sort the grid across, rather than downwards
+  -R, --recurse                recurse into directories
+  -T, --tree                   recurse into directories as a tree
+  -X, --dereference            dereference symbolic links when displaying information
+  -F, --classify=WHEN          display type indicator by file names (always, auto, never)
+  --colo[u]r=WHEN              when to use terminal colours (always, auto, never)
+  --colo[u]r-scale             highlight levels of 'field' distinctly(all, age, size)
+  --colo[u]r-scale-mode        use gradient or fixed colors in --color-scale (fixed, gradient)
+  --icons=WHEN                 when to display icons (always, auto, never)
+  --no-quotes                  don't quote file names with spaces
+  --hyperlink                  display entries as hyperlinks
+  --absolute                   display entries with their absolute path (on, follow, off)
+  -w, --width COLS             set screen width in columns
 
 
 FILTERING AND SORTING OPTIONS
-  -a, --all                  show hidden and 'dot' files. Use this twice to also
-                             show the '.' and '..' directories
-  -A, --almost-all           equivalent to --all; included for compatibility with `ls -A`
-  -d, --list-dirs            list directories as files; don't list their contents
-  -L, --level DEPTH          limit the depth of recursion
-  -r, --reverse              reverse the sort order
-  -s, --sort SORT_FIELD      which field to sort by
-  --group-directories-first  list directories before other files
-  -D, --only-dirs            list only directories
-  -f, --only-files           list only files
-  -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore";
+  -a, --all                    show hidden and 'dot' files. Use this twice to also
+                               show the '.' and '..' directories
+  -A, --almost-all             equivalent to --all; included for compatibility with `ls -A`
+  -d, --list-dirs              list directories as files; don't list their contents
+  -L, --level DEPTH            limit the depth of recursion
+  -r, --reverse                reverse the sort order
+  -s, --sort SORT_FIELD        which field to sort by
+  --group-directories-first    list directories before other files
+  -D, --only-dirs              list only directories
+  -f, --only-files             list only files
+  -I, --ignore-glob GLOBS      glob patterns (pipe-separated) of files to ignore";
 
 static GIT_FILTER_HELP: &str = "  \
-  --git-ignore               ignore files mentioned in '.gitignore'";
+  --git-ignore                 ignore files mentioned in '.gitignore
+  --ignore-submodule-contents  do not list contents of submodules";
 
 static USAGE_PART2: &str = "  \
-  Valid sort fields:         name, Name, extension, Extension, size, type,
-                             modified, accessed, created, inode, and none.
-                             date, time, old, and new all refer to modified.
+  Valid sort fields:           name, Name, extension, Extension, size, type,
+                               modified, accessed, created, inode, and none.
+                               date, time, old, and new all refer to modified.
 
 LONG VIEW OPTIONS
-  -b, --binary               list file sizes with binary prefixes
-  -B, --bytes                list file sizes in bytes, without any prefixes
-  -g, --group                list each file's group
-  --smart-group              only show group if it has a different name from owner
-  -h, --header               add a header row to each column
-  -H, --links                list each file's number of hard links
-  -i, --inode                list each file's inode number
-  -m, --modified             use the modified timestamp field
-  -M, --mounts               show mount details (Linux and Mac only)
-  -n, --numeric              list numeric user and group IDs
-  -O, --flags                list file flags (Mac, BSD, and Windows only)
-  -S, --blocksize            show size of allocated file system blocks
-  -t, --time FIELD           which timestamp field to list (modified, accessed, created)
-  -u, --accessed             use the accessed timestamp field
-  -U, --created              use the created timestamp field
-  --changed                  use the changed timestamp field
-  --time-style               how to format timestamps (default, iso, long-iso,
-                             full-iso, relative, or a custom style '+<FORMAT>'
-                             like '+%Y-%m-%d %H:%M')
-  --total-size               show the size of a directory as the size of all
-                             files and directories inside (unix only)
-  --no-permissions           suppress the permissions field
-  -o, --octal-permissions    list each file's permission in octal format
-  --no-filesize              suppress the filesize field
-  --no-user                  suppress the user field
-  --no-time                  suppress the time field
-  --stdin                    read file names from stdin, one per line or other separator 
-                             specified in environment";
+  -b, --binary                 list file sizes with binary prefixes
+  -B, --bytes                  list file sizes in bytes, without any prefixes
+  -g, --group                  list each file's group
+  --smart-group                only show group if it has a different name from owner
+  -h, --header                 add a header row to each column
+  -H, --links                  list each file's number of hard links
+  -i, --inode                  list each file's inode number
+  -m, --modified               use the modified timestamp field
+  -M, --mounts                 show mount details (Linux and Mac only)
+  -n, --numeric                list numeric user and group IDs
+  -O, --flags                  list file flags (Mac, BSD, and Windows only)
+  -S, --blocksize              show size of allocated file system blocks
+  -t, --time FIELD             which timestamp field to list (modified, accessed, created)
+  -u, --accessed               use the accessed timestamp field
+  -U, --created                use the created timestamp field
+  --changed                    use the changed timestamp field
+  --time-style                 how to format timestamps (default, iso, long-iso,
+                               full-iso, relative, or a custom style '+<FORMAT>'
+                               like '+%Y-%m-%d %H:%M')
+  --total-size                 show the size of a directory as the size of all
+                               files and directories inside (unix only)
+  --no-permissions             suppress the permissions field
+  -o, --octal-permissions      list each file's permission in octal format
+  --no-filesize                suppress the filesize field
+  --no-user                    suppress the user field
+  --no-time                    suppress the time field
+  --stdin                      read file names from stdin, one per line or other separator 
+                               specified in environment";
 
 static GIT_VIEW_HELP: &str = "  \
-  --git                      list each file's Git status, if tracked or ignored
-  --no-git                   suppress Git status (always overrides --git,
-                             --git-repos, --git-repos-no-status)
-  --git-repos                list root of git-tree status";
+  --git                        list each file's Git status, if tracked or ignored
+  --no-git                     suppress Git status (always overrides --git,
+                               --git-repos, --git-repos-no-status)
+  --git-repos                  list root of git-tree status";
 static EXTENDED_HELP: &str = "  \
-  -@, --extended             list each file's extended attributes and sizes";
+  -@, --extended               list each file's extended attributes and sizes";
 static SECATTR_HELP: &str = "  \
-  -Z, --context              list each file's security context";
+  -Z, --context                list each file's security context";
 
 /// All the information needed to display the help text, which depends
 /// on which features are enabled and whether the user only wants to

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -195,11 +195,15 @@ impl Options {
     fn deduce<V: Vars>(matches: &MatchedFlags<'_>, vars: &V) -> Result<Self, OptionsError> {
         if cfg!(not(feature = "git"))
             && matches
-                .has_where_any(|f| f.matches(&flags::GIT) || f.matches(&flags::GIT_IGNORE))
+                .has_where_any(|f| {
+                    f.matches(&flags::GIT)
+                        || f.matches(&flags::GIT_IGNORE)
+                        || f.matches(&flags::IGNORE_SUBMODULE_CONTENTS)
+                })
                 .is_some()
         {
             return Err(OptionsError::Unsupported(String::from(
-                "Options --git and --git-ignore can't be used because `git` feature was disabled in this build of exa"
+                "Options --git, --git-ignore, and --ignore-submodule-contents can't be used because `git` feature was disabled in this build of exa"
             )));
         }
 

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -167,7 +167,9 @@ impl Options {
     /// status column. It’s only worth trying to discover a repository if the
     /// results will end up being displayed.
     pub fn should_scan_for_git(&self) -> bool {
-        if self.filter.git_ignore == GitIgnore::CheckAndIgnore {
+        if self.filter.git_ignore == GitIgnore::CheckAndIgnore
+            || self.filter.ignore_submodule_contents
+        {
             return true;
         }
 

--- a/src/output/color_scale.rs
+++ b/src/output/color_scale.rs
@@ -41,6 +41,7 @@ impl ColorScaleInformation {
         dot_filter: DotFilter,
         git: Option<&GitCache>,
         git_ignoring: bool,
+        ignoring_submodule_contents: bool,
         r: Option<RecurseOptions>,
     ) -> Option<Self> {
         if color_scale.mode == ColorScaleMode::Fixed {
@@ -61,6 +62,7 @@ impl ColorScaleInformation {
                 dot_filter,
                 git,
                 git_ignoring,
+                ignoring_submodule_contents,
                 TreeDepth::root(),
                 r,
             );
@@ -108,6 +110,7 @@ fn update_information_recursively(
     dot_filter: DotFilter,
     git: Option<&GitCache>,
     git_ignoring: bool,
+    ignoring_submodule_contents: bool,
     depth: TreeDepth,
     r: Option<RecurseOptions>,
 ) {
@@ -150,6 +153,15 @@ fn update_information_recursively(
             && file.name != "."
             && file.name != ".."
         {
+            if ignoring_submodule_contents
+                && git
+                    .as_ref()
+                    .map(|g| g.has_in_submodule(&file.path))
+                    .unwrap_or(false)
+            {
+                continue;
+            }
+
             match file.to_dir() {
                 Ok(dir) => {
                     let files: Vec<File<'_>> = dir
@@ -163,6 +175,7 @@ fn update_information_recursively(
                         dot_filter,
                         git,
                         git_ignoring,
+                        ignoring_submodule_contents,
                         depth.deeper(),
                         r,
                     );

--- a/src/output/color_scale.rs
+++ b/src/output/color_scale.rs
@@ -153,17 +153,17 @@ fn update_information_recursively(
             && file.name != "."
             && file.name != ".."
         {
-            if ignoring_submodule_contents
-                && git
-                    .as_ref()
-                    .map(|g| g.has_in_submodule(&file.path))
-                    .unwrap_or(false)
-            {
-                continue;
-            }
-
             match file.to_dir() {
                 Ok(dir) => {
+                    if ignoring_submodule_contents
+                        && git
+                            .as_ref()
+                            .map(|g| g.has_in_submodule(&file.path))
+                            .unwrap_or(false)
+                    {
+                        continue;
+                    }
+
                     let files: Vec<File<'_>> = dir
                         .files(dot_filter, git, git_ignoring, false, false)
                         .flatten()

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -80,6 +80,9 @@ pub struct Render<'a> {
     pub console_width: usize,
 
     pub git_repos: bool,
+
+    /// Whether we are skipping recursing into submodules.
+    pub ignoring_submodule_contents: bool,
 }
 
 impl<'a> Render<'a> {
@@ -102,6 +105,7 @@ impl<'a> Render<'a> {
             git_ignoring:  self.git_ignoring,
             git:           self.git,
             git_repos:     self.git_repos,
+            ignoring_submodule_contents: self.ignoring_submodule_contents,
         };
     }
 
@@ -123,6 +127,7 @@ impl<'a> Render<'a> {
             self.filter.dot_filter,
             self.git,
             self.git_ignoring,
+            self.ignoring_submodule_contents,
             None,
         );
 

--- a/tests/gen/ignore_submodule_contents_long_recursive.toml
+++ b/tests/gen/ignore_submodule_contents_long_recursive.toml
@@ -1,0 +1,2 @@
+bin.name = "eza"
+args = "tests/test_dir/with_submodule -R --long --ignore-submodule-contents"

--- a/tests/gen/ignore_submodule_contents_recursive.toml
+++ b/tests/gen/ignore_submodule_contents_recursive.toml
@@ -1,0 +1,2 @@
+bin.name = "eza"
+args = "tests/test_dir/with_submodule -R --ignore-submodule-contents"

--- a/tests/gen/ignore_submodule_contents_recursive_symlink.toml
+++ b/tests/gen/ignore_submodule_contents_recursive_symlink.toml
@@ -1,0 +1,2 @@
+bin.name = "eza"
+args = "tests/test_dir/with_submodule_symlink -R --ignore-submodule-contents"

--- a/tests/gen/ignore_submodule_contents_tree.toml
+++ b/tests/gen/ignore_submodule_contents_tree.toml
@@ -1,0 +1,2 @@
+bin.name = "eza"
+args = "tests/test_dir/with_submodule --tree --ignore-submodule-contents"


### PR DESCRIPTION
## Problem

Resolves #420.

## Solution

Add --ignore-submodule-contents. I don't call it --ignore-submodules, since it doesn't solve https://github.com/ogham/exa/issues/1155. Actually that issue is asking for a different feature which could be called --ignore-submodule-status.

## Testing

Tested in combination with other flags as well as through symlinks, both manually and in `tests/gen`. Updated `powertest.yaml`. Also tested manually through `..`.