### PR TITLE
feat: Decode com.apple.ResourceFork extended attributes #771

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "jobserver",
  "libc",
@@ -284,6 +284,21 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "criterion"
@@ -446,6 +461,7 @@ dependencies = [
  "libc",
  "locale",
  "log",
+ "macbinary",
  "natord-plus-plus",
  "nu-ansi-term",
  "number_prefix",
@@ -737,7 +753,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -849,6 +865,19 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "macbinary"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3b20f06e85c883de160086c2e2b45524ff19888271eccd593c8956d1fc1687"
+dependencies = [
+ "crc",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_bytes",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "memchr"
@@ -1068,9 +1097,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d77244ce2d584cd84f6a15f86195b8c9b2a0dfbfd817c09e0464244091a58ed"
+checksum = "546b279bf0638ee811d9e47de2ca5b66575a543035d79fdf83959dd2f5c3b4c3"
 dependencies = [
  "base64",
  "indexmap",
@@ -1254,7 +1283,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1285,6 +1314,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1425,7 +1474,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1778,7 +1827,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,9 @@ windows-sys = { version = "0.60.2", features = [
   "Win32_Foundation",
 ] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+macbinary = { version = "0.2.1" }
+
 [build-dependencies]
 chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
 

--- a/src/fs/feature/xattr.rs
+++ b/src/fs/feature/xattr.rs
@@ -586,6 +586,10 @@ const ATTRIBUTE_DISPLAYS: &[AttributeDisplay] = &[
         attribute: "com.apple.macl",
         display: display_macl,
     },
+    AttributeDisplay {
+        attribute: "com.apple.ResourceFork",
+        display: display_resource_fork,
+    },
 ];
 
 #[cfg(not(target_os = "macos"))]
@@ -663,6 +667,31 @@ fn display_macl(attribute: &Attribute) -> Option<String> {
                 .join(", ");
             format!("[{macls}]")
         })
+}
+
+#[cfg(target_os = "macos")]
+fn display_resource_fork(attribute: &Attribute) -> Option<String> {
+    attribute.value.as_ref().and_then(|v| {
+        let rsrc = macbinary::ResourceFork::new(v).ok()?;
+        let mut resources = Vec::new();
+        for item in rsrc.resource_types() {
+            resources.extend(rsrc.resources(item).map(|resource| match resource.name() {
+                None => format!(
+                    r#"{{"type": {:?}, "id": {}, "length": {}}}"#,
+                    item.resource_type(),
+                    resource.id(),
+                    resource.data().len()
+                ),
+                Some(name) => format!(
+                    r#"{{"type": {:?}, "name": {name:?}, "id": {}, "length": {}}}"#,
+                    item.resource_type(),
+                    resource.id(),
+                    resource.data().len()
+                ),
+            }));
+        }
+        (!resources.is_empty()).then(|| format!("[{}]", resources.join(", ")))
+    })
 }
 
 // plist::XmlWriter takes the writer instead of borrowing it.  This is a


### PR DESCRIPTION
``` sh
~/src/rust/eza/target/debug/eza -l@
drwx------     - rminsk 26 Nov  2023 com.apple.launchd.U5S1fYnhl5
.rw-r--r--@    0 rminsk  7 Jan 23:15 has_icon
                                     ├── com.apple.FinderInfo: "\0\0\0\0\0\0\0\0\u{4}"
                                     ├── com.apple.ResourceFork: <[{"type": 'icns', "id": -16455, "length": 96924}]>
                                     └── com.apple.provenance: [01, 00, 00, a3, f3, 84, 32, 0e, f8, 0b, 5a]
```

This PR was done by @cfxegbert, but since I can't push to his codebase, I've updated the branch to resolve the conflicts.
The code still works as advertised.