### PR TITLE
docs: clarify built-in default theme location

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Check out the themes available in the official [eza-themes](https://github.com/e
 An example theme file is available in `docs/theme.yml`, and needs to either be placed in a directory specified by the 
 environment variable `EZA_CONFIG_DIR`, or will looked for by default in `$XDG_CONFIG_HOME/eza`.
 
+If you do not provide a `theme.yml`, eza falls back to a built-in default theme (compiled into the binary, not installed as a file). See `src/theme/default_theme.rs` for the defaults.
+
 Full details are available on the [man page](https://github.com/eza-community/eza/tree/main/man/eza_colors-explanation.5.md) and an example theme file is included [here](https://github.com/eza-community/eza/tree/main/docs/theme.yml)
 
 </details>

--- a/man/eza_colors-explanation.5.md
+++ b/man/eza_colors-explanation.5.md
@@ -52,6 +52,10 @@ Now you can specify these options and more in a `theme.yml` file with convenient
 Set `EZA_CONFIG_DIR` to specify which directory you would like eza to look for your `theme.yml` file,
 otherwise eza will look for `$XDG_CONFIG_HOME/eza/theme.yml`.
 
+When no `theme.yml` is found, eza uses a **built-in default theme** compiled into the binary
+(see `src/theme/default_theme.rs` in the source tree). There is no separate default `theme.yml` on disk;
+use `docs/theme.yml` in the repository as a starting point for your own file.
+
 
 These are the available options:
 


### PR DESCRIPTION
## Summary
- Documents that eza's default theme is built into the binary (`src/theme/default_theme.rs`)
- Clarifies there is no installed default `theme.yml` on disk; `docs/theme.yml` is the example template

Fixes #1782

## Test plan
- [ ] Docs read correctly in README and man page