### PR TITLE
feat(icons): add icon for Nushell extension

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -604,6 +604,7 @@ const EXTENSION_ICONS: Map<&'static str, char> = phf_map! {
     "ninja"          => '\u{f0774}',             // 󰝴
     "nix"            => '\u{f313}',              // 
     "node"           => Icons::NODEJS,           // 
+    "nu"             => Icons::SHELL_CMD,        // 
     "o"              => Icons::BINARY,           // 
     "obj"            => Icons::FILE_3D,          // 󰆧
     "odf"            => '\u{f0784}',             // 󰞄


### PR DESCRIPTION
This PR adds support (icon) for the [Nushell](https://github.com/nushell/nushell) extension, i.e. `nu`