### PR TITLE
DRAFT: feat: add option to show hidden files with underscore prefix on Windows

### DIFF
--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -58,6 +58,7 @@ impl Dir {
         git_ignoring: bool,
         deref_links: bool,
         total_size: bool,
+        #[cfg(windows)] show_hidden_underscore: bool,
     ) -> Files<'dir, 'ig> {
         Files {
             inner: self.contents.iter(),
@@ -68,6 +69,8 @@ impl Dir {
             git_ignoring,
             deref_links,
             total_size,
+            #[cfg(windows)]
+            show_hidden_underscore,
         }
     }
 
@@ -109,6 +112,10 @@ pub struct Files<'dir, 'ig> {
 
     /// Whether to calculate the directory size recursively
     total_size: bool,
+
+    /// Whether to show files with underscore prefix on Windows
+    #[cfg(windows)]
+    show_hidden_underscore: bool,
 }
 
 impl<'dir, 'ig> Files<'dir, 'ig> {
@@ -135,7 +142,7 @@ impl<'dir, 'ig> Files<'dir, 'ig> {
                 // Also hide _prefix files on Windows because it's used by old applications
                 // as an alternative to dot-prefix files.
                 #[cfg(windows)]
-                if !self.dotfiles && filename.starts_with('_') {
+                if !self.dotfiles && !self.show_hidden_underscore && filename.starts_with('_') {
                     continue;
                 }
 

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -750,7 +750,15 @@ impl<'dir> File<'dir> {
         match Dir::read_dir(self.path.clone()) {
             // . & .. are skipped, if the returned iterator has .next(), it's not empty
             Ok(has_files) => has_files
-                .files(super::DotFilter::Dotfiles, None, false, false, false)
+                .files(
+                    super::DotFilter::Dotfiles,
+                    None,
+                    false,
+                    false,
+                    false,
+                    #[cfg(windows)]
+                    false,
+                )
                 .next()
                 .is_none(),
             Err(_) => false,

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -41,6 +41,10 @@ pub enum FileFilterFlags {
     /// Whether directories should be listed as the last items, after other
     /// types of file. Some users prefer it like this.
     ListDirsLast,
+
+    /// Whether files starting with a _ should be treated as hidden under windows
+    #[cfg(windows)]
+    ShowHiddenUnderscore
 }
 
 /// The **file filter** processes a list of files before displaying them to
@@ -90,6 +94,10 @@ pub struct FileFilter {
 
     /// Whether to explicitly show symlinks
     pub show_symlinks: bool,
+
+    /// Whether to treat files with an _prefix as hidden under windows
+    #[cfg(windows)]
+    pub show_hidden_underscore: bool,
 }
 
 impl FileFilter {

--- a/src/main.rs
+++ b/src/main.rs
@@ -355,6 +355,8 @@ impl<'args> Exa<'args> {
                 git_ignore,
                 self.options.view.deref_links,
                 self.options.view.total_size,
+                #[cfg(windows)]
+                self.options.filter.show_hidden_underscore,
             ) {
                 children.push(file);
             }

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -28,6 +28,11 @@ impl FileFilter {
             (matches.has(&flags::SHOW_SYMLINKS)?, FFF::ShowSymlinks),
             (matches.has(&flags::DIRS_LAST)?, FFF::ListDirsLast),
             (matches.has(&flags::DIRS_FIRST)?, FFF::ListDirsFirst),
+            #[cfg(windows)]
+            (
+                matches.has(&flags::SHOW_HIDDEN_UNDERSCORE)?,
+                FFF::ShowHiddenUnderscore,
+            ),
         ] {
             if *has {
                 filter_flags.push(flag.clone());
@@ -36,13 +41,15 @@ impl FileFilter {
 
         #[rustfmt::skip]
         return Ok(Self {
-            no_symlinks:      filter_flags.contains(&FFF::NoSymlinks),
-            show_symlinks:    filter_flags.contains(&FFF::ShowSymlinks),
-            flags:            filter_flags,
-            sort_field:       SortField::deduce(matches)?,
-            dot_filter:       DotFilter::deduce(matches)?,
-            ignore_patterns:  IgnorePatterns::deduce(matches)?,
-            git_ignore:       GitIgnore::deduce(matches)?,
+            no_symlinks:            filter_flags.contains(&FFF::NoSymlinks),
+            show_symlinks:          filter_flags.contains(&FFF::ShowSymlinks),
+            #[cfg(windows)]
+            show_hidden_underscore: filter_flags.contains(&FFF::ShowHiddenUnderscore),
+            flags:                  filter_flags,
+            sort_field:             SortField::deduce(matches)?,
+            dot_filter:             DotFilter::deduce(matches)?,
+            ignore_patterns:        IgnorePatterns::deduce(matches)?,
+            git_ignore:             GitIgnore::deduce(matches)?,
         });
     }
 }

--- a/src/options/flags.rs
+++ b/src/options/flags.rs
@@ -52,6 +52,7 @@ pub static ONLY_DIRS:   Arg = Arg { short: Some(b'D'), long: "only-dirs", takes_
 pub static ONLY_FILES:  Arg = Arg { short: Some(b'f'), long: "only-files", takes_value: TakesValue::Forbidden };
 pub static NO_SYMLINKS: Arg = Arg { short: None,       long: "no-symlinks", takes_value: TakesValue::Forbidden };
 pub static SHOW_SYMLINKS: Arg = Arg { short: None,     long: "show-symlinks", takes_value: TakesValue::Forbidden };
+pub static SHOW_HIDDEN_UNDERSCORE: Arg = Arg {short: None, long: "show-hidden-underscore", takes_value: TakesValue::Forbidden };
 const SORTS: Values = &[ "name", "Name", "size", "extension",
                          "Extension", "modified", "changed", "accessed",
                          "created", "inode", "type", "none" ];
@@ -109,6 +110,7 @@ pub static ALL_ARGS: Args = Args(&[
     &BINARY, &BYTES, &GROUP, &NUMERIC, &HEADER, &ICONS, &INODE, &LINKS, &MODIFIED, &CHANGED,
     &BLOCKSIZE, &TOTAL_SIZE, &TIME, &ACCESSED, &CREATED, &TIME_STYLE, &HYPERLINK, &MOUNTS,
     &NO_PERMISSIONS, &NO_FILESIZE, &NO_USER, &NO_TIME, &SMART_GROUP, &NO_SYMLINKS, &SHOW_SYMLINKS,
+    &SHOW_HIDDEN_UNDERSCORE,
 
     &GIT, &NO_GIT, &GIT_REPOS, &GIT_REPOS_NO_STAT,
     &EXTENDED, &OCTAL, &SECURITY_CONTEXT, &STDIN, &FILE_FLAGS

--- a/src/output/color_scale.rs
+++ b/src/output/color_scale.rs
@@ -170,9 +170,16 @@ fn update_information_recursively(
             match file.to_dir() {
                 Ok(dir) => {
                     let files: Vec<File<'_>> = dir
-                        .files(dot_filter, git, git_ignoring, false, false)
+                        .files(
+                            dot_filter,
+                            git,
+                            git_ignoring,
+                            false,
+                            false,
+                            #[cfg(windows)]
+                            false,
+                        )
                         .collect();
-
                     update_information_recursively(
                         information,
                         &files,

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -361,6 +361,8 @@ impl<'a> Render<'a> {
                     self.git_ignoring,
                     egg.file.deref_links,
                     egg.file.is_recursive_size(),
+                    #[cfg(windows)]
+                    false
                 ) {
                     files.push(file_to_add);
                 }


### PR DESCRIPTION
I tried adding a flag to show `_prefix` files under windows. See #1233 and #1220 

I'm not happy with this. Adding a new boolean to Dir::files() meant touching every call site, which made the change feel more invasive than it should’ve been. There are some call sites like where I just chose a reasonable sounding default to pass along.

This is not complete and I'm not sure how to get there. `eza -T --show-hidden-underscore` for example doesn't work at the moment and I don't know quite why...

@cafkafk would you mind taking a look and see if this is more like what you had in mind in #1233 

closes #1220 