### PR TITLE
fix(pre-commit): make clippy work again

### DIFF
--- a/.pre-commit-config-non-nix.yaml
+++ b/.pre-commit-config-non-nix.yaml
@@ -12,6 +12,7 @@ repos:
       - id: rust-clippy
         name: Rust clippy
         description: Run clippy on included files
-        entry: cargo clippy --workspace --all-targets --all-features --
+        pass_filenames: false
+        entry: cargo clippy --workspace --all-targets --all-features
         types: [file, rust]
         language: system


### PR DESCRIPTION
Otherwise I get a bunch of errors similar to this one:

```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `/home/ariasuni/.rustup/toolchains/1.81-x86_64-unknown-linux-gnu/bin/clippy-driver /home/ariasuni/.rustup/toolchains/1.81-x86_64-unknown-linux-gnu/bin/rustc - --crate-name ___ --print=file-names --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg` (exit status: 1)
  --- stderr
  error: multiple input filenames provided (first two filenames are `-` and `src/options/vars.rs`)

error: failed to run `rustc` to learn about target-specific information
```