### PR TITLE
fix: use explicit grep command in bash completion to avoid alias issues

### DIFF
--- a/completions/bash/eza
+++ b/completions/bash/eza
@@ -58,13 +58,13 @@ _eza() {
         # _parse_help doesn’t pick up short options when they are on the same line than long options
         --*)
             # colo[u]r isn’t parsed correctly so we filter these options out and add them by hand
-            parse_help=$(eza --help | grep -oE ' (--[[:alnum:]@-]+)' | tr -d ' ' | grep -v '\--colo' | grep -v '\--list-dirs')
+            parse_help=$(eza --help | command grep -oE ' (--[[:alnum:]@-]+)' | tr -d ' ' | command grep -v '\--colo')
             completions=$(echo '--color --colour --color-scale --colour-scale --color-scale-mode --colour-scale-mode' "$parse_help")
             mapfile -t COMPREPLY < <(compgen -W "$completions" -- "$cur")
             ;;
 
         -*)
-            completions=$(eza --help | grep -oE ' (-[[:alnum:]@])' | tr -d ' ')
+            completions=$(eza --help | command grep -oE ' (-[[:alnum:]@])' | tr -d ' ')
             mapfile -t COMPREPLY < <(compgen -W "$completions" -- "$cur")
             ;;
 


### PR DESCRIPTION
Fixes #1529 