### PR TITLE
ci: full nix3 command output in logs

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Nix Flake Check
-        run: nix flake check --all-systems
+        run: nix flake check --all-systems -L
 
   build:
     name: Build Nix package
@@ -61,4 +61,4 @@ jobs:
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Nix Build
-        run: nix build .#packages.${{ matrix.target }}.default
+        run: nix build .#packages.${{ matrix.target }}.default -L


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Make sure you've read CONTRIBUTING.md and CODE_OF_CONDUCT.md -->
<!---  -->
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
##### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Consider including potentially useful screenshots of your feature in action -->

In #1146, I was made aware that we don't run the nix3 related CI command
with full logs displayed.

This adds the `-L` flag to those command invocations to address that.

Signed-off-by: Christina Sørensen <christina@cafkafk.com>

##### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This will be tested in the CI for the PR.
