### PR TITLE
feat: add icon for "cron.minutely" directory

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -136,6 +136,7 @@ const DIRECTORY_ICONS: Map<&'static str, char> = phf_map! {
     "cron.d"              => Icons::FOLDER_CONFIG,  // 
     "cron.daily"          => Icons::FOLDER_CONFIG,  // 
     "cron.hourly"         => Icons::FOLDER_CONFIG,  // 
+    "cron.minutely"       => Icons::FOLDER_CONFIG,  // 
     "cron.monthly"        => Icons::FOLDER_CONFIG,  // 
     "cron.weekly"         => Icons::FOLDER_CONFIG,  // 
     "Desktop"             => '\u{f108}',            // 


### PR DESCRIPTION
Cron optionally allows you to use a '/etc/cron.minutely' directory to trigger automated events on a per-minute basis.

There is currently no special icon set for cron.minutely, while the other cron.* directories do, so I added cron.minutely to the DIRECTORY_ICONS mapping and applied the `Icons::FOLDER_CONFIG` icon like the other cron.* directories.

I have tested it with `cargo check` and `cargo build`.
I apologize if I made any mistakes. I'm not too familiar with GitHub.