### PR TITLE
chore: add fox installation option

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -228,6 +228,16 @@ x env use eza
 x eza
 ```
 
+### fox (Linux, macOS)
+
+Eza is available from [fox](https://www.getfox.sh/).
+
+To install eza, run:
+
+```shell
+fox install eza
+```
+
 ### Completions
 
 #### For zsh:


### PR DESCRIPTION
This or just adds the option for people to install `eza` on linux and windows using `fox`