### PR TITLE
Fix cross-references and colors in man pages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,7 @@
           # For `nix build` `nix run`, & `nix profile install`:
           default = naersk'.buildPackage rec {
             pname = "eza";
-            version = "latest";
+            version = "git";
 
             src = ./.;
             doCheck = true; # run `cargo test` on build
@@ -120,9 +120,10 @@
             buildFeatures = "git";
 
             postInstall = ''
-              pandoc --standalone -f markdown -t man <(cat "man/eza.1.md" | sed "s/\$version/${version}/g") > man/eza.1
-              pandoc --standalone -f markdown -t man <(cat "man/eza_colors.5.md" | sed "s/\$version/${version}/g") > man/eza_colors.5
-              pandoc --standalone -f markdown -t man <(cat "man/eza_colors-explanation.5.md" | sed "s/\$version/${version}/g")> man/eza_colors-explanation.5
+              for page in eza.1 eza_colors.5 eza_colors-explanation.5; do
+                sed "s/\$version/${version}/g" "man/$page.md" |
+                  pandoc --standalone -f markdown -t man >"man/$page"
+              done
               installManPage man/eza.1 man/eza_colors.5 man/eza_colors-explanation.5
               installShellCompletion \
                 --bash completions/bash/eza \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -376,5 +376,5 @@ Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors 
 SEE ALSO
 ========
 
-- [eza_colors.5.md](eza_colors.5.md)
-- [eza_colors-explanation.5.md](eza_colors-explanation.5.md)
+- [**eza_colors**(5)](eza_colors.5.md)
+- [**eza_colors-explanation**(5)](eza_colors-explanation.5.md)

--- a/man/eza_colors-explanation.5.md
+++ b/man/eza_colors-explanation.5.md
@@ -228,5 +228,5 @@ You must name the file `theme.yml`, no matter the directory you specify.
 
 ## See also
 
-- [eza.1.md](eza.1.md)
-- [eza_colors.5.md](eza_colors.5.md)
+- [**eza**(1)](eza.1.md)
+- [**eza_colors**(5)](eza_colors.5.md)

--- a/man/eza_colors-explanation.5.md
+++ b/man/eza_colors-explanation.5.md
@@ -34,10 +34,10 @@ files; setting `EZA_COLORS="reset"` will highlight nothing.
 - Build (Makefile, Cargo.toml, package.json) are yellow and underlined.
 - Images (png, jpeg, gif) are purple.
 - Videos (mp4, ogv, m2ts) are a slightly purpler purple.
-- Music (mp3, m4a, ogg) is a deeper purple.
-- Lossless music (flac, alac, wav) is deeper than *that* purple. In general, most media files are some shade of purple.
-- Cryptographic files (asc, enc, p12) are a faint blue.
-- Documents (pdf, doc, dvi) are a less faint blue.
+- Music (mp3, m4a, ogg) is a faint blue.
+- Lossless music (flac, alac, wav) is a less faint blue.
+- Cryptographic files (asc, enc, p12) are bright green.
+- Documents (pdf, doc, dvi) are a fainter green.
 - Compressed files (zip, tgz, Z) are red.
 - Temporary files (tmp, swp, ~) are grey.
 - Compiled files (class, o, pyc) are yellow. A file is also counted as compiled if it uses a common extension and is

--- a/man/eza_colors.5.md
+++ b/man/eza_colors.5.md
@@ -399,5 +399,5 @@ Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors 
 SEE ALSO
 ========
 
-- [eza.1.md](eza.1.md)
-- [eza_colors-explanation.5.md](eza_colors-explanation.5.md)
+- [**eza**(1)](eza.1.md)
+- [**eza_colors-explanation**(5)](eza_colors-explanation.5.md)


### PR DESCRIPTION
The first commit fixes cross-references in the man page.

The second commit corrects the file type color descriptions to match current source. 

https://github.com/eza-community/eza/blob/e7882ceb427cc13ab337d688fd650674f3478800/src/theme/default_theme.rs#L110-L123

P.S.: The version packaged in nixpkgs has `$version` instead of the version number; I've opened https://github.com/NixOS/nixpkgs/pull/345185.