### PR TITLE
docs: fix man page cross-references to use proper man page notation

### DIFF
--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -343,7 +343,7 @@ See `https://no-color.org/` for details.
 
 Specifies the colour scheme used to highlight files based on their name and kind, as well as highlighting metadata and parts of the UI.
 
-For more information on the format of these environment variables, see the [eza_colors.5.md](eza_colors.5.md) manual page.
+For more information on the format of these environment variables, see the **eza_colors**(5) manual page.
 
 ## `EZA_OVERRIDE_GIT`
 
@@ -395,5 +395,4 @@ Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors 
 SEE ALSO
 ========
 
-- [**eza_colors**(5)](eza_colors.5.md)
-- [**eza_colors-explanation**(5)](eza_colors-explanation.5.md)
+**eza_colors**(5), **eza_colors-explanation**(5)

--- a/man/eza_colors-explanation.5.md
+++ b/man/eza_colors-explanation.5.md
@@ -228,5 +228,4 @@ You must name the file `theme.yml`, no matter the directory you specify.
 
 ## See also
 
-- [**eza**(1)](eza.1.md)
-- [**eza_colors**(5)](eza_colors.5.md)
+**eza**(1), **eza_colors**(5)

--- a/man/eza_colors.5.md
+++ b/man/eza_colors.5.md
@@ -399,5 +399,4 @@ Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors 
 SEE ALSO
 ========
 
-- [**eza**(1)](eza.1.md)
-- [**eza_colors-explanation**(5)](eza_colors-explanation.5.md)
+**eza**(1), **eza_colors-explanation**(5)


### PR DESCRIPTION
## Summary

Fix man page cross-references in all three man pages to use standard man page notation instead of markdown-style links with `.md` suffixes.

## Changes

- **eza.1.md**: Fix SEE ALSO section and inline `eza_colors.5.md` reference in EZA_COLORS docs
- **eza_colors.5.md**: Fix SEE ALSO section
- **eza_colors-explanation.5.md**: Fix See also section

### Before (rendered in man page)
```
SEE ALSO
  • eza_colors(5) (eza_colors.5.md)
  • eza_colors-explanation(5) (eza_colors-explanation.5.md)
```

### After (rendered in man page)
```
SEE ALSO
  eza_colors(5), eza_colors-explanation(5)
```

The markdown-style `[text](file.md)` links were appearing literally in rendered man pages (via `pandoc`), making the references look broken and non-functional. Standard man page notation (`**name**(section)`) renders correctly as bold text with the section number.

Partially fixes #981 (item 3: SEE ALSO section pointing to .md files).