### PR TITLE
ci: bump FreeBSD / NetBSD versions.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Compile
         uses: vmactions/freebsd-vm@v1
         with:
-          release: '14.1'
+          release: '14.2'
           usesh: true
           prepare: |
             pkg install -y rust git
@@ -113,11 +113,11 @@ jobs:
       - name: Compile
         uses: vmactions/netbsd-vm@v1
         with:
-          release: '10.0'
+          release: '10.1'
           usesh: true
           prepare: |
             PATH="/root/.cargo/bin:/usr/pkg/sbin:/usr/pkg/bin:$PATH"
-            PKG_PATH="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/10.0/All/"
+            PKG_PATH="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/10.1/All/"
             export PATH PKG_PATH
             /usr/sbin/pkg_add pkgin
             pkgin -y install rust git


### PR DESCRIPTION
- Bump FreeBSD to `14.2`
- Bump NetBSD to `10.1`

Release notes can be found here: 
- https://www.freebsd.org/releases/
- https://www.netbsd.org/releases/formal-10/NetBSD-10.1.html