### PR TITLE
fix(sort): map newest/oldest aliases to intuitive sort order

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ These options are available when running with `--long` (`-l`):
 Some of the options accept parameters:
 
 - Valid **--colo\[u\]r** options are **always**, **automatic** (or **auto** for short), and **never**.
-- Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **newest**, while its reverse has the aliases **age** and **oldest**.
+- Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **oldest**, while its reverse has the aliases **age** and **newest**.
 - Valid time fields are **modified**, **changed**, **accessed**, and **created**.
 - Valid time styles are **default**, **iso**, **long-iso**, **full-iso**, and **relative**.
 

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -79,7 +79,7 @@ complete -c eza -s s -l sort -d "Which field to sort by" -x -a "
     Name\t'Sort by filename (uppercase first)'
     newest\t'Sort by file modified time (newest first)'
     none\t'Do not sort files at all'
-    oldest\t'Sort by file modified time'
+    oldest\t'Sort by file modified time (oldest first)'
     size\t'Sort by file size'
     time\t'Sort by file modified time'
     type\t'Sort by file type'

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -164,7 +164,7 @@ Use this twice to also show the ‘`.`’ and ‘`..`’ directories.
 
 Valid sort fields are ‘`name`’, ‘`Name`’, ‘`extension`’, ‘`Extension`’, ‘`size`’, ‘`modified`’, ‘`changed`’, ‘`accessed`’, ‘`created`’, ‘`inode`’, ‘`type`’, and ‘`none`’.
 
-The `modified` sort field has the aliases ‘`date`’, ‘`time`’, and ‘`newest`’, and its reverse order has the aliases ‘`age`’ and ‘`oldest`’.
+The `modified` sort field has the aliases ‘`date`’, ‘`time`’, and ‘`oldest`’, and its reverse order has the aliases ‘`age`’ and ‘`newest`’.
 
 Sort fields starting with a capital letter will sort uppercase before lowercase: ‘A’ then ‘B’ then ‘a’ then ‘b’. Fields starting with a lowercase letter will mix them: ‘A’ then ‘a’ then ‘B’ then ‘b’.
 

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -347,6 +347,22 @@ mod tests {
     }
 
     #[test]
+    fn deduce_sort_field_newest() {
+        assert_eq!(
+            mock_cli(vec!["--sort", "newest"]).get_one::<SortField>("sort"),
+            Some(&SortField::ModifiedAge)
+        );
+    }
+
+    #[test]
+    fn deduce_sort_field_oldest() {
+        assert_eq!(
+            mock_cli(vec!["--sort", "oldest"]).get_one::<SortField>("sort"),
+            Some(&SortField::ModifiedDate)
+        );
+    }
+
+    #[test]
     fn deduce_sort_field_ch() {
         assert_eq!(
             mock_cli(vec!["--sort", "ch"]).get_one::<SortField>("sort"),

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -235,11 +235,11 @@ impl ValueEnum for SortField {
             // top and oldest at the bottom. I think this is the right way round to do this:
             // “size” puts the smallest at  the top and the largest at the bottom, doesn’t it?
             Self::ModifiedDate => {
-                PossibleValue::new("date").aliases(vec!["time", "mod", "modified", "new", "newest"])
+                PossibleValue::new("date").aliases(vec!["time", "mod", "modified", "new", "oldest"])
             }
             // Similarly, “age” means that files with the least age (the newest files) get sorted
             //  at the top, and files with the most age (the oldest) at the bottom.
-            Self::ModifiedAge => PossibleValue::new("age").aliases(vec!["old", "oldest"]),
+            Self::ModifiedAge => PossibleValue::new("age").aliases(vec!["old", "newest"]),
             Self::ChangedDate => PossibleValue::new("changed").alias("ch"),
             Self::AccessedDate => PossibleValue::new("accessed").alias("acc"),
             Self::CreatedDate => PossibleValue::new("created").alias("cr"),


### PR DESCRIPTION
## Summary

- `--sort=newest` now uses `ModifiedAge` (newest files first), matching fish completion help and user expectation
- `--sort=oldest` now uses `ModifiedDate` (oldest files first); previously both aliases were attached to the opposite sort fields
- Updates `README.md`, `man/eza.1.md`, and fish completion description for `oldest`

Fixes #1772

## Test plan

- [x] `cargo test deduce_sort_field_newest`
- [x] `cargo test deduce_sort_field_oldest`
- [ ] CI