### PR TITLE
docs(readme) command line options section: add link to man pages + fix  structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ specific installation instructions can be found in [INSTALL.md](INSTALL.md).
 <h1>Command-line options</h1>
 </a>
 
-eza’s options are almost, but not quite, entirely unlike `ls`’s.
+eza’s options are almost, but not quite, entirely unlike `ls`’s. Quick overview:
 
 ## Display options
 
@@ -162,7 +162,7 @@ Some of the options accept parameters:
 
 </details>
 
-See the `man` pages for more. They are available
+See the `man` pages for further documentation of usage. They are available
 - online [in the repo](https://github.com/eza-community/eza/tree/main/man)
 - in your terminal via `man eza`, as of version [`[0.18.13] - 2024-04-25`](https://github.com/eza-community/eza/blob/main/CHANGELOG.md#01813---2024-04-25)
 

--- a/README.md
+++ b/README.md
@@ -69,18 +69,16 @@ specific installation instructions can be found in [INSTALL.md](INSTALL.md).
 
 ---
 
-Click sections to expand.
-
 <a id="options">
-<details>
-    <summary> Command-line options </summary>
-
 <h1>Command-line options</h1>
 </a>
 
 eza’s options are almost, but not quite, entirely unlike `ls`’s.
 
 ## Display options
+
+<details>
+<summary>Click to expand</summary>
 
 - **-1**, **--oneline**: display one entry per line
 - **-G**, **--grid**: display entries as a grid (default)
@@ -97,7 +95,12 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s.
 - **--absolute=(mode)**: display entries with their absolute path (on, follow, off)
 - **-w**, **--width=(columns)**: set screen width in columns
 
+</details>
+
 ## Filtering options
+
+<details>
+<summary>Click to expand</summary>
 
 - **-a**, **--all**: show hidden and 'dot' files
 - **-d**, **--list-dirs**: list directories like regular files
@@ -112,7 +115,12 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s.
 
 Pass the `--all` option twice to also show the `.` and `..` directories.
 
+</details>
+
 ## Long view options
+
+<details>
+<summary>Click to expand</summary>
 
 These options are available when running with `--long` (`-l`):
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Some of the options accept parameters:
 
 </details>
 
+See the `man` pages for more. They are available
+- online [in the repo](https://github.com/eza-community/eza/tree/main/man)
+- in your terminal via `man eza`, as of version [`[0.18.13] - 2024-04-25`](https://github.com/eza-community/eza/blob/main/CHANGELOG.md#01813---2024-04-25)
+
 # Hacking on eza
 
 If you wanna contribute to eza, firstly, you're expected to follow our 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Click sections to expand.
 
 eza’s options are almost, but not quite, entirely unlike `ls`’s.
 
-### Display options
+## Display options
 
 - **-1**, **--oneline**: display one entry per line
 - **-G**, **--grid**: display entries as a grid (default)
@@ -97,7 +97,7 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s.
 - **--absolute=(mode)**: display entries with their absolute path (on, follow, off)
 - **-w**, **--width=(columns)**: set screen width in columns
 
-### Filtering options
+## Filtering options
 
 - **-a**, **--all**: show hidden and 'dot' files
 - **-d**, **--list-dirs**: list directories like regular files
@@ -112,7 +112,7 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s.
 
 Pass the `--all` option twice to also show the `.` and `..` directories.
 
-### Long view options
+## Long view options
 
 These options are available when running with `--long` (`-l`):
 


### PR DESCRIPTION
##### Description
`<!--- Describe your changes in detail -->`

1. Added link to the man pages in repo readme
2. Inserted a couple keywords typically associated with instructions
3. Also while I was there: 
  - Fixed the heading hierarchy 
  - Removed the entire "Command-line options" section from being in a `<details>` collapsible section. Instead made the content of the 3 subheadings collapsed which I infer from the wording was the original intention.

`<!--- Why is this change required? What problem does it solve? -->`

1. man pages are easy to miss and not widely available elsewhere
2. keywords ("quick", "overview", "documentation") that I thought would help someone find the instructional section using `ctrl`-`f`. Since content is still mostly collapsed it isn't visible when you quickly scroll the page.
3. The whole section being collapsed makes it difficult to notice the useage information. It breaks the anchor-based navigation and the popup menu on github.com. 

Hope it's OK to have added 2 and 3 at the same time; seems kind of minor to open an independent issue for. I tried to make the commits structured so they are independent in case it's unwanted.

`<!--- If it fixes an open issue, please link to the issue here. -->`

#967 

##### How Has This Been Tested?

I did not test this other than looking at it. I hope it's OK. If not, please discard this PR because I probably won't be able to set up a whole dev environment. If you wish to make use of the content somehow please do so in whatever fashion if most expedient.
