### PR TITLE
fix(theme): make temp files visible on white background

### DIFF
--- a/man/eza_colors-explanation.5.md
+++ b/man/eza_colors-explanation.5.md
@@ -39,7 +39,7 @@ files; setting `EZA_COLORS="reset"` will highlight nothing.
 - Cryptographic files (asc, enc, p12) are bright green.
 - Documents (pdf, doc, dvi) are a fainter green.
 - Compressed files (zip, tgz, Z) are red.
-- Temporary files (tmp, swp, ~) are grey.
+- Temporary files (tmp, swp, ~) are dimmed default foreground color.
 - Compiled files (class, o, pyc) are yellow. A file is also counted as compiled if it uses a common extension and is
 in the same directory as one of its source files: styles.css will count as compiled when next to styles.less or styles.sass, and scripts.js when next to scripts.ts or scripts.coffee.
 - Source files (cpp, js, java) are bright yellow.

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -116,7 +116,7 @@ impl Default for UiStyles {
                 crypto:     Some(Green.bold()),
                 document:   Some(Green.normal()),
                 compressed: Some(Red.normal()),
-                temp:       Some(White.normal()),
+                temp:       Some(Style::default().dimmed()),
                 compiled:   Some(Yellow.normal()),
                 build:      Some(Yellow.bold().underline()),
                 source:     Some(Yellow.bold()), // Need to discuss color


### PR DESCRIPTION
##### Description
As reported in #1406, currently default theme uses white for temporary files, which causes them to appear invisible on white background. Additionally the man page describes temp files color as grey.

I've changed the color to dimmed default foreground color, which ensures it will stay visible on both black and white backgrounds.

This _in most cases_ means grey (dimmed white or dimmed black), but it's not entirely true as default foreground color can be set to anything. I've changed the man page to reflect that, but I can drop it if you think "grey" is close enough.

Alternatively I can just set the temp files color to grey, but I think dimmed is a better option as it will work well on any background, as long as terminal has a foreground color with a proper contrast; _and_ I think a dimmed color just makes sense for temporary files.

##### How Has This Been Tested?
Ran `cargo fmt`, `cargo clippy` and `cargo test`, then compiled and tested on both black and white background terminal emulator themes.
