### PR TITLE
fix: `cargo deb` metadata to `LICENSE.txt`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ version = "0.23.0"
 
 
 [package.metadata.deb]
-license-file = ["LICENCE", "4"]
+license-file = ["LICENSE.txt", "4"]
 depends = "$auto"
 extended-description = """
 eza is a modern, maintained replacement for ls


### PR DESCRIPTION
A simple fix that makes `cargo deb` work.

Before this PR:

```
❯ cargo deb
error: unable to read license file: LICENCE
  cause: No such file or directory (os error 2)
```

After:
```
❯ cargo deb
    Finished `release` profile [optimized] target(s) in 0.08s
.../eza/target/debian/eza_0.23.0-1_amd64.deb
```

**NOTE**: One also has to run `just man`, and have `pandoc` installed, before the deb will build.