### PR TITLE
fix: remove depricated `chrono` `from_timestamp_opt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -755,11 +755,11 @@ impl<'dir> File<'dir> {
     fn systemtime_to_naivedatetime(st: SystemTime) -> Option<NaiveDateTime> {
         let duration = st.duration_since(SystemTime::UNIX_EPOCH).ok()?;
 
-        // FIXME: NaiveDateTime::from_timestamp_opt is deprecated since chrono 0.4.35
-        NaiveDateTime::from_timestamp_opt(
+        DateTime::from_timestamp(
             duration.as_secs().try_into().ok()?,
             (duration.as_nanos() % 1_000_000_000).try_into().ok()?,
         )
+        .map(|dt| dt.naive_local())
     }
 
     /// This file’s last modified timestamp, if available on this platform.
@@ -786,10 +786,11 @@ impl<'dir> File<'dir> {
             };
         }
         let md = self.metadata();
-        NaiveDateTime::from_timestamp_opt(
+        DateTime::from_timestamp(
             md.map_or(0, MetadataExt::ctime),
             md.map_or(0, |md| md.ctime_nsec() as u32),
         )
+        .map(|dt| dt.naive_local())
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
Co-authored-by: Erwin van Eijk <235739+erwinvaneijk@users.noreply.github.com>
Signed-off-by: Christina Sørensen <christina@cafkafk.com>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Make sure you've read CONTRIBUTING.md and CODE_OF_CONDUCT.md -->
<!---  -->
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
##### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Consider including potentially useful screenshots of your feature in action -->

This is a second (third?) attempt at getting this merged, I've copied the
changes from #1175 by @erwinvaneijk, I think it's gonna work this time.

##### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Nothing yet, will run `nix flake check` and do basic sanity checks before merge.
