### PR TITLE
fix(output): honor --across with --long --grid

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -466,7 +466,6 @@ impl Exa<'_> {
             }
 
             (Mode::GridDetails(opts), Some(console_width)) => {
-                let details = &opts.details;
                 let row_threshold = opts.row_threshold;
 
                 let filter = &self.options.filter;
@@ -479,7 +478,7 @@ impl Exa<'_> {
                     files,
                     theme,
                     file_style,
-                    details,
+                    opts,
                     filter,
                     row_threshold,
                     git_ignoring,

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -83,9 +83,11 @@ impl Mode {
             let details = details::Options::deduce_long(matches, vars, strict)?;
 
             if grid {
+                let across = matches.get_flag("across");
                 let row_threshold = RowThreshold::deduce(vars)?;
                 let grid_details = grid_details::Options {
                     details,
+                    across,
                     row_threshold,
                 };
                 return Ok(Self::GridDetails(grid_details));
@@ -940,6 +942,23 @@ mod tests {
             ),
             Ok(Mode::Grid(grid::Options { across: true }))
         );
+    }
+
+    #[test]
+    fn deduce_mode_grid_details_across() {
+        let result = Mode::deduce(
+            &mock_cli(vec!["--long", "--grid", "--across"]),
+            &MockVars::default(),
+            false,
+            false,
+        );
+        assert!(matches!(
+            result,
+            Ok(Mode::GridDetails(grid_details::Options {
+                across: true,
+                ..
+            }))
+        ));
     }
     #[test]
     fn deduce_details_options_tree() {

--- a/src/output/grid_details.rs
+++ b/src/output/grid_details.rs
@@ -25,6 +25,7 @@ use crate::theme::Theme;
 #[derive(PartialEq, Eq, Debug)]
 pub struct Options {
     pub details: DetailsOptions,
+    pub across: bool,
     pub row_threshold: RowThreshold,
 }
 
@@ -32,6 +33,15 @@ impl Options {
     #[must_use]
     pub fn to_details_options(&self) -> &DetailsOptions {
         &self.details
+    }
+
+    #[must_use]
+    pub fn direction(&self) -> Direction {
+        if self.across {
+            Direction::LeftToRight
+        } else {
+            Direction::TopToBottom
+        }
     }
 }
 
@@ -67,8 +77,8 @@ pub struct Render<'a> {
     /// How to format filenames.
     pub file_style: &'a FileStyle,
 
-    /// The details part of the grid-details view.
-    pub details: &'a DetailsOptions,
+    /// Grid-details options (details table + sort direction).
+    pub opts: &'a Options,
 
     /// How to filter files after listing a directory. The files in this
     /// render will already have been filtered and sorted, but any directories
@@ -104,7 +114,7 @@ impl<'a> Render<'a> {
             files:         Vec::new(),
             theme:         self.theme,
             file_style:    self.file_style,
-            opts:          self.details,
+            opts:          self.opts.to_details_options(),
             recurse:       None,
             filter:        self.filter,
             git_ignoring:  self.git_ignoring,
@@ -118,7 +128,8 @@ impl<'a> Render<'a> {
 
     pub fn render<W: Write>(mut self, w: &mut W) -> io::Result<()> {
         let options = self
-            .details
+            .opts
+            .to_details_options()
             .table
             .as_ref()
             .expect("Details table options not given!");
@@ -126,7 +137,7 @@ impl<'a> Render<'a> {
         let drender = self.details_for_column();
 
         let color_scale_info = ColorScaleInformation::from_color_scale(
-            self.details.color_scale,
+            self.opts.to_details_options().color_scale,
             &self.files,
             self.filter.dot_filter,
             self.git,
@@ -167,7 +178,7 @@ impl<'a> Render<'a> {
                 // Therefore we pad the filenames with some spaces. We have to
                 // use ansi_width here, because the filename might contain some
                 // styling.
-                let padding = " ".repeat(if self.details.header {
+                let padding = " ".repeat(if self.opts.to_details_options().header {
                     4usize.saturating_sub(ansi_width::ansi_width(&filename))
                 } else {
                     0
@@ -181,7 +192,7 @@ impl<'a> Render<'a> {
             cells,
             GridOptions {
                 filling: Filling::Spaces(4),
-                direction: Direction::TopToBottom,
+                direction: self.opts.direction(),
                 width: self.console_width,
             },
         );
@@ -198,7 +209,7 @@ impl<'a> Render<'a> {
                 files,
                 theme,
                 file_style,
-                details: opts,
+                opts,
                 filter,
                 git_ignoring,
                 git,
@@ -211,7 +222,7 @@ impl<'a> Render<'a> {
                 files,
                 theme,
                 file_style,
-                opts,
+                opts: opts.to_details_options(),
                 recurse: None,
                 filter,
                 git_ignoring,
@@ -221,7 +232,7 @@ impl<'a> Render<'a> {
             return r.render(w);
         }
 
-        if self.details.header {
+        if self.opts.to_details_options().header {
             let row = table.header_row();
             let name = TextCell::paint_str(self.theme.ui.header.unwrap_or_default(), "Name")
                 .strings()
@@ -260,7 +271,7 @@ impl<'a> Render<'a> {
 
         // The header row will be printed separately, but it should be
         // considered for the width calculations.
-        if self.details.header {
+        if self.opts.to_details_options().header {
             let row = table.header_row();
             table.add_widths(&row);
         }


### PR DESCRIPTION
## Summary

`eza --long --grid --across` previously produced the same column order as without `--across`, because grid-details mode hard-coded `Direction::TopToBottom`.

This threads the `across` flag through `grid_details::Options` and uses `Direction::LeftToRight` when set.

Fixes #1646

## Related

Rebases the approach from #1647 onto current `main` (that PR has merge conflicts).

## Test plan

- [x] `deduce_mode_grid_details_across` unit test
- [x] `cargo test` passes locally