### PR TITLE
feat!: remove special case for `_` prefixed files in windows

### DIFF
--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -129,13 +129,6 @@ impl<'dir, 'ig> Files<'dir, 'ig> {
                     continue;
                 }
 
-                // Also hide _prefix files on Windows because it's used by old applications
-                // as an alternative to dot-prefix files.
-                #[cfg(windows)]
-                if !self.dotfiles && filename.starts_with('_') {
-                    continue;
-                }
-
                 if self.git_ignoring {
                     let git_status = self.git.map(|g| g.get(&path, false)).unwrap_or_default();
                     if git_status.unstaged == GitStatus::Ignored {


### PR DESCRIPTION
On windows files prefixed with a `_` were being ignored because some old applications used those files as pseudo dotfiles.

This was controversial when the feature was added way back when: https://github.com/ogham/exa/pull/820#pullrequestreview-1134991947

Fixes eza-community/eza#1220