### PR TITLE
feat: add --ignore-glob-ci for case-insensitive ignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s. Quick overv
 - **--show-symlinks**: explicitly show links (with `--only-dirs`, `--only-files`, to show symlinks that match the filter)
 - **--git-ignore**: ignore files mentioned in `.gitignore`
 - **-I**, **--ignore-glob=(globs)**: glob patterns (pipe-separated) of files to ignore
+- **--ignore-glob-ci=(globs)**: like `--ignore-glob`, but case-insensitive (ASCII only)
 
 Pass the `--all` option twice to also show the `.` and `..` directories.
 

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -86,6 +86,7 @@ complete -c eza -s s -l sort -d "Which field to sort by" -x -a "
 "
 
 complete -c eza -s I -l ignore-glob -d "Ignore files that match these glob patterns" -r
+complete -c eza -l ignore-glob-ci -d "Ignore files that match these glob patterns (case-insensitive)" -r
 complete -c eza -s D -l only-dirs -d "List only directories"
 complete -c eza -s f -l only-files -d "List only files"
 complete -c eza -l show-symlinks -d "Explicitly show symbolic links (For use with --only-dirs | --only-files)"

--- a/completions/pwsh/_eza.ps1
+++ b/completions/pwsh/_eza.ps1
@@ -188,6 +188,7 @@ Register-ArgumentCompleter -Native -CommandName 'eza' -ScriptBlock {
             [CompletionResult]::new('--group-directories-last'   ,'gdl'                 , [CompletionResultType]::ParameterName, 'list directories after other files')
         #   [CompletionResult]::new('-I'                         ,'ignore-glob'         , [CompletionResultType]::ParameterName, 'glob patterns (pipe-separated) of files to ignore GLOBS')
             [CompletionResult]::new('--ignore-glob'              ,'ignore-glob'         , [CompletionResultType]::ParameterName, 'glob patterns (pipe-separated) of files to ignore GLOBS')
+            [CompletionResult]::new('--ignore-glob-ci'           ,'ignore-glob-ci'      , [CompletionResultType]::ParameterName, 'case-insensitive glob patterns (pipe-separated) of files to ignore GLOBS')
             [CompletionResult]::new('--git-ignore'               ,'git-ignore'          , [CompletionResultType]::ParameterName, 'ignore files mentioned in ''.gitignore''')
             break
         }

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -43,6 +43,7 @@ __eza() {
         {-r,--reverse}"[Reverse the sort order]" \
         {-s,--sort}="[Which field to sort by]:(sort field):(accessed age changed created date extension Extension filename Filename inode modified oldest name Name newest none size time type)" \
         {-I,--ignore-glob}"[Ignore files that match these glob patterns]" \
+        --ignore-glob-ci"[Ignore files that match these glob patterns (case-insensitive)]" \
         {-b,--binary}"[List file sizes with binary prefixes]" \
         {-B,--bytes}"[List file sizes in bytes, without any prefixes]" \
         --changed"[Use the changed timestamp field]" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -171,6 +171,9 @@ Sort fields starting with a capital letter will sort uppercase before lowercase:
 `-I`, `--ignore-glob=GLOBS`
 : Glob patterns, pipe-separated, of files to ignore.
 
+`--ignore-glob-ci=GLOBS`
+: Like `--ignore-glob`, but matches file names case-insensitively (ASCII only).
+
 `--git-ignore` [if eza was built with git support]
 : Do not list files that are ignored by Git.
 

--- a/powertest.yaml
+++ b/powertest.yaml
@@ -159,6 +159,9 @@ commands:
   :
   ? - -I # TODO: add more globs
     - --ignore-glob
+  :
+  ? - null
+    - --ignore-glob-ci
   : prefix: -l
     values:
       - "*.toml"

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -324,6 +324,7 @@ impl SortField {
 #[derive(PartialEq, Eq, Default, Debug, Clone)]
 pub struct IgnorePatterns {
     patterns: Vec<glob::Pattern>,
+    case_insensitive_patterns: Vec<glob::Pattern>,
 }
 
 impl FromIterator<glob::Pattern> for IgnorePatterns {
@@ -332,7 +333,10 @@ impl FromIterator<glob::Pattern> for IgnorePatterns {
         I: IntoIterator<Item = glob::Pattern>,
     {
         let patterns = iter.into_iter().collect();
-        Self { patterns }
+        Self {
+            patterns,
+            case_insensitive_patterns: Vec::new(),
+        }
     }
 }
 
@@ -342,6 +346,19 @@ impl IgnorePatterns {
     /// don’t parse correctly are returned separately.
     pub fn parse_from_iter<'a, I: IntoIterator<Item = &'a str>>(
         iter: I,
+    ) -> (Self, Vec<glob::PatternError>) {
+        Self::parse_from_iter_with_case(iter, false)
+    }
+
+    pub fn parse_case_insensitive_from_iter<'a, I: IntoIterator<Item = &'a str>>(
+        iter: I,
+    ) -> (Self, Vec<glob::PatternError>) {
+        Self::parse_from_iter_with_case(iter, true)
+    }
+
+    fn parse_from_iter_with_case<'a, I: IntoIterator<Item = &'a str>>(
+        iter: I,
+        case_insensitive: bool,
     ) -> (Self, Vec<glob::PatternError>) {
         let iter = iter.into_iter();
 
@@ -362,7 +379,19 @@ impl IgnorePatterns {
             }
         }
 
-        (Self { patterns }, errors)
+        let result = if case_insensitive {
+            Self {
+                patterns: Vec::new(),
+                case_insensitive_patterns: patterns,
+            }
+        } else {
+            Self {
+                patterns,
+                case_insensitive_patterns: Vec::new(),
+            }
+        };
+
+        (result, errors)
     }
 
     /// Create a new empty set of patterns that matches nothing.
@@ -370,12 +399,28 @@ impl IgnorePatterns {
     pub fn empty() -> Self {
         Self {
             patterns: Vec::new(),
+            case_insensitive_patterns: Vec::new(),
         }
+    }
+
+    /// Merge another set of patterns into this one.
+    pub fn extend(&mut self, other: Self) {
+        self.patterns.extend(other.patterns);
+        self.case_insensitive_patterns
+            .extend(other.case_insensitive_patterns);
     }
 
     /// Test whether the given file should be hidden from the results.
     fn is_ignored(&self, file: &str) -> bool {
+        let case_insensitive = glob::MatchOptions {
+            case_sensitive: false,
+            ..glob::MatchOptions::new()
+        };
         self.patterns.iter().any(|p| p.matches(file))
+            || self
+                .case_insensitive_patterns
+                .iter()
+                .any(|p| p.matches_with(file, case_insensitive))
     }
 }
 
@@ -422,5 +467,23 @@ mod test_ignores {
         assert!(fails.is_empty());
         assert!(pats.is_ignored("nothing"));
         assert!(pats.is_ignored("test.mp3"));
+    }
+
+    #[test]
+    fn ignores_case_insensitive() {
+        let (pats, fails) = IgnorePatterns::parse_case_insensitive_from_iter(vec!["bar"]);
+        assert!(fails.is_empty());
+        assert!(pats.is_ignored("bar"));
+        assert!(pats.is_ignored("Bar"));
+        assert!(pats.is_ignored("BAR"));
+        assert!(!pats.is_ignored("baz"));
+    }
+
+    #[test]
+    fn case_sensitive_does_not_ignore_different_case() {
+        let (pats, fails) = IgnorePatterns::parse_from_iter(vec!["bar"]);
+        assert!(fails.is_empty());
+        assert!(pats.is_ignored("bar"));
+        assert!(!pats.is_ignored("Bar"));
     }
 }

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -121,25 +121,28 @@ impl DotFilter {
 
 impl IgnorePatterns {
     /// Determines the set of glob patterns to use based on the
-    /// `--ignore-glob` argument’s value. This is a list of strings
-    /// separated by pipe (`|`) characters, given in any order.
+    /// `--ignore-glob` and `--ignore-glob-ci` argument values. Each is a list
+    /// of strings separated by pipe (`|`) characters, given in any order.
     pub fn deduce(matches: &ArgMatches) -> Result<Self, OptionsError> {
-        // If there are no inputs, we return a set of patterns that doesn’t
-        // match anything, rather than, say, `None`.
-        let Some(inputs) = matches.get_one::<String>("ignore-glob") else {
-            return Ok(Self::empty());
-        };
+        let mut patterns = Self::empty();
 
-        // Awkwardly, though, a glob pattern can be invalid, and we need to
-        // deal with invalid patterns somehow.
-        let (patterns, mut errors) = Self::parse_from_iter(inputs.split('|'));
-
-        // It can actually return more than one glob error,
-        // but we only use one. (TODO)
-        match errors.pop() {
-            Some(e) => Err(e.into()),
-            None => Ok(patterns),
+        if let Some(inputs) = matches.get_one::<String>("ignore-glob") {
+            let (parsed, mut errors) = Self::parse_from_iter(inputs.split('|'));
+            if let Some(e) = errors.pop() {
+                return Err(e.into());
+            }
+            patterns.extend(parsed);
         }
+
+        if let Some(inputs) = matches.get_one::<String>("ignore-glob-ci") {
+            let (parsed, mut errors) = Self::parse_case_insensitive_from_iter(inputs.split('|'));
+            if let Some(e) = errors.pop() {
+                return Err(e.into());
+            }
+            patterns.extend(parsed);
+        }
+
+        Ok(patterns)
     }
 }
 
@@ -199,6 +202,15 @@ mod tests {
         assert_eq!(
             IgnorePatterns::deduce(&mock_cli(vec!["--ignore-glob", "["])),
             Err(e.pop().unwrap().into())
+        );
+    }
+
+    #[test]
+    fn deduce_ignore_patterns_case_insensitive() {
+        let (expected, _) = IgnorePatterns::parse_case_insensitive_from_iter(["bar"]);
+        assert_eq!(
+            IgnorePatterns::deduce(&mock_cli(vec!["--ignore-glob-ci", "bar"])),
+            Ok(expected)
         );
     }
 

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -102,6 +102,7 @@ pub fn get_command() -> clap::Command {
         .arg(arg!(--"show-symlinks" "explicitly show symbolic links (with --only-dirs and --only-files)"))
         .arg(arg!(--"no-symlinks" "do not show symbolic links"))
         .arg(arg!(-I --"ignore-glob" <GLOBS> "glob patterns (pipe-separated) of files to ignore"))
+        .arg(arg!(--"ignore-glob-ci" <GLOBS> "case-insensitive glob patterns (pipe-separated) of files to ignore"))
         .arg(arg!(--"git-ignore" "ignore files mentioned in '.gitignore'"))
 
         .next_help_heading("SORTING OPTIONS")

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -30,15 +30,16 @@ DISPLAY OPTIONS:
       --no-quotes                  don't quote file names with spaces
 
 FILTERING OPTIONS:
-  -a, --all...               show hidden files. Use this twice to also show the '.' and '..' directories
-  -A, --almost-all           equivalent to --all; included for compatibility with `ls -A`
-  -d, --treat-dirs-as-files  treat directories as files; don't list their contents
-  -D, --only-dirs            list only directories
-  -f, --only-files           list only files
-      --show-symlinks        explicitly show symbolic links (with --only-dirs and --only-files)
-      --no-symlinks          do not show symbolic links
-  -I, --ignore-glob <GLOBS>  glob patterns (pipe-separated) of files to ignore
-      --git-ignore           ignore files mentioned in '.gitignore'
+  -a, --all...                  show hidden files. Use this twice to also show the '.' and '..' directories
+  -A, --almost-all              equivalent to --all; included for compatibility with `ls -A`
+  -d, --treat-dirs-as-files     treat directories as files; don't list their contents
+  -D, --only-dirs               list only directories
+  -f, --only-files              list only files
+      --show-symlinks           explicitly show symbolic links (with --only-dirs and --only-files)
+      --no-symlinks             do not show symbolic links
+  -I, --ignore-glob <GLOBS>     glob patterns (pipe-separated) of files to ignore
+      --ignore-glob-ci <GLOBS>  case-insensitive glob patterns (pipe-separated) of files to ignore
+      --git-ignore              ignore files mentioned in '.gitignore'
 
 SORTING OPTIONS:
       --group-directories-first  list directories before other files


### PR DESCRIPTION
## Summary

Fixes #1750.

Adds `--ignore-glob-ci=GLOBS`, a case-insensitive variant of `--ignore-glob`. Patterns are pipe-separated like the existing flag. Matching uses `glob::MatchOptions` with `case_sensitive: false` (ASCII only, per the `glob` crate).

Example: `eza --tree foo --ignore-glob-ci='bar'` excludes `bar`, `Bar`, and `BAR`.

`--ignore-glob` behavior is unchanged.

## Test plan

- [x] `cargo test` (unit + integration)
- [x] New tests for case-sensitive vs case-insensitive matching and CLI deduce
- [ ] CI