### PR TITLE
fix: remove non_alpha from percent encoding to fix hyprlinks

### DIFF
--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -402,7 +402,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
         &self,
         style_override: Option<Style>,
     ) -> Vec<ANSIString<'unused>> {
-        use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+        use percent_encoding::{utf8_percent_encode, CONTROLS};
 
         const HYPERLINK_START: &str = "\x1B]8;;";
         const HYPERLINK_END: &str = "\x1B\x5C";
@@ -417,7 +417,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
                 .absolute_path()
                 .and_then(|p| p.as_os_str().to_str())
             {
-                let abs_path = utf8_percent_encode(abs_path, NON_ALPHANUMERIC).to_string();
+                let abs_path = utf8_percent_encode(abs_path, CONTROLS).to_string();
 
                 // On Windows, `std::fs::canonicalize` adds the Win32 File prefix, which we need to remove
                 #[cfg(target_os = "windows")]


### PR DESCRIPTION
fix #1131

Wasn't sure if we should revert or not