### PR TITLE
feat(icon): update YAML icon to be more intuitive

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -147,7 +147,7 @@ impl Icons {
     const VIM: char             = '\u{e7c5}';  // 
     const WRENCH: char          = '\u{f0ad}';  // 
     const XML: char             = '\u{f05c0}'; // 󰗀
-    const YAML: char            = '\u{e6a8}';  // 
+    const YAML: char            = '\u{ee19}';  // 
     const YARN: char            = '\u{e6a7}';  // 
 }
 


### PR DESCRIPTION
After seeing [this issue](https://github.com/eza-community/eza.rocks/issues/10?t) I realized I wasn't the only one confused by the oddity of the YAML icon being an exclamation point.

The best alternative I see in NF is the staggered bars, which evoke the structure of YAML slightly and aren't used for any other file types.

nf-seti-yml \u{e6a8} ()
->
fa-bars_staggered \u{ee19} ()