### PR TITLE
feat: case-insensitive glob ignore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ eza’s options are almost, but not quite, entirely unlike `ls`’s. Quick overv
 - **--show-symlinks**: explicitly show links (with `--only-dirs`, `--only-files`, to show symlinks that match the filter)
 - **--git-ignore**: ignore files mentioned in `.gitignore`
 - **-I**, **--ignore-glob=(globs)**: glob patterns (pipe-separated) of files to ignore
+- **--ignore-glob-ci=(globs)**: glob patterns (pipe-separated) of files to ignore (case-insensitive)
 
 Pass the `--all` option twice to also show the `.` and `..` directories.
 

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -86,6 +86,7 @@ complete -c eza -s s -l sort -d "Which field to sort by" -x -a "
 "
 
 complete -c eza -s I -l ignore-glob -d "Ignore files that match these glob patterns" -r
+complete -c eza -l ignore-glob-ci -d "Ignore files that match these glob patterns (case insensitive)" -r
 complete -c eza -s D -l only-dirs -d "List only directories"
 complete -c eza -s f -l only-files -d "List only files"
 complete -c eza -l show-symlinks -d "Explicitly show symbolic links (For use with --only-dirs | --only-files)"

--- a/completions/pwsh/_eza.ps1
+++ b/completions/pwsh/_eza.ps1
@@ -188,6 +188,7 @@ Register-ArgumentCompleter -Native -CommandName 'eza' -ScriptBlock {
             [CompletionResult]::new('--group-directories-last'   ,'gdl'                 , [CompletionResultType]::ParameterName, 'list directories after other files')
         #   [CompletionResult]::new('-I'                         ,'ignore-glob'         , [CompletionResultType]::ParameterName, 'glob patterns (pipe-separated) of files to ignore GLOBS')
             [CompletionResult]::new('--ignore-glob'              ,'ignore-glob'         , [CompletionResultType]::ParameterName, 'glob patterns (pipe-separated) of files to ignore GLOBS')
+            [CompletionResult]::new('--ignore-glob-ci'           ,'ignore-glob-ci'      , [CompletionResultType]::ParameterName, 'glob patterns (pipe-separated) of files to ignore (case-insensitive) GLOBS')
             [CompletionResult]::new('--git-ignore'               ,'git-ignore'          , [CompletionResultType]::ParameterName, 'ignore files mentioned in ''.gitignore''')
             break
         }

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -43,6 +43,7 @@ __eza() {
         {-r,--reverse}"[Reverse the sort order]" \
         {-s,--sort}="[Which field to sort by]:(sort field):(accessed age changed created date extension Extension filename Filename inode modified oldest name Name newest none size time type)" \
         {-I,--ignore-glob}"[Ignore files that match these glob patterns]" \
+        --ignore-glob-ci"[Ignore files that match these glob patterns (case-insensitive)]" \
         {-b,--binary}"[List file sizes with binary prefixes]" \
         {-B,--bytes}"[List file sizes in bytes, without any prefixes]" \
         --changed"[Use the changed timestamp field]" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -171,6 +171,9 @@ Sort fields starting with a capital letter will sort uppercase before lowercase:
 `-I`, `--ignore-glob=GLOBS`
 : Glob patterns, pipe-separated, of files to ignore.
 
+`--ignore-glob=GLOBS`
+: Glob patterns, pipe-separated, of files to ignore (case-insensitive).
+
 `--git-ignore` [if eza was built with git support]
 : Do not list files that are ignored by Git.
 

--- a/powertest.yaml
+++ b/powertest.yaml
@@ -163,6 +163,11 @@ commands:
     values:
       - "*.toml"
   ? - null
+    - --ignore-glob-ci
+  : prefix: -l
+    values:
+      - "*.toML"
+  ? - null
     - --git-ignore
   :
   ? - -b # Long View Options

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -81,6 +81,7 @@ pub struct FileFilter {
     /// Glob patterns to ignore. Any file name that matches *any* of these
     /// patterns won’t be displayed in the list.
     pub ignore_patterns: IgnorePatterns,
+    pub ignore_patterns_caseins: IgnorePatterns,
 
     /// Whether to ignore Git-ignored patterns.
     pub git_ignore: GitIgnore,
@@ -99,7 +100,10 @@ impl FileFilter {
     pub fn filter_child_files(&self, is_recurse: bool, files: &mut Vec<File<'_>>) {
         use FileFilterFlags::{NoSymlinks, OnlyDirs, OnlyFiles, ShowSymlinks};
 
-        files.retain(|f| !self.ignore_patterns.is_ignored(&f.name));
+        files.retain(|f| {
+            !(self.ignore_patterns.is_ignored(&f.name)
+                | self.ignore_patterns_caseins.is_ignored(&f.name))
+        });
         files.retain(|f| {
             match (
                 self.flags.contains(&OnlyDirs),
@@ -129,7 +133,10 @@ impl FileFilter {
     /// `exa -I='*.ogg' music/*` should filter out the ogg files obtained
     /// from the glob, even though the globbing is done by the shell!
     pub fn filter_argument_files(&self, files: &mut Vec<File<'_>>) {
-        files.retain(|f| !self.ignore_patterns.is_ignored(&f.name));
+        files.retain(|f| {
+            !(self.ignore_patterns.is_ignored(&f.name)
+                | self.ignore_patterns_caseins.is_ignored(&f.name))
+        });
     }
 
     /// Sort the files in the given vector based on the sort field option.

--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -324,6 +324,7 @@ impl SortField {
 #[derive(PartialEq, Eq, Default, Debug, Clone)]
 pub struct IgnorePatterns {
     patterns: Vec<glob::Pattern>,
+    options: glob::MatchOptions,
 }
 
 impl FromIterator<glob::Pattern> for IgnorePatterns {
@@ -332,7 +333,10 @@ impl FromIterator<glob::Pattern> for IgnorePatterns {
         I: IntoIterator<Item = glob::Pattern>,
     {
         let patterns = iter.into_iter().collect();
-        Self { patterns }
+        Self {
+            patterns,
+            options: glob::MatchOptions::new(),
+        }
     }
 }
 
@@ -362,7 +366,13 @@ impl IgnorePatterns {
             }
         }
 
-        (Self { patterns }, errors)
+        (
+            Self {
+                patterns,
+                options: glob::MatchOptions::new(),
+            },
+            errors,
+        )
     }
 
     /// Create a new empty set of patterns that matches nothing.
@@ -370,12 +380,30 @@ impl IgnorePatterns {
     pub fn empty() -> Self {
         Self {
             patterns: Vec::new(),
+            options: glob::MatchOptions::new(),
         }
+    }
+    /// Create a new empty set of patterns and set case insensitive
+    #[must_use]
+    pub fn empty_insensitive() -> Self {
+        Self {
+            patterns: Vec::new(),
+            options: glob::MatchOptions {
+                case_sensitive: false,
+                ..glob::MatchOptions::new()
+            },
+        }
+    }
+    pub fn set_match_options(mut self, opts: glob::MatchOptions) -> Self {
+        self.options = opts;
+        self
     }
 
     /// Test whether the given file should be hidden from the results.
     fn is_ignored(&self, file: &str) -> bool {
-        self.patterns.iter().any(|p| p.matches(file))
+        self.patterns
+            .iter()
+            .any(|p| p.matches_with(file, self.options))
     }
 }
 
@@ -422,5 +450,17 @@ mod test_ignores {
         assert!(fails.is_empty());
         assert!(pats.is_ignored("nothing"));
         assert!(pats.is_ignored("test.mp3"));
+    }
+
+    #[test]
+    fn ignores_insensitive() {
+        let (mut pats, fails) = IgnorePatterns::parse_from_iter(vec!["nothing"]);
+        assert!(fails.is_empty());
+        pats = pats.set_match_options(glob::MatchOptions {
+            case_sensitive: false,
+            ..glob::MatchOptions::new()
+        });
+        assert!(pats.is_ignored("nothing"));
+        assert!(pats.is_ignored("NoThING"));
     }
 }

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -42,6 +42,7 @@ impl FileFilter {
             sort_field: *matches.get_one("sort").unwrap(),
             dot_filter: DotFilter::deduce(matches, strict)?,
             ignore_patterns: IgnorePatterns::deduce(matches)?,
+            ignore_patterns_caseins: IgnorePatterns::deduce_set_insensitive(matches)?,
             git_ignore: GitIgnore::deduce(matches),
         })
     }
@@ -123,10 +124,10 @@ impl IgnorePatterns {
     /// Determines the set of glob patterns to use based on the
     /// `--ignore-glob` argument’s value. This is a list of strings
     /// separated by pipe (`|`) characters, given in any order.
-    pub fn deduce(matches: &ArgMatches) -> Result<Self, OptionsError> {
+    fn deduce_from_arg(matches: &ArgMatches, arg_name: &str) -> Result<Self, OptionsError> {
         // If there are no inputs, we return a set of patterns that doesn’t
         // match anything, rather than, say, `None`.
-        let Some(inputs) = matches.get_one::<String>("ignore-glob") else {
+        let Some(inputs) = matches.get_one::<String>(arg_name) else {
             return Ok(Self::empty());
         };
 
@@ -140,6 +141,18 @@ impl IgnorePatterns {
             Some(e) => Err(e.into()),
             None => Ok(patterns),
         }
+    }
+
+    pub fn deduce(matches: &ArgMatches) -> Result<Self, OptionsError> {
+        Self::deduce_from_arg(matches, "ignore-glob")
+    }
+
+    pub fn deduce_set_insensitive(matches: &ArgMatches) -> Result<Self, OptionsError> {
+        let patterns = Self::deduce_from_arg(matches, "ignore-glob-ci")?;
+        Ok(patterns.set_match_options(glob::MatchOptions {
+            case_sensitive: false,
+            ..glob::MatchOptions::new()
+        }))
     }
 }
 
@@ -198,6 +211,39 @@ mod tests {
         let (_, mut e) = IgnorePatterns::parse_from_iter(pattern.to_string_lossy().split('|'));
         assert_eq!(
             IgnorePatterns::deduce(&mock_cli(vec!["--ignore-glob", "["])),
+            Err(e.pop().unwrap().into())
+        );
+    }
+
+    #[test]
+    fn deduce_ignore_patterns_ci_empty() {
+        assert_eq!(
+            IgnorePatterns::deduce_set_insensitive(&mock_cli(vec![""])),
+            Ok(IgnorePatterns::empty_insensitive())
+        );
+    }
+
+    #[test]
+    fn deduce_ignore_patterns_ci_one() {
+        let pattern = OsString::from("*.o");
+        let (mut res, _) = IgnorePatterns::parse_from_iter(pattern.to_string_lossy().split('|'));
+        res = res.set_match_options(glob::MatchOptions {
+            case_sensitive: false,
+            ..glob::MatchOptions::new()
+        });
+
+        assert_eq!(
+            IgnorePatterns::deduce_set_insensitive(&mock_cli(vec!["--ignore-glob-ci", "*.o"])),
+            Ok(res)
+        );
+    }
+
+    #[test]
+    fn deduce_ignore_patterns_ci_error() {
+        let pattern = OsString::from("[");
+        let (_, mut e) = IgnorePatterns::parse_from_iter(pattern.to_string_lossy().split('|'));
+        assert_eq!(
+            IgnorePatterns::deduce_set_insensitive(&mock_cli(vec!["--ignore-glob-ci", "["])),
             Err(e.pop().unwrap().into())
         );
     }
@@ -384,6 +430,7 @@ mod tests {
                 sort_field: SortField::default(),
                 dot_filter: DotFilter::JustFiles,
                 ignore_patterns: IgnorePatterns::empty(),
+                ignore_patterns_caseins: IgnorePatterns::empty_insensitive(),
                 git_ignore: GitIgnore::Off,
                 no_symlinks: false,
                 show_symlinks: false,
@@ -400,6 +447,7 @@ mod tests {
                 sort_field: SortField::default(),
                 dot_filter: DotFilter::JustFiles,
                 ignore_patterns: IgnorePatterns::empty(),
+                ignore_patterns_caseins: IgnorePatterns::empty_insensitive(),
                 git_ignore: GitIgnore::Off,
                 no_symlinks: false,
                 show_symlinks: false,
@@ -416,6 +464,7 @@ mod tests {
                 sort_field: SortField::default(),
                 dot_filter: DotFilter::JustFiles,
                 ignore_patterns: IgnorePatterns::empty(),
+                ignore_patterns_caseins: IgnorePatterns::empty_insensitive(),
                 git_ignore: GitIgnore::Off,
                 no_symlinks: false,
                 show_symlinks: false,
@@ -432,6 +481,7 @@ mod tests {
                 sort_field: SortField::default(),
                 dot_filter: DotFilter::JustFiles,
                 ignore_patterns: IgnorePatterns::empty(),
+                ignore_patterns_caseins: IgnorePatterns::empty_insensitive(),
                 git_ignore: GitIgnore::Off,
                 no_symlinks: false,
                 show_symlinks: false,

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -102,6 +102,7 @@ pub fn get_command() -> clap::Command {
         .arg(arg!(--"show-symlinks" "explicitly show symbolic links (with --only-dirs and --only-files)"))
         .arg(arg!(--"no-symlinks" "do not show symbolic links"))
         .arg(arg!(-I --"ignore-glob" <GLOBS> "glob patterns (pipe-separated) of files to ignore"))
+        .arg(arg!(--"ignore-glob-ci" <GLOBS> "glob patterns (pipe-separated) of files to ignore (case-insensitive)"))
         .arg(arg!(--"git-ignore" "ignore files mentioned in '.gitignore'"))
 
         .next_help_heading("SORTING OPTIONS")

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -30,15 +30,16 @@ DISPLAY OPTIONS:
       --no-quotes                  don't quote file names with spaces
 
 FILTERING OPTIONS:
-  -a, --all...               show hidden files. Use this twice to also show the '.' and '..' directories
-  -A, --almost-all           equivalent to --all; included for compatibility with `ls -A`
-  -d, --treat-dirs-as-files  treat directories as files; don't list their contents
-  -D, --only-dirs            list only directories
-  -f, --only-files           list only files
-      --show-symlinks        explicitly show symbolic links (with --only-dirs and --only-files)
-      --no-symlinks          do not show symbolic links
-  -I, --ignore-glob <GLOBS>  glob patterns (pipe-separated) of files to ignore
-      --git-ignore           ignore files mentioned in '.gitignore'
+  -a, --all...                  show hidden files. Use this twice to also show the '.' and '..' directories
+  -A, --almost-all              equivalent to --all; included for compatibility with `ls -A`
+  -d, --treat-dirs-as-files     treat directories as files; don't list their contents
+  -D, --only-dirs               list only directories
+  -f, --only-files              list only files
+      --show-symlinks           explicitly show symbolic links (with --only-dirs and --only-files)
+      --no-symlinks             do not show symbolic links
+  -I, --ignore-glob <GLOBS>     glob patterns (pipe-separated) of files to ignore
+      --ignore-glob-ci <GLOBS>  glob patterns (pipe-separated) of files to ignore (case-insensitive)
+      --git-ignore              ignore files mentioned in '.gitignore'
 
 SORTING OPTIONS:
       --group-directories-first  list directories before other files

--- a/tests/ptests/ptest_a0478afb9ca3ea53.stdout
+++ b/tests/ptests/ptest_a0478afb9ca3ea53.stdout
@@ -1,0 +1,10 @@
+drwxr-xr-x - nixbld  1 Jan  1970 dirs-ext
+drwxr-xr-x - nixbld  1 Jan  1970 git
+drwxr-xr-x - nixbld  1 Jan  1970 grid
+drwxr-xr-x - nixbld  1 Jan  1970 group
+drwxr-xr-x - nixbld  1 Jan  1970 icons
+drwxr-xr-x - nixbld  1 Jan  1970 perms
+drwxr-xr-x - nixbld  1 Jan  1970 size
+drwxr-xr-x - nixbld  1 Jan  1970 specials
+drwxr-xr-x - nixbld  1 Jan  1970 symlinks
+drwxr-xr-x - nixbld  1 Jan  1970 time

--- a/tests/ptests/ptest_a0478afb9ca3ea53.toml
+++ b/tests/ptests/ptest_a0478afb9ca3ea53.toml
@@ -1,0 +1,2 @@
+bin.name = "eza"
+args = "tests/test_dir -l --ignore-glob-ci *.toML"


### PR DESCRIPTION
Add new option `--ignore-glob-ci` behaving similar to `--ignore-glob` with case insensitive matching.

Closes #1750