### PR TITLE
ci: remove magic nix cache

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -180,8 +180,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Nix Flake Check
         run: nix build .#checks.${{ matrix.target }}.${{ matrix.checks }} -L
   flake-build:
@@ -196,7 +194,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Nix Build
         run: nix build .#packages.${{ matrix.target }}.default -L


### PR DESCRIPTION
Magic Nix Cache has been deprecated due to a change in the underlying
GitHub APIs and will stop working on 1 February 2025.

Signed-off-by: Christina Sørensen <ces@fem.gg>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Make sure you've read CONTRIBUTING.md and CODE_OF_CONDUCT.md -->
<!---  -->
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
##### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Consider including potentially useful screenshots of your feature in action -->

##### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

