### PR TITLE
temporarily downgrade palette dependency from v0.7.6 -> v0.7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,12 +170,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
-name = "by_address"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "palette"
-version = "0.7.6"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+checksum = "ebfc23a4b76642983d57e4ad00bb4504eb30a8ce3c70f4aee1f725610e36d97a"
 dependencies = [
  "approx",
  "fast-srgb8",
@@ -875,11 +869,10 @@ dependencies = [
 
 [[package]]
 name = "palette_derive"
-version = "0.7.6"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+checksum = "e8890702dbec0bad9116041ae586f84805b13eecd1d8b1df27c29998a9969d6d"
 dependencies = [
- "by_address",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ log = "0.4"
 natord = "1.0"
 path-clean = "1.0.1"
 number_prefix = "0.4"
-palette = { version = "0.7.6", default-features = false, features = ["std"] }
+palette = { version = "0.7.5", default-features = false, features = ["std"] }
 once_cell = "1.20.2"
 percent-encoding = "2.3.1"
 phf = { version = "0.11.2", features = ["macros"] }


### PR DESCRIPTION
palette_derive 0.7.6 introduces a new dependency on the by_address crate, which looks like it has correctness / soundness issues (uncovered by running tests in "release" mode or in miri):

https://github.com/mbrubeck/by_address/issues/9

This PR is intended to temporarily downgrade / relax the palette / palette_derive dependency to the last version before the by_address dependency was added.
