### PR TITLE
chore(snap): update snapcraft manifest for core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Christina Sørensen
 # SPDX-License-Identifier: EUPL-1.2
 name: eza
-base: core22
+base: core24
 version: 'latest'
 summary: Replacement for 'ls' written in Rust
 description: |
@@ -19,12 +19,20 @@ grade: stable
 confinement: classic
 apps:
   eza:
-    command: eza
+    command: bin/eza
 parts:
   eza:
     plugin: rust
     source: .
+    build-attributes:
+      - enable-patchelf
     stage-packages:
-      - libgit2-24
       - cmake
       - libz-dev
+platforms:
+  amd64:
+    build-on: [amd64, arm64]
+  arm64:
+    build-on: [amd64, arm64]
+  armhf:
+    build-on: [amd64, arm64]


### PR DESCRIPTION
New contributor, so bear with me. I happily accept PR critique.  🙇🏻‍♀️

I want to see eza on snap, so I'm trying to make that happen! I couldn't get it to build as-is, so here are the modifications I've made.

It doesn't look like libgit2 is available, and even though git2-rs says it's included in the the libgit2-sys crate, that crate was also installed back when this file was written... I'm a little concerned about having to remove this line and would like to make sure no functionality is broken. `--git` and `--git-repos` are still working without it.

There are still a couple oddities during the build...
```
Pulling eza :: Downloading package: libnghttp2-14 - (2.0s)/snap/snapcraft/15775/lib/python3.12/site-packages/apt/package.py:810: Warning: W:Download is performed unsandboxed as root as file '/root/.cache/snapcraft/download/libnghttp2-14_1.59.0-1ubuntu0.2_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
  acq.run()
```
and some linter warnings that might be false positives
```
Lint OK:
- classic: Snap confinement is set to classic.
Lint warnings:
- library: libicuio.so.74: unused library 'usr/lib/x86_64-linux-gnu/libicuio.so.74.2'. (https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-library-linter)
- library: libicutest.so.74: unused library 'usr/lib/x86_64-linux-gnu/libicutest.so.74.2'. (https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-library-linter)
```
but I've cleaned up all the errors and warnings I can. I've built amd64, arm64 , and armhf snaps successfully from my amd64 system. I can only test the amd64 snap, so I'm hoping the multi-arch thing panned out, but, well... that one works, I can't find a way to break it! Is there a way I can run any tests on a locally-installed command, instead of building from source in nix?

I'd love to publish these to the snap store, if that is acceptable to you. If so, is there anything I should do to put it on that little repology badge?