### PR TITLE
perf: use a hashmap when possible for file extension matching

### DIFF
--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -211,13 +211,16 @@ struct ExtensionMappings {
 }
 
 #[derive(PartialEq, Debug)]
-/// Using a hashmap here for "simple" patterns (plain extensions like '*.txt') improves performance
-/// drastically. It doesn't change highlighting behavior, as we still walk the
-/// [`ExtensionMappings`] in reverse order, and the hashmap will only consist of disjoint sets (it
-/// doesn't matter in which order we search *.txt or *.pdf).
+/// Using a hashmap here for "simple" patterns (plain extensions like '*.txt')
+/// improves performance drastically for complex `LS_COLORS` usage (see
+/// <https://github.com/eza-community/eza/pull/1421#issuecomment-2816666661>).
 ///
-/// In the event that a pattern shows up twice, we will use the later one (since .insert overrides
-/// any entry that exists), which is the correct behavior.
+/// It doesn't change highlighting behavior, as we still walk the
+/// [`ExtensionMappings`] in reverse order, and the hashmap will only consist of
+/// disjoint sets (it doesn't matter in which order we search *.txt or *.pdf).
+///
+/// In the event that a pattern shows up twice, we will use the later one (since
+/// .insert overrides any entry that exists), which is the correct behavior.
 enum GlobPattern {
     Complex(glob::Pattern, Style),
     Simple(HashMap<String, Style>),


### PR DESCRIPTION
This shouldn't affect behavior in any way, since glob patterns of the form `*.foo` / `*.bar` are disjoint, so it doesn't *matter* which order we search them in.

The exact order of disjoint patterns like that aren't preserved anymore, so the test suite needed to change a bit.

`hyperfine "./target/release/eza --color=always /nix/store"` on 3ad8132f874f66945eca3511491afa85c5f43ebe gets

> Benchmark 1: ./target/release/eza --color=always /nix/store
>  Time (mean ± σ):      5.109 s ±  0.488 s    [User: 4.682 s, System: 0.383 s]
>  Range (min … max):    4.691 s …  6.262 s    10 runs

when on this branch (d2ff56bba42012f07ebad2e1188ba7abb51e7d2b), it is

> Benchmark 1: ./target/release/eza --color=always /nix/store
>  Time (mean ± σ):     724.7 ms ±   6.3 ms    [User: 379.4 ms, System: 339.9 ms]
>  Range (min … max):   714.7 ms … 733.0 ms    10 runs

(and for reference: `ls /nix/store | wc -l` is 77967)

I didn't want to add any new dependencies, but `Simple` probably should be using a small string. This is definitely *an* improvement as-is though.