### PR TITLE
fix: folder icons

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -1104,9 +1104,9 @@ pub fn icon_for_file(file: &File<'_>) -> char {
     if file.points_to_directory() {
         *DIRECTORY_ICONS.get(file.name.as_str()).unwrap_or_else(|| {
             if file.is_empty_dir() {
-                &Icons::FOLDER_OPEN // 
-            } else {
                 &Icons::FOLDER // 
+            } else {
+                &Icons::FOLDER_OPEN // 
             }
         })
     } else if let Some(icon) = FILENAME_ICONS.get(file.name.as_str()) {

--- a/tests/cmd/long_icons_always.stdout
+++ b/tests/cmd/long_icons_always.stdout
@@ -3,7 +3,7 @@
 .rw-r--r--  0 nixbld  1 Jan  1970  c
 .rw-r--r--  0 nixbld  1 Jan  1970  d
 .rw-r--r--  0 nixbld  1 Jan  1970  e
-drwxr-xr-x  - nixbld  1 Jan  1970  exa
+drwxr-xr-x  - nixbld  1 Jan  1970  exa
 .rw-r--r--  0 nixbld  1 Jan  1970  f
 .rw-r--r--  0 nixbld  1 Jan  1970  g
 .rw-r--r--  0 nixbld  1 Jan  1970  h
@@ -18,4 +18,4 @@ drwxr-xr-x  - nixbld  1 Jan  1970  exa
 .rw-r--r--  0 nixbld  1 Jan  1970  o
 .rw-r--r--  0 nixbld  1 Jan  1970  p
 .rw-r--r--  0 nixbld  1 Jan  1970  q
-drwxr-xr-x  - nixbld  1 Jan  1970  vagrant
+drwxr-xr-x  - nixbld  1 Jan  1970  vagrant


### PR DESCRIPTION
Empty folders now have the closed folder icon, non-empty folders have the open folder icon.