### PR TITLE
fix: FreeBSD build.

### DIFF
--- a/.github/workflows/unit-tests-bsd.yml
+++ b/.github/workflows/unit-tests-bsd.yml
@@ -21,30 +21,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # BUG: These tests are broken
-  # unit-tests-freebsd:
-  #     runs-on: ubuntu-22.04
-  #     timeout-minutes: 20
-  #     steps:
-  #       - uses: actions/checkout@v4
-  #         with:
-  #           submodules: recursive
-  #       - name: Compile
-  #         uses: vmactions/freebsd-vm@v1
-  #         with:
-  #           release: '14.1'
-  #           usesh: true
-  #           prepare: |
-  #             pkg install -y rust git
-  #             cargo install cargo-hack
-  #             git config --global --add safe.directory /home/runner/work/eza/eza
-  #           run: |
-  #             set -e
-  #             export CARGO_TERM_COLOR="always"
-  #             export RUSTFLAGS="--deny warnings"
-  #             cargo fmt --check
-  #             cargo clippy -- -D warnings
-  #             cargo hack test
+  unit-tests-freebsd:
+      runs-on: ubuntu-22.04
+      timeout-minutes: 20
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            submodules: recursive
+        - name: Compile
+          uses: vmactions/freebsd-vm@v1
+          with:
+            release: '14.1'
+            usesh: true
+            prepare: |
+              pkg install -y rust git
+              cargo install cargo-hack
+              git config --global --add safe.directory /home/runner/work/eza/eza
+            run: |
+              set -e
+              export CARGO_TERM_COLOR="always"
+              export RUSTFLAGS="--deny warnings"
+              cargo fmt --check
+              cargo clippy -- -D warnings
+              cargo hack test
 
   unit-tests-netbsd:
     runs-on: ubuntu-22.04

--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -106,7 +106,7 @@ pub struct GitRepo {
     workdir: PathBuf,
 
     /// The path that was originally checked to discover this repository.
-    /// This is as important as the extra_paths (it gets checked first), but
+    /// This is as important as the `extra_paths` (it gets checked first), but
     /// is separate to avoid having to deal with a non-empty Vec.
     original_path: PathBuf,
 

--- a/src/fs/fields.rs
+++ b/src/fs/fields.rs
@@ -82,6 +82,7 @@ pub struct Permissions {
 /// The file's `FileAttributes` field, available only on Windows.
 #[derive(Copy, Clone)]
 #[rustfmt::skip]
+#[cfg(windows)]
 pub struct Attributes {
     pub archive:         bool,
     pub directory:       bool,

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -99,7 +99,7 @@ pub struct File<'dir> {
     /// instead.
     pub deref_links: bool,
 
-    /// The recursive directory size when total_size is used.
+    /// The recursive directory size when `total_size` is used.
     recursive_size: RecursiveSize,
 
     /// The extended attributes of this file.

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -126,7 +126,7 @@ pub struct Render<'a> {
 
     /// Whether to recurse through directories with a tree view, and if so,
     /// which options to use. This field is only relevant here if the `tree`
-    /// field of the RecurseOptions is `true`.
+    /// field of the `RecurseOptions` is `true`.
     pub recurse: Option<RecurseOptions>,
 
     /// How to sort and filter the files after getting their details.

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -70,6 +70,7 @@ pub struct Render<'a> {
 
     /// The minimum number of rows that there need to be before grid-details
     /// mode is activated.
+    #[allow(dead_code)]
     pub row_threshold: RowThreshold,
 
     /// Whether we are skipping Git-ignored files.


### PR DESCRIPTION
Address `clippy` warnings from FreeBSD builds, compiling under.

```
rustc 1.79.0 (129f3b996 2024-06-10) (built from a source tarball) 
```