### PR TITLE
docs(man): document that exit 13 == permission denied

### DIFF
--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -365,6 +365,9 @@ EXIT STATUSES
 3
 : If there was a problem with the command-line arguments.
 
+13
+: If permission is denied to access a path.
+
 
 AUTHOR
 ======


### PR DESCRIPTION
Resolves: #1058 

Tested by:

```
just man
man ./target/man/eza.1
```

and the new line was added and formatted consistently with the others.