### PR TITLE
fix(cli): make -F ls-compatible for zsh tab completion

### DIFF
--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -19,7 +19,8 @@ __eza() {
         {-R,--recurse}"[Recurse into directories]" \
         {-T,--tree}"[Recurse into directories as a tree]" \
         {-X,--dereference}"[Dereference symbolic links when displaying file information]" \
-        {-F,--classify}"[Display type indicator by file names]:(when):(always auto automatic never)" \
+        {-F}"[Display type indicator by file names (ls -F compatible)]" \
+        --classify="[Display type indicator by file names]:(when):(always auto automatic never)" \
         --colo{,u}r="[When to use terminal colours]:(when):(always auto automatic never)" \
         --colo{,u}r-scale"[highlight levels of 'field' distinctly]:(fields):(all age size)" \
         --colo{,u}r-scale-mode"[Use gradient or fixed colors in --color-scale]:(mode):(fixed gradient)" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -63,7 +63,10 @@ When used without a value, defaults to '`on`'.
 '`follow`': Show absolute paths and resolve symbolic links to their targets.
 '`off`': Show relative paths (default behavior).
 
-`-F`, `--classify=WHEN`
+`-F`
+: Display file kind indicators next to file names (equivalent to ‘`--classify=always`’; compatible with ‘`ls -F`’ and combined short options like ‘`-lAFh`’).
+
+`--classify=WHEN`
 : Display file kind indicators next to file names.
 
 Valid settings are ‘`always`’, ‘`automatic`’ (or ‘`auto`’ for short), and ‘`never`’.

--- a/src/options/file_name.rs
+++ b/src/options/file_name.rs
@@ -39,6 +39,9 @@ impl Options {
 
 impl Classify {
     fn deduce(matches: &ArgMatches) -> Self {
+        if matches.get_flag("classify_short") {
+            return Self::AddFileIndicators;
+        }
         match matches.get_one("classify") {
             Some(ShowWhen::Auto) => Self::AutomaticAddFileIndicators,
             Some(ShowWhen::Always) => Self::AddFileIndicators,
@@ -110,7 +113,7 @@ mod tests {
 
     use super::*;
     use crate::options::parser::ShowWhen;
-    use crate::options::parser::test::mock_cli;
+    use crate::options::parser::test::{mock_cli, mock_cli_try};
     use crate::options::vars::test::MockVars;
     use crate::output::file_name::Absolute;
 
@@ -122,6 +125,20 @@ mod tests {
             Classify::deduce(&mock_cli(vec!["--classify"])),
             Classify::AutomaticAddFileIndicators
         );
+    }
+
+    #[test]
+    fn deduce_classify_short_flag() {
+        assert_eq!(
+            Classify::deduce(&mock_cli(vec!["-F"])),
+            Classify::AddFileIndicators
+        );
+    }
+
+    #[test]
+    fn deduce_classify_ls_style_cluster() {
+        let matches = mock_cli_try(vec!["-lAFh"]).expect("ls-style short options");
+        assert_eq!(Classify::deduce(&matches), Classify::AddFileIndicators);
     }
 
     #[test]

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -54,10 +54,17 @@ pub fn get_command() -> clap::Command {
             .value_parser(value_parser!(usize)))
 
         .next_help_heading("DISPLAY OPTIONS")
-        .arg(arg!(-F --classify <WHEN> "display type indicator by file names")
+        .arg(
+            clap::Arg::new("classify_short")
+                .short('F')
+                .help("display type indicator by file names (equivalent to --classify=always)")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(arg!(--classify <WHEN> "display type indicator by file names")
             .num_args(0..=1)
             .value_parser(value_parser!(ShowWhen))
-            .default_missing_value("auto"))
+            .default_missing_value("auto")
+            .conflicts_with("classify_short"))
         .arg(arg!(-X --dereference  "dereference symbolic links when displaying information"))
         .arg(arg!(--absolute "display entries with their absolute path")
             .num_args(0..=1)

--- a/tests/ptests/ptest_109771b99ff4bc2c.toml
+++ b/tests/ptests/ptest_109771b99ff4bc2c.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir -F never"
+args = "tests/test_dir --classify=never"

--- a/tests/ptests/ptest_219f7c8dfa0d0323.toml
+++ b/tests/ptests/ptest_219f7c8dfa0d0323.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir -F always"
+args = "tests/test_dir --classify=always"

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -19,7 +19,8 @@ LAYOUT OPTIONS:
   -w, --width <COLS>     set screen width in columns
 
 DISPLAY OPTIONS:
-  -F, --classify [<WHEN>]          display type indicator by file names [possible values: always, auto, never]
+  -F                               display type indicator by file names (equivalent to --classify=always)
+      --classify [<WHEN>]          display type indicator by file names [possible values: always, auto, never]
   -X, --dereference                dereference symbolic links when displaying information
       --absolute [<absolute>]      display entries with their absolute path [possible values: on, off, follow]
       --color [<WHEN>]             When to use colours. [default: auto] [possible values: always, auto, never]

--- a/tests/ptests/ptest_a78bf581d9095079.toml
+++ b/tests/ptests/ptest_a78bf581d9095079.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir -F auto"
+args = "tests/test_dir --classify=auto"


### PR DESCRIPTION
## Summary

- `-F` is now a boolean flag (like `ls -F`), equivalent to `--classify=always`
- `--classify=WHEN` keeps optional values (`auto`, `always`, `never`)
- Combined short options like `-lAFh` now parse as `-l -A -F -h` instead of treating `h` as a classify value

## Motivation

Aliases such as `eza -lAFh` broke zsh tab completion because `-F` greedily consumed the next letter as its optional argument (#1054).

## Test plan

- [x] `cargo test`
- [x] Manual: `eza -lAFh /tmp` succeeds
- [ ] zsh: `eza -F<Tab>` completes file names

Fixes #1054