### PR TITLE
Fix typo `--get-repos-no-status` to `--git-repos-no-status`

### DIFF
--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -96,7 +96,7 @@ static GIT_VIEW_HELP: &str = "  \
   --no-git                   suppress Git status (always overrides --git,
                              --git-repos, --git-repos-no-status)
   --git-repos                list root of git-tree status
-  --get-repos-no-status      list each git-repos branch name (much faster)
+  --git-repos-no-status      list each git-repos branch name (much faster)
     ";
 static EXTENDED_HELP: &str = "  \
   -@, --extended             list each file's extended attributes and sizes";

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -78,7 +78,7 @@ LONG VIEW OPTIONS
   --no-git                   suppress Git status (always overrides --git,
                              --git-repos, --git-repos-no-status)
   --git-repos                list root of git-tree status
-  --get-repos-no-status      list each git-repos branch name (much faster)
+  --git-repos-no-status      list each git-repos branch name (much faster)
     
   -@, --extended             list each file's extended attributes and sizes
   -Z, --context              list each file's security context


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Make sure you've read CONTRIBUTING.md and CODE_OF_CONDUCT.md -->
<!---  -->
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
##### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Consider including potentially useful screenshots of your feature in action -->
Fix #1211  a typo `--get-repos-no-staus` in `help.rs`

##### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

