### PR TITLE
fix(view)!: make --grid work when not in TTY

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -448,7 +448,20 @@ impl Exa<'_> {
                 r.render(&mut self.writer)
             }
 
-            (Mode::Grid(_), None) | (Mode::Lines, _) => {
+            (Mode::Grid(ref opts), None) => {
+                let filter = &self.options.filter;
+                let r = grid::Render {
+                    files,
+                    theme,
+                    file_style,
+                    opts,
+                    console_width: 80,
+                    filter,
+                };
+                r.render(&mut self.writer)
+            }
+
+            (Mode::Lines, _) => {
                 let filter = &self.options.filter;
                 let r = lines::Render {
                     files,

--- a/tests/gen/long_time_style_custom_non_recent_empty_nix.stderr
+++ b/tests/gen/long_time_style_custom_non_recent_empty_nix.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at src/options/view.rs:357:21:
+thread 'main' panicked at src/options/view.rs:365:21:
 Custom timestamp format is empty, please supply a chrono format string after the plus sign.
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/gen/long_time_style_custom_non_recent_none_nix.stderr
+++ b/tests/gen/long_time_style_custom_non_recent_none_nix.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at src/options/view.rs:355:47:
+thread 'main' panicked at src/options/view.rs:363:47:
 Custom timestamp format is empty, please supply a chrono format string after the plus sign.
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/gen/long_time_style_custom_recent_empty_nix.stderr
+++ b/tests/gen/long_time_style_custom_recent_empty_nix.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at src/options/view.rs:371:25:
+thread 'main' panicked at src/options/view.rs:379:25:
 Custom timestamp format for recent files is empty, please supply a chrono format string at the second line.
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Make sure you've read CONTRIBUTING.md and CODE_OF_CONDUCT.md -->
<!---  -->
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
##### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Consider including potentially useful screenshots of your feature in action -->
When output is not a TTY (e.g. when piped), fix grid view instead of
outputting oneline view.

BREAKING CHANGE: When using --grid, the output for non-TTY is now the
grid view as well, breaking scripts that may have erroniously used
--grid.

Fixes #1545


##### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `nix flake check -L`.
- Sanity checks on command output for the bug.

##### Relationships
Closes #1545.
