### PR TITLE
refactor!: stdin handling

### DIFF
--- a/src/options/stdin.rs
+++ b/src/options/stdin.rs
@@ -9,8 +9,6 @@ use clap::ArgMatches;
 use crate::options::Vars;
 use crate::options::vars::EZA_STDIN_SEPARATOR;
 use std::ffi::OsString;
-use std::io;
-use std::io::IsTerminal;
 
 #[derive(Debug, PartialEq)]
 pub enum FilesInput {
@@ -20,7 +18,7 @@ pub enum FilesInput {
 
 impl FilesInput {
     pub fn deduce<V: Vars>(matches: &ArgMatches, vars: &V) -> Self {
-        if matches.get_flag("stdin") || !io::stdin().is_terminal() {
+        if matches.get_flag("stdin") {
             let separator = vars
                 .get(EZA_STDIN_SEPARATOR)
                 .unwrap_or(OsString::from("\n"));


### PR DESCRIPTION
After fixing the handling of standard input, an issue #1568 was opened. While the previous PR (#1336) made this behavior possible, the problem is rather caused by the environments that run eza. The issue described in #1568 is happening because eza is not run interactively, but via something else: e.g. gh actions, claude, ... These environments mess with the terminal and the standard input/output/error streams. They use pseudo terminals and/or redirect input/output.

An argument was made that there is no reason for eza to allow data being piped into it. By default that is, not via an argument like `--stdin`. This is a perfectly valid point, especially since a lot of other command line tools do not read from stdin by default, when data is piped into them.

The following change makes eza only read from stdin, if the argument `--stdin` is used.

This will fix the misbehavior caused by certain environments.

BREAKING CHANGE: only read from stdin, if the argument `--stdin` is used.

closes #1568