### PR TITLE
fix(bash): use command grep in completion to avoid alias breakage

### DIFF
--- a/completions/bash/eza
+++ b/completions/bash/eza
@@ -63,13 +63,13 @@ _eza() {
         # _parse_help doesn’t pick up short options when they are on the same line than long options
         --*)
             # colo[u]r isn’t parsed correctly so we filter these options out and add them by hand
-            parse_help=$(eza --help | grep -oE ' (--[[:alnum:]@-]+)' | tr -d ' ' | grep -v '\--colo')
+            parse_help=$(eza --help | command grep -oE ' (--[[:alnum:]@-]+)' | tr -d ' ' | command grep -v '\--colo')
             completions=$(echo '--color --colour --color-scale --colour-scale --color-scale-mode --colour-scale-mode' "$parse_help")
             mapfile -t COMPREPLY < <(compgen -W "$completions" -- "$cur")
             ;;
 
         -*)
-            completions=$(eza --help | grep -oE ' (-[[:alnum:]@])' | tr -d ' ')
+            completions=$(eza --help | command grep -oE ' (-[[:alnum:]@])' | tr -d ' ')
             mapfile -t COMPREPLY < <(compgen -W "$completions" -- "$cur")
             ;;
 


### PR DESCRIPTION
## Summary

When `grep` is aliased to `ripgrep` (or another tool without `-E`), `eza` bash tab completion fails with an `rg` parse error. Completion scripts call `grep -oE` on `eza --help` output.

This PR uses `command grep` so completion always invokes the real `grep` binary, not shell aliases.

Fixes #1529

## Related

Supersedes / refreshes #1530 (that PR has merge conflicts with `main`).

## Test plan

- [x] With `alias grep=rg`, `eza --<Tab>` completes long options without error
- [x] With `alias grep=rg`, `eza -<Tab>` completes short options without error