### PR TITLE
feat: add --no-|show-symlinks flags for filtering output

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s. Quick overv
 - **--group-directories-first**: list directories before other files
 - **-D**, **--only-dirs**: list only directories
 - **-f**, **--only-files**: list only files
+- **--no-symlinks**: don't show symbolic links
+- **--show-symlinks**: explicitly show links (with `--only-dirs`, `--only-files`, to show symlinks that match the filter)
 - **--git-ignore**: ignore files mentioned in `.gitignore`
 - **-I**, **--ignore-glob=(globs)**: glob patterns (pipe-separated) of files to ignore
 

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -81,6 +81,8 @@ complete -c eza -s s -l sort -d "Which field to sort by" -x -a "
 complete -c eza -s I -l ignore-glob -d "Ignore files that match these glob patterns" -r
 complete -c eza -s D -l only-dirs -d "List only directories"
 complete -c eza -s f -l only-files -d "List only files"
+complete -c eza -l show-symlinks -d "Explicitly show symbolic links (For use with --only-dirs | --only-files)"
+complete -c eza -l no-symlinks -d "Do not show symbolic links"
 
 # Long view options
 complete -c eza -s b -l binary -d "List file sizes with binary prefixes"

--- a/completions/nush/eza.nu
+++ b/completions/nush/eza.nu
@@ -30,6 +30,8 @@ export extern "eza" [
     --sort(-s)                 # Which field to sort by
     --only-dirs(-D)            # List only directories
     --only-files(-f)           # List only files
+    --show-symlinks            # Explicitly show symbolic links (for use with --only-dirs | --only-files)
+    --no-symlinks              # Do not show symbolic links
     --binary(-b)               # List file sizes with binary prefixes
     --bytes(-B)                # List file sizes in bytes, without any prefixes
     --group(-g)                # List each file's group

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -33,6 +33,8 @@ __eza() {
         {-A,--almost-all}"[Equivalent to --all; included for compatibility with \'ls -A\']" \
         {-d,--list-dirs}"[List directories like regular files]" \
         {-D,--only-dirs}"[List only directories]" \
+        --no-symlinks"[Do not show symbolic links]"
+        --show-symlinks"[Explictly show symbolic links: for use with '--only-dirs'| '--only-files']"
         {-f,--only-files}"[List only files]" \
         {-L,--level}"+[Limit the depth of recursion]" \
         {-w,--width}"+[Limits column output of grid, 0 implies auto-width]" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -166,6 +166,11 @@ Sort fields starting with a capital letter will sort uppercase before lowercase:
 `-f`, `--only-files`
 : List only files, not directories.
 
+`--show-symlinks`
+: Explicitly show symbolic links (when used with `--only-files` | `--only-dirs`)
+
+`--no-symlinks`
+: Do not show symbolic links
 
 LONG VIEW OPTIONS
 =================

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -18,6 +18,8 @@ impl FileFilter {
             (matches.has(&flags::REVERSE)?, FFF::Reverse),
             (matches.has(&flags::ONLY_DIRS)?, FFF::OnlyDirs),
             (matches.has(&flags::ONLY_FILES)?, FFF::OnlyFiles),
+            (matches.has(&flags::NO_SYMLINKS)?, FFF::NoSymlinks),
+            (matches.has(&flags::SHOW_SYMLINKS)?, FFF::ShowSymlinks),
         ] {
             if *has {
                 filter_flags.push(flag.clone());
@@ -27,6 +29,8 @@ impl FileFilter {
         #[rustfmt::skip]
         return Ok(Self {
             list_dirs_first:  matches.has(&flags::DIRS_FIRST)?,
+            no_symlinks:      filter_flags.contains(&FFF::NoSymlinks),
+            show_symlinks:    filter_flags.contains(&FFF::ShowSymlinks),
             flags: filter_flags,
             sort_field:       SortField::deduce(matches)?,
             dot_filter:       DotFilter::deduce(matches)?,

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -41,6 +41,8 @@ pub static GIT_IGNORE:  Arg = Arg { short: None, long: "git-ignore",           t
 pub static DIRS_FIRST:  Arg = Arg { short: None, long: "group-directories-first",  takes_value: TakesValue::Forbidden };
 pub static ONLY_DIRS:   Arg = Arg { short: Some(b'D'), long: "only-dirs", takes_value: TakesValue::Forbidden };
 pub static ONLY_FILES:  Arg = Arg { short: Some(b'f'), long: "only-files", takes_value: TakesValue::Forbidden };
+pub static NO_SYMLINKS: Arg = Arg { short: None,       long: "no-symlinks", takes_value: TakesValue::Forbidden };
+pub static SHOW_SYMLINKS: Arg = Arg { short: None,     long: "show-symlinks", takes_value: TakesValue::Forbidden };
 const SORTS: Values = &[ "name", "Name", "size", "extension",
                          "Extension", "modified", "changed", "accessed",
                          "created", "inode", "type", "none" ];
@@ -97,7 +99,7 @@ pub static ALL_ARGS: Args = Args(&[
 
     &BINARY, &BYTES, &GROUP, &NUMERIC, &HEADER, &ICONS, &INODE, &LINKS, &MODIFIED, &CHANGED,
     &BLOCKSIZE, &TOTAL_SIZE, &TIME, &ACCESSED, &CREATED, &TIME_STYLE, &HYPERLINK, &MOUNTS,
-    &NO_PERMISSIONS, &NO_FILESIZE, &NO_USER, &NO_TIME, &SMART_GROUP,
+    &NO_PERMISSIONS, &NO_FILESIZE, &NO_USER, &NO_TIME, &SMART_GROUP, &NO_SYMLINKS, &SHOW_SYMLINKS,
 
     &GIT, &NO_GIT, &GIT_REPOS, &GIT_REPOS_NO_STAT,
     &EXTENDED, &OCTAL, &SECURITY_CONTEXT, &STDIN, &FILE_FLAGS


### PR DESCRIPTION
Currently you can use `--only-dirs` and get only directory output, or you can use `--only-files` and get only files. 

Someone requested the ability to hide symlinks (for some MacOS feature where they use symlinks to make their directory structure more unix-like), but I think it makes more sense to also be able to filter and get all directories or all files (symlinks or otherwise), as well as hide symlinks in normal output. 

