### PR TITLE
docs(man): add missing --absolute option to man page

### DIFF
--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -53,6 +53,16 @@ DISPLAY OPTIONS
 `-1`, `--oneline`
 : Display one entry per line.
 
+`--absolute=WHEN`
+: Display entries with their absolute path.
+
+Valid settings are '`on`', '`follow`', and '`off`'.
+When used without a value, defaults to '`on`'.
+
+'`on`': Show absolute paths for all entries.
+'`follow`': Show absolute paths and resolve symbolic links to their targets.
+'`off`': Show relative paths (default behavior).
+
 `-F`, `--classify=WHEN`
 : Display file kind indicators next to file names.
 


### PR DESCRIPTION
Fixed #981 

The `--absolute` option was available in CLI but missing from the man page documentation.
Added documentation for `--absolute=WHEN` with all valid settings (`on`, `follow`, `off`) in the DISPLAY OPTIONS section.