### PR TITLE
feat: add non-nix pre-commit rustfmt and clippy hooks

### DIFF
--- a/.pre-commit-config-non-nix.yaml
+++ b/.pre-commit-config-non-nix.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: local
+    hooks:
+      - id: rust-linting
+        name: Rust linting
+        description: Run rustfmt on included files
+        entry: cargo fmt --
+        types: [file, rust]
+        language: system
+      - id: rust-clippy
+        name: Rust clippy
+        description: Run clippy on included files
+        entry: cargo clippy --workspace --all-targets --all-features --
+        types: [file, rust]
+        language: system

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,11 @@ Some useful commands include:
   pre-commit-hooks.nix
 - `just itest`: runs integration tests
 
+**For non-nix users,**
+There are traditional `pre-commit` hooks, which you can install with your system package manager or
+`brew|pip install pre-commit`, and run `pre-commit install -c .pre-commit-config-non-nix.yaml` in the root of the repository.
+Then these hooks will run automatically when you commit.
+
 The [just](https://github.com/casey/just) command runner can be used to run some
 helpful development commands, in a manner similar to `make`.  Run `just --list`
 to get an overview of what’s available.


### PR DESCRIPTION
For those of us who don't use nix on a daily basis, it's nice to have the option of getting `rustfmt` + `clippy` running before we commit.