### PR TITLE
feat(once_cell): remove dependency on once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,6 @@ dependencies = [
  "natord-plus-plus",
  "nu-ansi-term",
  "number_prefix",
- "once_cell",
  "palette",
  "path-clean",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,6 @@ natord-plus-plus = "2.0"
 path-clean = "1.0.1"
 number_prefix = "0.4"
 palette = { version = "0.7.6", default-features = false, features = ["std"] }
-once_cell = "1.21.0"
 percent-encoding = "2.3.1"
 phf = { version = "0.11.2", features = ["macros"] }
 plist = { version = "1.7.0", default-features = false }

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -26,7 +26,7 @@ use chrono::prelude::*;
 
 use log::*;
 #[cfg(unix)]
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 use crate::fs::dir::Dir;
 use crate::fs::feature::xattr;
@@ -41,11 +41,10 @@ use super::mounts::MountedFs;
 // Maps (device_id, inode) => (size_in_bytes, size_in_blocks)
 // Mutex::new is const but HashMap::new is not const requiring us to use lazy
 // initialization.
-// TODO: Replace with std::sync::LazyLock when it is stable.
 #[allow(clippy::type_complexity)]
 #[cfg(unix)]
-static DIRECTORY_SIZE_CACHE: Lazy<Mutex<HashMap<(u64, u64), (u64, u64)>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
+static DIRECTORY_SIZE_CACHE: LazyLock<Mutex<HashMap<(u64, u64), (u64, u64)>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// A **File** is a wrapper around one of Rust’s `PathBuf` values, along with
 /// associated data about the file.

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -12,7 +12,7 @@ use std::sync::{Mutex, MutexGuard};
 use chrono::prelude::*;
 
 use log::*;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 #[cfg(unix)]
 use uzers::UsersCache;
 
@@ -398,7 +398,7 @@ impl Environment {
     }
 }
 
-static ENVIRONMENT: Lazy<Environment> = Lazy::new(Environment::load_all);
+static ENVIRONMENT: LazyLock<Environment> = LazyLock::new(Environment::load_all);
 
 pub struct Table<'a> {
     columns: Vec<Column>,

--- a/src/output/time.rs
+++ b/src/output/time.rs
@@ -8,7 +8,7 @@
 
 use chrono::prelude::*;
 use core::cmp::max;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::time::Duration;
 use unicode_width::UnicodeWidthStr;
 
@@ -140,12 +140,12 @@ fn custom(time: &DateTime<FixedOffset>, non_recent_fmt: &str, recent_fmt: Option
     }
 }
 
-static CURRENT_YEAR: Lazy<i32> = Lazy::new(|| Local::now().year());
+static CURRENT_YEAR: LazyLock<i32> = LazyLock::new(|| Local::now().year());
 
-static LOCALE: Lazy<locale::Time> =
-    Lazy::new(|| locale::Time::load_user_locale().unwrap_or_else(|_| locale::Time::english()));
+static LOCALE: LazyLock<locale::Time> =
+    LazyLock::new(|| locale::Time::load_user_locale().unwrap_or_else(|_| locale::Time::english()));
 
-static MAX_MONTH_WIDTH: Lazy<usize> = Lazy::new(|| {
+static MAX_MONTH_WIDTH: LazyLock<usize> = LazyLock::new(|| {
     // Some locales use a three-character wide month name (Jan to Dec);
     // others vary between three to four (1月 to 12月, juil.). We check each month width
     // to detect the longest and set the output format accordingly.


### PR DESCRIPTION
Rust 1.80 has a proper implementation of LazyLock, which, when used, removes the dependency on once_cell.

- update toolchain to 1.80.0 from 1.70.0
- remove once_cell from dependencies

Fixes: #1169