### PR TITLE
fix: stdin behavior

### DIFF
--- a/src/options/stdin.rs
+++ b/src/options/stdin.rs
@@ -20,9 +20,7 @@ pub enum FilesInput {
 impl FilesInput {
     pub fn deduce<V: Vars>(matches: &MatchedFlags<'_>, vars: &V) -> Result<Self, OptionsError> {
         Ok(
-            if io::stdin().is_terminal() || !matches.has(&flags::STDIN)? {
-                FilesInput::Args
-            } else if matches.has(&flags::STDIN)? && !io::stdin().is_terminal() {
+            if matches.has(&flags::STDIN)? || !io::stdin().is_terminal() {
                 let separator = vars
                     .get(EZA_STDIN_SEPARATOR)
                     .unwrap_or(OsString::from("\n"));


### PR DESCRIPTION
The issue is that eza ignores the `--stdin` argument, unless there is data piped into it. This is not how stdin behavior is supposed to work. e.g. look at the `cat` command.
The flag should tell eza that the input is read from stdin. But if you call `eza --stdin` nothing is read from stdin.

This means that the current argument is moot and serves no purpose, because eza already has the capability of checking whether data is piped into it.
So eza behaves like this: if you pipe data into eza, eza will ignore the data, unless you additionally specify `--stdin` This makes no sense.
Besides, what else is eza supposed to read when data is piped into it?

closes #1326