### PR TITLE
fix: too many open files error in recursive directory traversal

### DIFF
--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -31,6 +31,32 @@ pub struct Dir {
 }
 
 impl Dir {
+    /// Create a new, empty `Dir` object representing the directory at the given path.
+    ///
+    /// This function does not attempt to read the contents of the directory; it merely
+    /// initializes an instance of `Dir` with an empty `DirEntry` list and the specified path.
+    /// To populate the `Dir` object with actual directory contents, use the `read`.
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            contents: vec![],
+            path,
+        }
+    }
+
+    /// Reads the contents of the directory into DirEntry.
+    ///
+    /// It is recommended to use this method in conjunction with `new` in recursive
+    /// calls, rather than `read_dir`, to avoid holding multiple open file descriptors
+    /// simultaneously, which can lead to "too many open files" errors.
+    pub fn read(&mut self) -> io::Result<&Self> {
+        info!("Reading directory {:?}", &self.path);
+
+        self.contents = fs::read_dir(&self.path)?.collect::<Result<Vec<_>, _>>()?;
+
+        info!("Read directory success {:?}", &self.path);
+        Ok(self)
+    }
+
     /// Create a new Dir object filled with all the files in the directory
     /// pointed to by the given path. Fails if the directory can’t be read, or
     /// isn’t actually a directory, or if there’s an IO error that occurs at

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -43,7 +43,7 @@ impl Dir {
         }
     }
 
-    /// Reads the contents of the directory into DirEntry.
+    /// Reads the contents of the directory into `DirEntry`.
     ///
     /// It is recommended to use this method in conjunction with `new` in recursive
     /// calls, rather than `read_dir`, to avoid holding multiple open file descriptors

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -35,7 +35,7 @@ impl Dir {
     ///
     /// This function does not attempt to read the contents of the directory; it merely
     /// initializes an instance of `Dir` with an empty `DirEntry` list and the specified path.
-    /// To populate the `Dir` object with actual directory contents, use the `read`.
+    /// To populate the `Dir` object with actual directory contents, use the `read` function.
     pub fn new(path: PathBuf) -> Self {
         Self {
             contents: vec![],

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -317,7 +317,7 @@ impl<'dir> File<'dir> {
     /// the current file. It does not perform any validation to check if the
     /// file is actually a directory. To verify that, use `is_directory()`.
     pub fn to_dir(&self) -> Dir {
-        trace!("read_dir: initializating dir form path");
+        trace!("read_dir: initializating dir from path");
         Dir::new(self.path.clone())
     }
 

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -313,14 +313,22 @@ impl<'dir> File<'dir> {
         false
     }
 
+    /// Initializes a new `Dir` object using the `PathBuf` of
+    /// the current file. It does not perform any validation to check if the
+    /// file is actually a directory. To verify that, use `is_directory()`.
+    pub fn to_dir(&self) -> Dir {
+        trace!("read_dir: initializating dir form path");
+        Dir::new(self.path.clone())
+    }
+
     /// If this file is a directory on the filesystem, then clone its
     /// `PathBuf` for use in one of our own `Dir` values, and read a list of
     /// its contents.
     ///
     /// Returns an IO error upon failure, but this shouldn’t be used to check
     /// if a `File` is a directory or not! For that, just use `is_directory()`.
-    pub fn to_dir(&self) -> io::Result<Dir> {
-        trace!("to_dir: reading dir");
+    pub fn read_dir(&self) -> io::Result<Dir> {
+        trace!("read_dir: reading dir");
         Dir::read_dir(self.path.clone())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -413,11 +413,11 @@ impl Exa<'_> {
 
         if !denied_dirs.is_empty() {
             eprintln!(
-                "\nSkipped {} directories due to permission denied",
+                "\nSkipped {} directories due to permission denied: ",
                 denied_dirs.len()
             );
             for path in denied_dirs {
-                eprintln!("  - {}", path.display());
+                eprintln!("  {}", path.display());
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,10 +396,10 @@ impl Exa<'_> {
                                 f.is_directory()
                             }) && !f.is_all_all
                         })
-                        .map(|f| f.to_dir())
+                        .map(fs::File::to_dir)
                         .collect::<Vec<Dir>>();
 
-                    self.print_files(Some(&dir), children)?;
+                    self.print_files(Some(dir), children)?;
                     match self.print_dirs(child_dirs, false, false, exit_status) {
                         Ok(_) => (),
                         Err(e) => return Err(e),
@@ -408,7 +408,7 @@ impl Exa<'_> {
                 }
             }
 
-            self.print_files(Some(&dir), children)?;
+            self.print_files(Some(dir), children)?;
         }
 
         if !denied_dirs.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,7 +334,7 @@ impl Exa<'_> {
                         );
                         denied_dirs.push(dir.path);
                         continue;
-                    };
+                    }
 
                     eprintln!("{}: {}", dir.path.display(), e);
                     continue;

--- a/src/output/color_scale.rs
+++ b/src/output/color_scale.rs
@@ -167,7 +167,7 @@ fn update_information_recursively(
             && file.name != "."
             && file.name != ".."
         {
-            match file.to_dir() {
+            match file.read_dir() {
                 Ok(dir) => {
                     let files: Vec<File<'_>> = dir
                         .files(dot_filter, git, git_ignoring, false, false)

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -303,8 +303,8 @@ impl<'a> Render<'a> {
                     }) && r.tree
                         && !r.is_too_deep(depth.0)
                     {
-                        trace!("matching on to_dir");
-                        match file.to_dir() {
+                        trace!("matching on read_dir");
+                        match file.read_dir() {
                             Ok(d) => {
                                 dir = Some(d);
                             }


### PR DESCRIPTION
Previously, recursive directory traversal caused excessive open file descriptors, leading to OS errors like:
```sh
eza --almost-all --recurse >/dev/null
```
Which was caused by directories being read too early, keeping file handles open for too long. Now, `to_dir` only sets up the `Dir` instance without reading contents and waits to read directories until needed, reducing open files

fixes: https://github.com/eza-community/eza/issues/1387