### PR TITLE
Simplify Colorization through Theme File

### DIFF
--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -263,7 +263,7 @@ impl FromOverride<FileKindsOverride> for FileKinds {
         FileKinds {
             normal: FromOverride::from(value.normal, default.normal),
             directory: FromOverride::from(value.directory, default.directory),
-            symlink: FromOverride::from(value.symlink, default.directory),
+            symlink: FromOverride::from(value.symlink, default.symlink),
             pipe: FromOverride::from(value.pipe, default.pipe),
             block_device: FromOverride::from(value.block_device, default.block_device),
             char_device: FromOverride::from(value.char_device, default.char_device),

--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -40,36 +40,47 @@ where
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Default)]
 pub struct StyleOverride {
     /// The style's foreground color, if it has one.
+    #[serde(alias = "fg")]
     pub foreground: Option<Color>,
 
     /// The style's background color, if it has one.
+    #[serde(alias = "bg")]
     pub background: Option<Color>,
 
     /// Whether this style is bold.
+    #[serde(alias = "bold")]
     pub is_bold: Option<bool>,
 
     /// Whether this style is dimmed.
+    #[serde(alias = "dimmed")]
     pub is_dimmed: Option<bool>,
 
     /// Whether this style is italic.
+    #[serde(alias = "italic")]
     pub is_italic: Option<bool>,
 
     /// Whether this style is underlined.
+    #[serde(alias = "underline")]
     pub is_underline: Option<bool>,
 
     /// Whether this style is blinking.
+    #[serde(alias = "blink")]
     pub is_blink: Option<bool>,
 
     /// Whether this style has reverse colors.
+    #[serde(alias = "reverse")]
     pub is_reverse: Option<bool>,
 
     /// Whether this style is hidden.
+    #[serde(alias = "hidden")]
     pub is_hidden: Option<bool>,
 
     /// Whether this style is struckthrough.
+    #[serde(alias = "strikethrough")]
     pub is_strikethrough: Option<bool>,
 
     /// Wether this style is always displayed starting with a reset code to clear any remaining style artifacts
+    #[serde(alias = "prefix_reset")]
     pub prefix_with_reset: Option<bool>,
 }
 

--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -38,11 +38,9 @@ where
 }
 
 #[rustfmt::skip]
-fn deserialize_color<'de, D>(deserializer: D) -> Result<Option<Color>, D::Error>
-where D: Deserializer<'de> {
+fn color_from_str(s: &str) -> Option<Color> {
     use Color::*;
-    let s: String = Deserialize::deserialize(deserializer)?;
-    Ok(match s.as_str() {
+    match s {
         // nothing
         "" | "none"    | "None"         => None,
 
@@ -72,33 +70,39 @@ where D: Deserializer<'de> {
             // #rrggbb hex color
             ['#', r1, r2, g1, g2, b1, b2] => {
                 let Ok(r) = u8::from_str_radix(&format!("{}{}", r1, r2), 16)
-                    else { return Ok(None) };
+                    else { return None };
                 let Ok(g) = u8::from_str_radix(&format!("{}{}", g1, g2), 16)
-                    else { return Ok(None) };
+                    else { return None };
                 let Ok(b) = u8::from_str_radix(&format!("{}{}", b1, b2), 16)
-                    else { return Ok(None) };
+                    else { return None };
                 Some(Rgb(r, g, b))
             },
             // #rgb shorthand hex color
             ['#', r, g, b]              => {
                 let Ok(r) = u8::from_str_radix(&format!("{}{}", r, r), 16)
-                    else { return Ok(None) };
+                    else { return None };
                 let Ok(g) = u8::from_str_radix(&format!("{}{}", g, g), 16)
-                    else { return Ok(None) };
+                    else { return None };
                 let Ok(b) = u8::from_str_radix(&format!("{}{}", b, b), 16)
-                    else { return Ok(None) };
+                    else { return None };
                 Some(Rgb(r, g, b))
             },
             // 0-255 color code
             [c1, c2] => {
                 let Ok(c) = u8::from_str_radix(&format!("{}{}", c1, c2), 10)
-                    else { return Ok(None) };
+                    else { return None };
                 Some(Fixed(c))
             },
             // unknown format
             _ => None,
         }
-    })
+    }
+}
+
+#[rustfmt::skip]
+fn deserialize_color<'de, D>(deserializer: D) -> Result<Option<Color>, D::Error>
+where D: Deserializer<'de> {
+    Ok(color_from_str(&String::deserialize(deserializer)?))
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Default)]

--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -1,7 +1,7 @@
 use crate::theme::ThemeFileType as FileType;
 use crate::theme::*;
 use nu_ansi_term::{Color, Style};
-use serde::{Deserialize, Serialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_yaml;
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -69,27 +69,27 @@ fn color_from_str(s: &str) -> Option<Color> {
         s => match s.chars().collect::<Vec<_>>()[..] {
             // #rrggbb hex color
             ['#', r1, r2, g1, g2, b1, b2] => {
-                let Ok(r) = u8::from_str_radix(&format!("{}{}", r1, r2), 16)
+                let Ok(r) = u8::from_str_radix(&format!("{r1}{r2}"), 16)
                     else { return None };
-                let Ok(g) = u8::from_str_radix(&format!("{}{}", g1, g2), 16)
+                let Ok(g) = u8::from_str_radix(&format!("{g1}{g2}"), 16)
                     else { return None };
-                let Ok(b) = u8::from_str_radix(&format!("{}{}", b1, b2), 16)
+                let Ok(b) = u8::from_str_radix(&format!("{b1}{b2}"), 16)
                     else { return None };
                 Some(Rgb(r, g, b))
             },
             // #rgb shorthand hex color
             ['#', r, g, b]              => {
-                let Ok(r) = u8::from_str_radix(&format!("{}{}", r, r), 16)
+                let Ok(r) = u8::from_str_radix(&format!("{r}{r}"), 16)
                     else { return None };
-                let Ok(g) = u8::from_str_radix(&format!("{}{}", g, g), 16)
+                let Ok(g) = u8::from_str_radix(&format!("{g}{g}"), 16)
                     else { return None };
-                let Ok(b) = u8::from_str_radix(&format!("{}{}", b, b), 16)
+                let Ok(b) = u8::from_str_radix(&format!("{b}{b}"), 16)
                     else { return None };
                 Some(Rgb(r, g, b))
             },
             // 0-255 color code
             [c1, c2] => {
-                let Ok(c) = u8::from_str_radix(&format!("{}{}", c1, c2), 10)
+                let Ok(c) = str::parse::<u8>(&format!("{c1}{c2}"))
                     else { return None };
                 Some(Fixed(c))
             },

--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -108,11 +108,11 @@ where D: Deserializer<'de> {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Default)]
 pub struct StyleOverride {
     /// The style's foreground color, if it has one.
-    #[serde(alias = "fg", deserialize_with = "deserialize_color")]
+    #[serde(alias = "fg", deserialize_with = "deserialize_color", default)]
     pub foreground: Option<Color>,
 
     /// The style's background color, if it has one.
-    #[serde(alias = "bg", deserialize_with = "deserialize_color")]
+    #[serde(alias = "bg", deserialize_with = "deserialize_color", default)]
     pub background: Option<Color>,
 
     /// Whether this style is bold.

--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -615,3 +615,50 @@ impl ThemeConfig {
         FromOverride::from(ui_styles_override, Some(UiStyles::default()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_none_color_from_string() {
+        ["", "none", "None"].iter().for_each(|case| {
+            assert_eq!(color_from_str(case), None);
+        });
+    }
+
+    #[test]
+    fn parse_default_color_from_string() {
+        ["default", "Default"].iter().for_each(|case| {
+            assert_eq!(color_from_str(case), Some(Color::Default));
+        });
+    }
+
+    #[test]
+    fn parse_fixed_color_from_string() {
+        ["black", "Black"].iter().for_each(|case| {
+            assert_eq!(color_from_str(case), Some(Color::Black));
+        });
+    }
+
+    #[test]
+    fn parse_long_hex_color_from_string() {
+        ["#ff00ff", "#FF00FF"].iter().for_each(|case| {
+            assert_eq!(color_from_str(case), Some(Color::Rgb(255, 0, 255)));
+        });
+    }
+
+    #[test]
+    fn parse_short_hex_color_from_string() {
+        ["#f0f", "#F0F"].iter().for_each(|case| {
+            assert_eq!(color_from_str(case), Some(Color::Rgb(255, 0, 255)));
+        });
+    }
+
+    #[test]
+    fn parse_color_code_from_string() {
+        [("10", 10), ("01", 1)].iter().for_each(|(s, c)| {
+            assert_eq!(color_from_str(s), Some(Color::Fixed(*c)));
+        });
+    }
+}


### PR DESCRIPTION
I'm currently working on an [eza-themes](https://github.com/eza-community/eza-themes) repo to test out theming, find issues and improve ergonomics. One thing in particular I noticed is the poor deserialization of the `Color` type. While hardcoded colors can simply be specified by name, e.g. `White`, working with specific RGB values isn't very pretty and requires to use custom YAML tags your editor is gonna complain about:

![Screenshot from 2024-09-02 21-43-15](https://github.com/user-attachments/assets/2a1de5c7-132a-4bcd-b648-d5a4b65d43df)

This PR adds a custom deserialization function that recognizes hardcoded colors, color codes and hex colors, all in upper- and lowercase writing, which makes theming significantly more intuitive:

![Screenshot from 2024-09-02 21-32-59](https://github.com/user-attachments/assets/89b76860-a7df-4067-a0ce-e95bc54494ed)

It also adds a few unittests to said function and fixes a typo elsewhere in the config module.

I would hold creating any themes in the currently still private [eza-themes](https://github.com/eza-community/eza-themes) repo until this is merged since this simplifies the process a lot.