### PR TITLE
Use Specific Rust Version in FreeBSD CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -92,11 +92,14 @@ jobs:
           release: '14.2'
           usesh: true
           prepare: |
-            pkg install -y rust git
+            pkg install -y curl git
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.74 -y
+            . ~/.cargo/env
             cargo install cargo-hack
             git config --global --add safe.directory /home/runner/work/eza/eza
           run: |
             set -e
+            . ~/.cargo/env
             export CARGO_TERM_COLOR="always"
             export RUSTFLAGS="--deny warnings"
             cargo fmt --check


### PR DESCRIPTION
The FreeBSD CI seems to be failing in several PRs due to it using the latest available rust version on FreeBSD (1.83), see discussion: https://github.com/eza-community/eza/pull/1336

This attempts to set a specific version by using rustup instead of `pkg install`. We could also use the version matrix then, I think.

Also, this is the LEET/1337 PR :) ... had to be BSD related of course XD