### PR TITLE
chore: changelog spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: EUPL-1.2
 ### Bug Fixes
 
 - Ensure nested tree parts align under item name
-- Remove depricated `chrono` `from_timestamp_opt`
+- Remove deprecated `chrono` `from_timestamp_opt`
 
 ### Miscellaneous Tasks
 


### PR DESCRIPTION
I started this branch because I noticed some warnings while building eza with `cargo build --release`.
```
warning: use of deprecated associated function `chrono::NaiveDateTime::from_timestamp_opt`: use `DateTime::from_timestamp` instead
   --> src/fs/file.rs:734:24
    |
734 |         NaiveDateTime::from_timestamp_opt(
    |                        ^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated associated function `chrono::NaiveDateTime::from_timestamp_opt`: use `DateTime::from_timestamp` instead
   --> src/fs/file.rs:763:24
    |
763 | ...   [NaiveDateTime::from_timestamp_opt(self.me](http://naivedatetime::from_timestamp_opt(self.me/)...
    |                      ^^^^^^^^^^^^^^^^^^

warning: `eza` (lib) generated 2 warnings
warning: `eza` (bin "eza") generated 2 warnings (2 duplicates)
```
Then I noticed I was on an old version and did a `git pull`

Turns out those errors were already fixed, and there was nothing to do!
Except change 1 measly letter in the changelog. :sweat_smile: