### PR TITLE
chore(output): add icon for '.stowrc' files

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -259,6 +259,7 @@ const FILENAME_ICONS: Map<&'static str, char> = phf_map! {
     ".rvm"                => Icons::LANG_RUBY,      // 
     ".rvmrc"              => Icons::LANG_RUBY,      // 
     ".SRCINFO"            => '\u{f303}',            // 
+    ".stowrc"             => '\u{eef1}',            // 
     ".tcshrc"             => Icons::SHELL,          // 󱆃
     ".viminfo"            => Icons::VIM,            // 
     ".vimrc"              => Icons::VIM,            // 


### PR DESCRIPTION
Added an icon association for `.stowrc` files to `output/icons.rs`. `.stowrc` is an ignore-type file for [GNU Stow](https://gnu.org/software/stow). The icon is the `nf-fa-cow (eef1)`, It is available in all _Nerd Font_ variants. It is a cow icon due to common usage of '_symlink farms_' and other farm-related terms in the manual and info pages for GNU Stow.