### PR TITLE
chore: update package.exclude list in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,22 @@ categories = ["command-line-utilities"]
 edition = "2021"
 rust-version = "1.70.0"
 exclude = [
-  "/devtools/*",
-  "/Justfile",
-  "/Vagrantfile",
-  "/screenshots.png",
-  "/tests",
+  "/docs/",
+  "/devtools/",
+  "/snap/",
+  "/tests/",
+  "/.config/",
+  "/.github/",
+  "/deb.asc",
+  "/deny.toml",
+  "/flake.*",
+  "/justfile",
+  "/powertest.yaml",
+  "/rust-toolchain.toml",
+  "/.envrc",
+  "/.gitignore",
+  "/.git-blame-ignore-revs",
+  "/.pre-commit-config-non-nix.yaml",
 ]
 readme = "README.md"
 homepage = "https://github.com/eza-community/eza"


### PR DESCRIPTION
It looks like this list hasn't been updated for new, removed, moved, or renamed files in a while.

I've added all folders / files that are not useful for consumers of the published crate to the "package.exclude" list.

This results in a reduction of the .crate file size by ~80%, from 1.24 MB to 205 kB.
