### PR TITLE
fix: implement `EZA_GRID_ROWS` grid details view minimum rows threshold

### DIFF
--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -143,11 +143,11 @@ impl<'a> Render<'a> {
 
         let cells = rows
             .into_iter()
-            .zip(self.files)
+            .zip(&self.files)
             .map(|(row, file)| {
                 let filename = self
                     .file_style
-                    .for_file(&file, self.theme)
+                    .for_file(file, self.theme)
                     .paint()
                     .strings()
                     .to_string();
@@ -177,6 +177,41 @@ impl<'a> Render<'a> {
                 width: self.console_width,
             },
         );
+
+        // If a minimum grid rows threshold has been set
+        // via the `EZA_GRID_ROWS` environment variable
+        // and the grid is going to get rendered with fewer rows,
+        // then render a details list view instead.
+        if let RowThreshold::MinimumRows(minimum_rows) = self.row_threshold {
+            if grid.row_count() < minimum_rows {
+                let Self {
+                    dir,
+                    files,
+                    theme,
+                    file_style,
+                    details: opts,
+                    filter,
+                    git_ignoring,
+                    git,
+                    git_repos,
+                    ..
+                } = self;
+
+                let r = DetailsRender {
+                    dir,
+                    files,
+                    theme,
+                    file_style,
+                    opts,
+                    recurse: None,
+                    filter,
+                    git_ignoring,
+                    git,
+                    git_repos,
+                };
+                return r.render(w);
+            }
+        }
 
         if self.details.header {
             let row = table.header_row();


### PR DESCRIPTION
Grid details view had been prevented only by console width being unavailable.

This changeset implements `EZA_GRID_ROWS` as secondary grid details inhibitor, preventing grid details view if the minimum rows threshold is not reached by the grid which would be rendered.

Fixes complaint at https://github.com/eza-community/eza/issues/66#issuecomment-2198567463

Side note: `EZA_GRID_ROWS` only applies to `--long --grid`, but not to _non-details_ `--grid` view. Looking at the code and [documentation](https://github.com/eza-community/eza/issues/1044#issuecomment-2200573562), this appears to be intentional.