### PR TITLE
fix: selectively filter files when recursing

### DIFF
--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -85,7 +85,7 @@ pub struct FileFilter {
 impl FileFilter {
     /// Remove every file in the given vector that does *not* pass the
     /// filter predicate for files found inside a directory.
-#[rustfmt::skip]
+    #[rustfmt::skip]
     pub fn filter_child_files(&self, is_recurse: bool, files: &mut Vec<File<'_>>) {
         use FileFilterFlags::{NoSymlinks, OnlyDirs, OnlyFiles, ShowSymlinks};
 

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -356,7 +356,8 @@ impl<'a> Render<'a> {
                     }
                 }
 
-                self.filter.filter_child_files(&mut files);
+                self.filter
+                    .filter_child_files(self.recurse.is_some(), &mut files);
 
                 if !files.is_empty() {
                     for xattr in egg.xattrs {


### PR DESCRIPTION
fixes #1101 

![eza](https://github.com/user-attachments/assets/0ea48472-380f-4673-80a8-340b8e60bcc1)
