### PR TITLE
fix: list cwd when stdin is /dev/null (#1725)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,10 @@ fn main() {
                                 .filter(|s| !s.is_empty())
                                 .collect::<Vec<_>>(),
                         );
+                        if input_paths.is_empty() {
+                            // Stdin is non-tty but empty (e.g. `/dev/null` in sandboxes).
+                            input_paths = vec![OsStr::new(".")];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

When stdin is non-tty but empty (e.g. `eza < /dev/null` in bubblewrap/Docker sandboxes), fall back to listing the current directory instead of exiting with no output.

Fixes #1725

## Test plan

- [x] Manual: `eza < /dev/null` lists `.` in `/tmp/eza-work`
- [x] `cargo test`
- [ ] CI