### PR TITLE
docs: fix man page cross-references and mangen 

### DIFF
--- a/justfile
+++ b/justfile
@@ -286,9 +286,10 @@ alias c := cross
 @mangen:
     # Setup Output Directory
     mkdir -p ./target/"man-$(convco version)"
-    pandoc --standalone -f markdown -t man man/eza.1.md > ./target/"man-$(convco version)"/eza.1
-    pandoc --standalone -f markdown -t man man/eza_colors.5.md > ./target/"man-$(convco version)"/eza_colors.5
-    pandoc --standalone -f markdown -t man man/eza_colors-explanation.5.md > ./target/"man-$(convco version)"/eza_colors-explanation.5
+    version=$(awk 'BEGIN { FS = "\"" } ; /^version/ { print $2 ; exit }' Cargo.toml); \
+    for page in eza.1 eza_colors.5 eza_colors-explanation.5; do \
+        sed "s/\$version/v${version}/g" "man/${page}.md" | pandoc --standalone -f markdown -t man > "./target/man-$(convco version)/${page}"; \
+    done
     tar czvf ./target/"man-$(convco version)".tar.gz ./target/"man-$(convco version)"
 
 [group('documentation')]

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -348,7 +348,7 @@ See `https://no-color.org/` for details.
 
 Specifies the colour scheme used to highlight files based on their name and kind, as well as highlighting metadata and parts of the UI.
 
-For more information on the format of these environment variables, see the [eza_colors.5.md](eza_colors.5.md) manual page.
+For more information on the format of these environment variables, see [**eza_colors**(5)](eza_colors.5).
 
 ## `EZA_OVERRIDE_GIT`
 
@@ -400,5 +400,5 @@ Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors 
 SEE ALSO
 ========
 
-- [**eza_colors**(5)](eza_colors.5.md)
-- [**eza_colors-explanation**(5)](eza_colors-explanation.5.md)
+- [**eza_colors**(5)](eza_colors.5)
+- [**eza_colors-explanation**(5)](eza_colors-explanation.5)

--- a/man/eza_colors.5.md
+++ b/man/eza_colors.5.md
@@ -399,5 +399,5 @@ Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors 
 SEE ALSO
 ========
 
-- [**eza**(1)](eza.1.md)
-- [**eza_colors-explanation**(5)](eza_colors-explanation.5.md)
+- [**eza**(1)](eza.1)
+- [**eza_colors-explanation**(5)](eza_colors-explanation.5)


### PR DESCRIPTION
## Summary

- Remove `.md` suffix from SEE ALSO cross-references in man page sources so rendered man pages link correctly.
- Run `$version` substitution in the `@mangen` release recipe (matching the existing `@man` target).

Fixes #981

## Test plan

- [ ] `just man` — generated man pages show version instead of `$version`
- [ ] `just mangen` — tarball man pages likewise substitute version
- [ ] SEE ALSO sections reference `eza_colors.5` not `eza_colors.5.md`