### PR TITLE
feat: determine system locale to use in locale-aware unicode sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +405,7 @@ dependencies = [
  "criterion",
  "git2",
  "glob",
+ "icu_locid",
  "libc",
  "locale",
  "log",
@@ -530,6 +542,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +660,12 @@ name = "linux-raw-sys"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "locale"
@@ -1221,6 +1251,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1710e589de0a76aaf295cd47a6699f6405737dbfd3cf2b75c92d000b548d0e6"
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1659,12 @@ checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "zoneinfo_compiled"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ name = "eza"
 nu-ansi-term = "0.50.0"
 chrono = { version = "0.4.34", default-features = false, features = ["clock"] }
 glob = "0.3"
+icu_locid = "1.5.0"
 libc = "0.2"
 locale = "0.2"
 log = "0.4"


### PR DESCRIPTION
Prerequisite to an implementation of [#1006][1] following the example of [tidy's `sort_carefully`][2] using [`icu::collator::Collator`][3].

[1]: https://github.com/eza-community/eza/issues/1006
[2]: https://github.com/sts10/tidy/blob/main/src/list_manipulations.rs#L24
[3]: https://docs.rs/icu_collator/1.5.0/icu_collator/index.html