### PR TITLE
fix(deps): update git2 to 0.20.4 (libgit2 1.9.2) for security fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ backtrace = "0.3"
 clap = { version = "4.5.38", features = ["cargo", "derive"] }
 
 [dependencies.git2]
-version = "0.20"
+version = "0.20.4"
 optional = true
 default-features = false
 


### PR DESCRIPTION
##### Description

Updates `git2` from 0.20.2 to 0.20.4, which pulls in `libgit2-sys` 0.18.3+1.9.2 (libgit2 1.9.2). This addresses two security vulnerabilities fixed in [libgit2 1.9.2](https://github.com/libgit2/libgit2/releases/tag/v1.9.2):

1. **SSH arbitrary command execution** — Remote repository names were improperly sent to the shell without quoting when using external SSH transport, potentially allowing arbitrary command execution.

2. **SSH public key buffer overflow** — Public keys that are not NUL-terminated were improperly zeroed using `memset` with the wrong length, resulting in a buffer overflow or incomplete key zeroing.

**Changes:**
- `Cargo.toml`: Bump `git2` version requirement from `"0.20"` to `"0.20.4"`
- `Cargo.lock`: `git2` 0.20.2 → 0.20.4, `libgit2-sys` 0.18.2+1.9.1 → 0.18.3+1.9.2

**References:**
- [libgit2 v1.9.2 release notes](https://github.com/libgit2/libgit2/releases/tag/v1.9.2)
- [libgit2 security advisories](https://libgit2.org/security/)

Fixes: #1734

##### How Has This Been Tested?

This is a dependency-only update with no API changes between git2 0.20.2 and 0.20.4. Verified locally that `cargo update` resolves correctly and the lockfile only changes the `git2` and `libgit2-sys` entries.

- [x] `cargo check` passes
- [x] Lockfile diff is minimal (only git2 + libgit2-sys version and checksum)
- [x] Lockfile version stays at v3 (MSRV compatible)

**Note:** The `security_audit` CI job has a pre-existing failure on `main` due to `RUSTSEC-2026-0009` (`time v0.3.44`), which is unrelated to this change. See [run #22494088282](https://github.com/eza-community/eza/actions/runs/22494088282).