### PR TITLE
fix(git-repo): Don’t truncate branch name

### DIFF
--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -396,16 +396,7 @@ fn current_branch(repo: &git2::Repository) -> Option<String> {
         }
     };
 
-    if let Some(h) = head {
-        if let Some(s) = h.shorthand() {
-            let branch_name = s.to_owned();
-            if branch_name.len() > 10 {
-                return Some(branch_name[..8].to_string() + "..");
-            }
-            return Some(branch_name);
-        }
-    }
-    None
+    head.and_then(|h| h.shorthand().map(std::string::ToString::to_string))
 }
 
 impl f::SubdirGitRepo {

--- a/src/output/render/git.rs
+++ b/src/output/render/git.rs
@@ -51,13 +51,10 @@ pub trait Colours {
 impl f::SubdirGitRepo {
     pub fn render(self, colours: &dyn RepoColours) -> TextCell {
         let branch_name = match self.branch {
-            Some(name) => {
-                if name == "main" || name == "master" {
-                    colours.branch_main().paint(name)
-                } else {
-                    colours.branch_other().paint(name)
-                }
-            }
+            Some(name) => match name.as_ref() {
+                "main" | "master" => colours.branch_main().paint(name),
+                _ => colours.branch_other().paint(name),
+            },
             None => colours.no_repo().paint("-"),
         };
 

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -224,7 +224,7 @@ impl Column {
             #[cfg(unix)]
             Self::Inode => "inode",
             Self::GitStatus => "Git",
-            Self::SubdirGitRepo(_) => "Repo",
+            Self::SubdirGitRepo(_) => "Git Repo",
             #[cfg(unix)]
             Self::Octal => "Octal",
             #[cfg(unix)]


### PR DESCRIPTION
Fix #1434

Just pushing something I was working on a bit more than a year ago and that I think is still relevant.

If this change is not accepted, we would still have to change the code because indexing `String` doesn’t work well with UTF-8. I got alignment issues because of branch name with `é` in it, it’s two code points but one character, and it could also result in splitting a code point and trying to display an incorrect character).