### PR TITLE
build(release): add libgit alternative for arm builds

### DIFF
--- a/justfile
+++ b/justfile
@@ -156,6 +156,9 @@ release:
 #    binaries    #
 #----------------#
 
+# TODO: make static/no_static DRY
+# TODO: add name prefix/suffix arguments
+
 [group('binaries')]
 tar BINARY TARGET:
     tar czvf ./target/"bin-$(convco version)"/{{BINARY}}_{{TARGET}}.tar.gz -C ./target/{{TARGET}}/release/ ./{{BINARY}}
@@ -171,6 +174,22 @@ tar_static BINARY TARGET:
 [group('binaries')]
 zip_static BINARY TARGET:
     zip -j ./target/"bin-$(convco version)"/{{BINARY}}_{{TARGET}}_static.zip ./target/{{TARGET}}/release/{{BINARY}}
+
+[group('binaries')]
+tar_no_libgit BINARY TARGET:
+    tar czvf ./target/"bin-$(convco version)"/{{BINARY}}_{{TARGET}}_no_libgit.tar.gz -C ./target/{{TARGET}}/release/ ./{{BINARY}}
+
+[group('binaries')]
+zip_no_libgit BINARY TARGET:
+    zip -j ./target/"bin-$(convco version)"/{{BINARY}}_{{TARGET}}_no_libgit.zip ./target/{{TARGET}}/release/{{BINARY}}
+
+[group('binaries')]
+tar_static_no_libgit BINARY TARGET:
+    tar czvf ./target/"bin-$(convco version)"/{{BINARY}}_{{TARGET}}_static_no_libgit.tar.gz -C ./target/{{TARGET}}/release/ ./{{BINARY}}
+
+[group('binaries')]
+zip_static_no_libgit BINARY TARGET:
+    zip -j ./target/"bin-$(convco version)"/{{BINARY}}_{{TARGET}}_static_no_libgit.zip ./target/{{TARGET}}/release/{{BINARY}}
 
 [group('binaries')]
 binary BINARY TARGET:
@@ -190,15 +209,15 @@ binary_static BINARY TARGET:
 binary_no_libgit BINARY TARGET:
     rustup target add {{TARGET}}
     cross build --no-default-features --release --target {{TARGET}}
-    just tar {{BINARY}} {{TARGET}}
-    just zip {{BINARY}} {{TARGET}}
+    just tar_no_libgit {{BINARY}} {{TARGET}}
+    just zip_no_libgit {{BINARY}} {{TARGET}}
 
 [group('binaries')]
 binary_static_no_libgit BINARY TARGET:
     rustup target add {{TARGET}}
     RUSTFLAGS='-C target-feature=+crt-static' cross build --no-default-features --release --target {{TARGET}}
-    just tar_static {{BINARY}} {{TARGET}}
-    just zip_static {{BINARY}} {{TARGET}}
+    just tar_static_no_libgit {{BINARY}} {{TARGET}}
+    just zip_static_no_libgit {{BINARY}} {{TARGET}}
 
 [group('binaries')]
 checksum:
@@ -237,10 +256,12 @@ alias c := cross
     # just binary_static eza x86_64-unknown-linux-musl
 
     ### aarch
+    just binary eza aarch64-unknown-linux-gnu
     just binary_no_libgit eza aarch64-unknown-linux-gnu
     # BUG: just binary_static eza aarch64-unknown-linux-gnu
 
     ### arm
+    just binary eza arm-unknown-linux-gnueabihf
     just binary_no_libgit eza arm-unknown-linux-gnueabihf
     # just binary_static eza arm-unknown-linux-gnueabihf
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Make sure you've read CONTRIBUTING.md and CODE_OF_CONDUCT.md -->
<!---  -->
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
##### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Consider including potentially useful screenshots of your feature in action -->
This adds `libgit` enabled arm builds, meaning we'll ship both with and
without libgit for arm releases. The ever growing justfile is reminding
me of the horrors often seen in Makefiles... but fixing that is left as
an exercise to the reader (likely me when I find the spoons).

This will probably be adjusted slightly on release day, experience shows
that the gh-release recipe resists improvements, but I'll deal with that
on <commit date> + ~thursday.

Closes: #1138 #1060
Signed-off-by: Christina Sørensen <ces@fem.gg>

##### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It hasn't, but it will be on ~thursday. It's easy to revert if it becomes release blocking.
