### PR TITLE
feat: add `opml` file extension

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -615,6 +615,7 @@ const EXTENSION_ICONS: Map<&'static str, char> = phf_map! {
     "ogg"            => Icons::AUDIO,            // 
     "ogm"            => Icons::VIDEO,            // 
     "ogv"            => Icons::VIDEO,            // 
+    "opml"           => Icons::XML,              // 󰗀
     "opus"           => Icons::AUDIO,            // 
     "orf"            => Icons::IMAGE,            // 
     "org"            => '\u{e633}',              // 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/OPML

> OPML (Outline Processor Markup Language) is an XML format for outlines.

`file` identifies a sample `.opml` file as "XML 1.0 document, Unicode text, UTF-8 text".