### PR TITLE
fix(output): dim filename quote marks for readability

### DIFF
--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -17,7 +17,8 @@ pub fn escape(
 ) {
     let bits_starting_length = bits.len();
     let needs_quotes = string.contains(' ') || string.contains('\'');
-    let quote_bit = good.paint(if string.contains('\'') { "\"" } else { "\'" });
+    let quote_style_for_quotes = good.dimmed();
+    let quote_bit = quote_style_for_quotes.paint(if string.contains('\'') { "\"" } else { "\'" });
 
     if string
         .chars()
@@ -64,6 +65,24 @@ pub fn get_hyperlink_start_tag(abs_path: &str) -> String {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn quotes_use_dimmed_style() {
+        let good = Style::default();
+        let bad = Style::default().bold();
+        let mut bits = Vec::new();
+        escape(
+            "file name".into(),
+            &mut bits,
+            good,
+            bad,
+            QuoteStyle::QuoteSpaces,
+        );
+        assert_eq!(bits.len(), 3);
+        assert_eq!(format!("{}", bits[0]), format!("{}", good.dimmed().paint("'")));
+        assert_eq!(format!("{}", bits[2]), format!("{}", good.dimmed().paint("'")));
+        assert_eq!(format!("{}", bits[1]), format!("{}", good.paint("file name")));
+    }
 
     #[test]
     fn hyperlink_start_tag_escape_spaces() {

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -79,9 +79,18 @@ mod test {
             QuoteStyle::QuoteSpaces,
         );
         assert_eq!(bits.len(), 3);
-        assert_eq!(format!("{}", bits[0]), format!("{}", good.dimmed().paint("'")));
-        assert_eq!(format!("{}", bits[2]), format!("{}", good.dimmed().paint("'")));
-        assert_eq!(format!("{}", bits[1]), format!("{}", good.paint("file name")));
+        assert_eq!(
+            format!("{}", bits[0]),
+            format!("{}", good.dimmed().paint("'"))
+        );
+        assert_eq!(
+            format!("{}", bits[2]),
+            format!("{}", good.dimmed().paint("'"))
+        );
+        assert_eq!(
+            format!("{}", bits[1]),
+            format!("{}", good.paint("file name"))
+        );
     }
 
     #[test]

--- a/tests/gen/long_links_recurse_unix.stdout
+++ b/tests/gen/long_links_recurse_unix.stdout
@@ -4196,7 +4196,7 @@ tests/test_dir/specials:
 tests/test_dir/symlinks:
 2 dir
 1 file
-1 ' lorem ipsum'
+1 [2m'[0m lorem ipsum[2m'[0m
 1 symlink -> file
 1 symlink2 -> symlink
 1 symlink3 -> dir

--- a/tests/gen/recursive_long_unix.stdout
+++ b/tests/gen/recursive_long_unix.stdout
@@ -4196,7 +4196,7 @@ tests/test_dir/specials:
 tests/test_dir/symlinks:
 dir
 file
-' lorem ipsum'
+[2m'[0m lorem ipsum[2m'[0m
 symlink -> file
 symlink2 -> symlink
 symlink3 -> dir

--- a/tests/gen/recursive_unix.stdout
+++ b/tests/gen/recursive_unix.stdout
@@ -4196,7 +4196,7 @@ tests/test_dir/specials:
 tests/test_dir/symlinks:
 dir
 file
-' lorem ipsum'
+[2m'[0m lorem ipsum[2m'[0m
 symlink -> file
 symlink2 -> symlink
 symlink3 -> dir

--- a/tests/gen/tree_long_unix.stdout
+++ b/tests/gen/tree_long_unix.stdout
@@ -2150,7 +2150,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir

--- a/tests/gen/tree_unix.stdout
+++ b/tests/gen/tree_unix.stdout
@@ -2150,7 +2150,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir

--- a/tests/ptests/ptest_1c1df011089efa5f.stdout
+++ b/tests/ptests/ptest_1c1df011089efa5f.stdout
@@ -2050,7 +2050,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir

--- a/tests/ptests/ptest_391fb71023fbe78f.stdout
+++ b/tests/ptests/ptest_391fb71023fbe78f.stdout
@@ -2150,7 +2150,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir

--- a/tests/ptests/ptest_4728f2d14d31f2ff.stdout
+++ b/tests/ptests/ptest_4728f2d14d31f2ff.stdout
@@ -2150,7 +2150,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir

--- a/tests/ptests/ptest_4b0ed60c44c669f.stdout
+++ b/tests/ptests/ptest_4b0ed60c44c669f.stdout
@@ -2150,7 +2150,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir

--- a/tests/ptests/ptest_57a5aac99c0c821c.stdout
+++ b/tests/ptests/ptest_57a5aac99c0c821c.stdout
@@ -4196,7 +4196,7 @@ tests/test_dir/specials:
 tests/test_dir/symlinks:
 dir
 file
-' lorem ipsum'
+[2m'[0m lorem ipsum[2m'[0m
 symlink -> file
 symlink2 -> symlink
 symlink3 -> dir

--- a/tests/ptests/ptest_5bf846977eb5a96e.stdout
+++ b/tests/ptests/ptest_5bf846977eb5a96e.stdout
@@ -2150,7 +2150,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir

--- a/tests/ptests/ptest_5d72b8a5ba66436b.stdout
+++ b/tests/ptests/ptest_5d72b8a5ba66436b.stdout
@@ -2150,7 +2150,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir

--- a/tests/ptests/ptest_607792764dd84355.stdout
+++ b/tests/ptests/ptest_607792764dd84355.stdout
@@ -2150,7 +2150,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir

--- a/tests/ptests/ptest_6796295d6420d03a.stdout
+++ b/tests/ptests/ptest_6796295d6420d03a.stdout
@@ -2150,7 +2150,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir

--- a/tests/ptests/ptest_97958c59351ef010.stdout
+++ b/tests/ptests/ptest_97958c59351ef010.stdout
@@ -4196,7 +4196,7 @@ tests/test_dir/specials:
 tests/test_dir/symlinks:
 dir
 file
-' lorem ipsum'
+[2m'[0m lorem ipsum[2m'[0m
 symlink -> file
 symlink2 -> symlink
 symlink3 -> dir

--- a/tests/ptests/ptest_dc6b5f21bb23c27.stdout
+++ b/tests/ptests/ptest_dc6b5f21bb23c27.stdout
@@ -2050,7 +2050,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir

--- a/tests/ptests/ptest_f261ab10a0ea20f.stdout
+++ b/tests/ptests/ptest_f261ab10a0ea20f.stdout
@@ -2150,7 +2150,7 @@ tests/test_dir
 ├── symlinks
 │   ├── dir
 │   ├── file
-│   ├── ' lorem ipsum'
+│   ├── [2m'[0m lorem ipsum[2m'[0m
 │   ├── symlink -> file
 │   ├── symlink2 -> symlink
 │   ├── symlink3 -> dir


### PR DESCRIPTION
## Summary

Partially addresses #728: quote characters added around spaced filenames now use `good.dimmed()` so they are visually distinct from the filename itself.

This does **not** change:
- mixed single/double quote selection per file (#730 may cover broader quoting changes)
- column alignment padding

## Test plan

- [x] `quotes_use_dimmed_style` unit test in `escape.rs`
- [x] `cargo test escape::` passes locally