### PR TITLE
fix(zsh): separate -F flag from --classify to fix tab completion

### DIFF
--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -19,7 +19,8 @@ __eza() {
         {-R,--recurse}"[Recurse into directories]" \
         {-T,--tree}"[Recurse into directories as a tree]" \
         {-X,--dereference}"[Dereference symbolic links when displaying file information]" \
-        {-F,--classify}"[Display type indicator by file names]:(when):(always auto automatic never)" \
+        -F"[Display type indicator by file names (defaults to always)]" \
+        --classify="[Display type indicator by file names]:(when):(always auto automatic never)" \
         --colo{,u}r="[When to use terminal colours]:(when):(always auto automatic never)" \
         --colo{,u}r-scale"[highlight levels of 'field' distinctly]:(fields):(all age size)" \
         --colo{,u}r-scale-mode"[Use gradient or fixed colors in --color-scale]:(mode):(fixed gradient)" \


### PR DESCRIPTION
When using the `-F` flag with zsh completion, pressing tab shows the possible values for `--classify` (always, auto, automatic, never) instead of actual filenames. I ran into this myself when using aliases like `eza -lAF`.

The root cause is that `-F` and `--classify` were defined together in the completion script with an optional argument spec. This means zsh thinks `-F` can take an argument, so it tries to complete that argument instead of moving on to filenames.

The fix separates them:
- `-F` is now a pure flag with no arguments, matching how `ls -F` works
- `--classify=` keeps the optional argument with `=` syntax for explicit values

This also fixes the related issue where stacked flags like `-lAFh` would fail with "Flag -F cannot take a value" because `h` was being consumed as an argument to `-F`.

Tested by sourcing the updated completion script and verifying:
- `eza -F <tab>` now shows filenames
- `eza --classify=<tab>` shows the valid options
- `eza -lAFh` no longer errors

Fixes: #1054
