### PR TITLE
docs(install): add x-cmd method to install eza

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -210,6 +210,18 @@ To install eza, run:
 flox install eza
 ```
 
+### X-CMD (Linux, macOS, Windows WSL, Windows GitBash)
+
+Eza is available from [x-cmd](https://www.x-cmd.com).
+
+To install eza, run:
+
+```shell
+x env use eza
+# or
+x eza
+```
+
 ### Completions
 
 #### For zsh:


### PR DESCRIPTION
- Hi, [x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.. It helps you download eza release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the eza installation.md?**[The installation method for the x command](https://www.x-cmd.com/start/).
  ```sh
  x env use eza
  # or
  x eza
  ```

- We wrote a [eza introduction article](https://www.x-cmd.com/pkg/eza) and a [demo](https://www.x-cmd.com/1min/eza)