### PR TITLE
Add Flox to installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -198,6 +198,16 @@ To install eza, run:
 scoop install eza
 ```
 
+### Flox (Linux, macOS, Windows WSL)
+
+Eza is available from [Flox](https://flox.dev).
+
+To install eza, run:
+
+```shell
+flox install eza
+```
+
 ### Completions
 
 #### For zsh:


### PR DESCRIPTION
Eza is currently available and working in Flox.
Sadly, no repology badge for Flox just yet.