### PR TITLE
docs(man): replace decay with color-scale

### DIFF
--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -330,7 +330,7 @@ For more information on the format of these environment variables, see the [eza_
 Overrides any `--git` or `--git-repos` argument
 
 ## `EZA_MIN_LUMINANCE`
-Specifies the minimum luminance to use when decay is active. It's value can be between -100 to 100.
+Specifies the minimum luminance to use when color-scale is active. It's value can be between -100 to 100.
 
 ## `EZA_ICONS_AUTO`
 


### PR DESCRIPTION
I believe this feature changed name sometimes during development, but it's still called decay in the description of EZA_MIN_LUMINANCE, which confused me while I read the man page.