### PR TITLE
docs(man): clarify --list-dirs completes task at #1487

### DIFF
--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -148,6 +148,11 @@ Use this twice to also show the ‘`.`’ and ‘`..`’ directories.
 
 : For simply listing only directories and not files, consider using the `--only-dirs` (`-D`) option as an alternative.
 
+`--list-dirs`
+: List directories matched by the given pattern instead of recursing into them.
+
+: This is particularly useful when using globbing, as it will display only the directories that match the glob instead of their contents.
+
 `-L`, `--level=DEPTH`
 : Limit the depth of recursion.
 

--- a/src/options/help.rs
+++ b/src/options/help.rs
@@ -42,6 +42,7 @@ FILTERING AND SORTING OPTIONS
                              show the '.' and '..' directories
   -A, --almost-all           equivalent to --all; included for compatibility with `ls -A`
   -d, --treat-dirs-as-files  list directories as files; don't list their contents
+  --list-dirs                List directories matched by the given pattern instead of recursing into them.
   -D, --only-dirs            list only directories
   -f, --only-files           list only files
   --show-symlinks            explicitly show symbolic links (for use with --only-dirs | --only-files)


### PR DESCRIPTION
docs(man): add description for --list-dirs flag

Completes task at #1487. Added detailed description and example
for the --list-dirs flag, which was missing previously. This
clarifies its behavior and interaction with globbing patterns.
