### PR TITLE
fix: colors in old ms command prompt

### DIFF
--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -67,6 +67,19 @@ impl Options {
             let exts = Box::new(NoFileStyle);
             return Theme { ui, exts };
         };
+
+        #[cfg(windows)]
+        if nu_ansi_term::enable_ansi_support().is_err() {
+            // Failed to enable ansi support, probably because legacy mode console.
+            // No need to alert the user unless they explicitly set color=always
+            if self.use_colours == UseColours::Always {
+                eprintln!("eza: Ignoring option color=always in legacy console.");
+            }
+            let ui = UiStyles::plain();
+            let exts = Box::new(NoFileStyle);
+            return Theme { ui, exts };
+        }
+
         match self.theme_config {
             Some(ref theme) => {
                 if let Some(mut ui) = theme.to_theme() {


### PR DESCRIPTION
Description

Old ms windows command prompt cant directly handle all of the ansi terminal control codes.

How Has This Been Tested?

![image](https://github.com/user-attachments/assets/a2b77789-7270-4224-a9fa-6e7397a4fac3)

The fix is to use the following snippet, as per the upstream examples in the nu_ansi_term
```
    #[cfg(windows)]
    nu_ansi_term::enable_ansi_support().unwrap();
```