### PR TITLE
feat: show directories last

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s. Quick overv
 - **-r**, **--reverse**: reverse the sort order
 - **-s**, **--sort=(field)**: which field to sort by
 - **--group-directories-first**: list directories before other files
+- **--group-directories-last**: list directories after other files
 - **-D**, **--only-dirs**: list only directories
 - **-f**, **--only-files**: list only files
 - **--no-symlinks**: don't show symbolic links

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -48,6 +48,7 @@ complete -c eza -l smart-group -d "Only show group if it has a different name fr
 
 # Filtering and sorting options
 complete -c eza -l group-directories-first -d "Sort directories before other files"
+complete -c eza -l group-directories-last -d "Sort directories after other files"
 complete -c eza -l git-ignore -d "Ignore files mentioned in '.gitignore'"
 complete -c eza -s a -l all -d "Show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories"
 complete -c eza -s A -l almost-all -d "Equivalent to --all; included for compatibility with `ls -A`"

--- a/completions/nush/eza.nu
+++ b/completions/nush/eza.nu
@@ -21,6 +21,7 @@ export extern "eza" [
     --absolute                 # Display entries with their absolute path
     --follow-symlinks          # Drill down into symbolic links that point to directories
     --group-directories-first  # Sort directories before other files
+    --group-directories-last   # Sort directories after other files
     --git-ignore               # Ignore files mentioned in '.gitignore'
     --all(-a)                  # Show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories
     --almost-all(-A)           # Equivalent to --all; included for compatibility with `ls -A`

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -29,6 +29,7 @@ __eza() {
         --absolute"[Display entries with their absolute path]:(mode):(on follow off)" \
         --follow-symlinks"[Drill down into symbolic links that point to directories]" \
         --group-directories-first"[Sort directories before other files]" \
+        --group-directories-last"[Sort directories after other files]" \
         --git-ignore"[Ignore files mentioned in '.gitignore']" \
         {-a,--all}"[Show hidden and 'dot' files. Use this twice to also show the '.' and '..' directories]" \
         {-A,--almost-all}"[Equivalent to --all; included for compatibility with \'ls -A\']" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -162,6 +162,9 @@ Sort fields starting with a capital letter will sort uppercase before lowercase:
 `--group-directories-first`
 : List directories before other files.
 
+`--group-directories-last`
+: List directories after other files.
+
 `-D`, `--only-dirs`
 : List only directories, not files.
 

--- a/powertest.yaml
+++ b/powertest.yaml
@@ -135,6 +135,9 @@ commands:
   ? - null
     - --group-directories-first
   :
+  ? - null
+    - --group-directories-last
+  :
   ? - -D
     - --only-dirs
   :

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -33,11 +33,11 @@ pub enum FileFilterFlags {
 
     /// Whether to explicitly show symlinks
     ShowSymlinks,
-    
+
     /// Whether directories should be listed first, and other types of file
     /// second. Some users prefer it like this.
     ListDirsFirst,
-    
+
     /// Whether directories should be listed as the last items, after other
     /// types of file. Some users prefer it like this.
     ListDirsLast,

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -55,6 +55,10 @@ pub struct FileFilter {
     /// second. Some users prefer it like this.
     pub list_dirs_first: bool,
 
+    /// Whether directories should be listed as the last items, after other
+    /// types of file. Some users prefer it like this.
+    pub list_dirs_last: bool,
+
     /// The metadata field to sort by.
     pub sort_field: SortField,
 
@@ -146,6 +150,12 @@ impl FileFilter {
                 b.as_ref()
                     .points_to_directory()
                     .cmp(&a.as_ref().points_to_directory())
+            });
+        } else if self.list_dirs_last {
+            files.sort_by(|a, b| {
+                a.as_ref()
+                    .points_to_directory()
+                    .cmp(&b.as_ref().points_to_directory())
             });
         }
     }

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -33,6 +33,14 @@ pub enum FileFilterFlags {
 
     /// Whether to explicitly show symlinks
     ShowSymlinks,
+    
+    /// Whether directories should be listed first, and other types of file
+    /// second. Some users prefer it like this.
+    ListDirsFirst,
+    
+    /// Whether directories should be listed as the last items, after other
+    /// types of file. Some users prefer it like this.
+    ListDirsLast,
 }
 
 /// The **file filter** processes a list of files before displaying them to
@@ -51,14 +59,6 @@ pub enum FileFilterFlags {
 /// performing the comparison.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileFilter {
-    /// Whether directories should be listed first, and other types of file
-    /// second. Some users prefer it like this.
-    pub list_dirs_first: bool,
-
-    /// Whether directories should be listed as the last items, after other
-    /// types of file. Some users prefer it like this.
-    pub list_dirs_last: bool,
-
     /// The metadata field to sort by.
     pub sort_field: SortField,
 
@@ -143,7 +143,7 @@ impl FileFilter {
             files.reverse();
         }
 
-        if self.list_dirs_first {
+        if self.flags.contains(&FileFilterFlags::ListDirsFirst) {
             // This relies on the fact that `sort_by` is *stable*: it will keep
             // adjacent elements next to each other.
             files.sort_by(|a, b| {
@@ -151,7 +151,7 @@ impl FileFilter {
                     .points_to_directory()
                     .cmp(&a.as_ref().points_to_directory())
             });
-        } else if self.list_dirs_last {
+        } else if self.flags.contains(&FileFilterFlags::ListDirsLast) {
             files.sort_by(|a, b| {
                 a.as_ref()
                     .points_to_directory()

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -26,6 +26,8 @@ impl FileFilter {
             (matches.has(&flags::ONLY_FILES)?, FFF::OnlyFiles),
             (matches.has(&flags::NO_SYMLINKS)?, FFF::NoSymlinks),
             (matches.has(&flags::SHOW_SYMLINKS)?, FFF::ShowSymlinks),
+            (matches.has(&flags::DIRS_LAST)?, FFF::ListDirsLast),
+            (matches.has(&flags::DIRS_FIRST)?, FFF::ListDirsFirst)
         ] {
             if *has {
                 filter_flags.push(flag.clone());
@@ -34,8 +36,6 @@ impl FileFilter {
 
         #[rustfmt::skip]
         return Ok(Self {
-            list_dirs_first:  matches.has(&flags::DIRS_FIRST)?,
-            list_dirs_last:   matches.has(&flags::DIRS_LAST)?,
             no_symlinks:      filter_flags.contains(&FFF::NoSymlinks),
             show_symlinks:    filter_flags.contains(&FFF::ShowSymlinks),
             flags:            filter_flags,

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -27,7 +27,7 @@ impl FileFilter {
             (matches.has(&flags::NO_SYMLINKS)?, FFF::NoSymlinks),
             (matches.has(&flags::SHOW_SYMLINKS)?, FFF::ShowSymlinks),
             (matches.has(&flags::DIRS_LAST)?, FFF::ListDirsLast),
-            (matches.has(&flags::DIRS_FIRST)?, FFF::ListDirsFirst)
+            (matches.has(&flags::DIRS_FIRST)?, FFF::ListDirsFirst),
         ] {
             if *has {
                 filter_flags.push(flag.clone());

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -35,9 +35,10 @@ impl FileFilter {
         #[rustfmt::skip]
         return Ok(Self {
             list_dirs_first:  matches.has(&flags::DIRS_FIRST)?,
+            list_dirs_last:   matches.has(&flags::DIRS_LAST)?,
             no_symlinks:      filter_flags.contains(&FFF::NoSymlinks),
             show_symlinks:    filter_flags.contains(&FFF::ShowSymlinks),
-            flags: filter_flags,
+            flags:            filter_flags,
             sort_field:       SortField::deduce(matches)?,
             dot_filter:       DotFilter::deduce(matches)?,
             ignore_patterns:  IgnorePatterns::deduce(matches)?,

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -47,6 +47,7 @@ pub static SORT:        Arg = Arg { short: Some(b's'), long: "sort",        take
 pub static IGNORE_GLOB: Arg = Arg { short: Some(b'I'), long: "ignore-glob", takes_value: TakesValue::Necessary(None) };
 pub static GIT_IGNORE:  Arg = Arg { short: None, long: "git-ignore",           takes_value: TakesValue::Forbidden };
 pub static DIRS_FIRST:  Arg = Arg { short: None, long: "group-directories-first",  takes_value: TakesValue::Forbidden };
+pub static DIRS_LAST:   Arg = Arg { short: None, long: "group-directories-last",  takes_value: TakesValue::Forbidden };
 pub static ONLY_DIRS:   Arg = Arg { short: Some(b'D'), long: "only-dirs", takes_value: TakesValue::Forbidden };
 pub static ONLY_FILES:  Arg = Arg { short: Some(b'f'), long: "only-files", takes_value: TakesValue::Forbidden };
 pub static NO_SYMLINKS: Arg = Arg { short: None,       long: "no-symlinks", takes_value: TakesValue::Forbidden };
@@ -102,7 +103,7 @@ pub static ALL_ARGS: Args = Args(&[
     &COLOR, &COLOUR, &COLOR_SCALE, &COLOUR_SCALE, &COLOR_SCALE_MODE, &COLOUR_SCALE_MODE,
     &WIDTH, &NO_QUOTES, &ABSOLUTE,
 
-    &ALL, &ALMOST_ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST,
+    &ALL, &ALMOST_ALL, &LIST_DIRS, &LEVEL, &REVERSE, &SORT, &DIRS_FIRST, &DIRS_LAST,
     &IGNORE_GLOB, &GIT_IGNORE, &ONLY_DIRS, &ONLY_FILES,
 
     &BINARY, &BYTES, &GROUP, &NUMERIC, &HEADER, &ICONS, &INODE, &LINKS, &MODIFIED, &CHANGED,

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -46,6 +46,7 @@ FILTERING AND SORTING OPTIONS
   -r, --reverse              reverse the sort order
   -s, --sort SORT_FIELD      which field to sort by
   --group-directories-first  list directories before other files
+  --group-directories-last   list directories after other files
   -D, --only-dirs            list only directories
   -f, --only-files           list only files
   -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore";


### PR DESCRIPTION
For example, it will be quite useful to use this feature alongside --tree as then when printing a deeply nested directory structure, all the files within each directory will be listed first and then the remaining deeply nested directory subtree within it will be printed, giving the users a far better understanding of which files are within each folder.

This addresses issue #872 