### PR TITLE
fix: do not print parent filename with --absolute=on

### DIFF
--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -237,7 +237,7 @@ impl<'a, 'dir, C: Colours> FileName<'a, 'dir, C> {
             bits.push(style.paint(" ".repeat(spaces_count as usize)));
         }
 
-        if self.file.parent_dir.is_none() {
+        if self.file.parent_dir.is_none() && self.options.absolute == Absolute::Off {
             if let Some(parent) = self.file.path.parent() {
                 self.add_parent_bits(&mut bits, parent);
             }

--- a/tests/cmd/absolute_file_all.stdout
+++ b/tests/cmd/absolute_file_all.stdout
@@ -1,0 +1,1 @@
+[CWD]/tests/itest/index.svg

--- a/tests/cmd/absolute_file_all.toml
+++ b/tests/cmd/absolute_file_all.toml
@@ -1,0 +1,2 @@
+bin.name = "eza"
+args = "tests/itest/index.svg --absolute"


### PR DESCRIPTION
The parent path of a file was added even with absolute={on,follow}, causing the parent path being prepended to the resolved (absolute) filepath.

Fixes: #1151