### PR TITLE
docs: document PowerShell 5.1 path quoting limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ If you want to pass arguments this way, use e.g. `nix run github:eza-community/e
 eza is available for Windows, macOS and Linux. Platform and distribution
 specific installation instructions can be found in [INSTALL.md](INSTALL.md).
 
+On Windows, PowerShell 5.1 can pass quoted native-command paths that end in a
+backslash with an extra quote. For example, `eza 'C:\Program Files\'` can reach
+eza as an invalid path and report `OS error 123`. Use PowerShell 6+ (`pwsh`) or
+omit the trailing backslash, such as `eza 'C:\Program Files'`.
+
 [![Packaging status](https://repology.org/badge/vertical-allrepos/eza.svg?columns=3)](https://repology.org/project/eza/versions)
 
 ---


### PR DESCRIPTION
##### Description

Document the Windows PowerShell 5.1 native-command argument parsing limitation for quoted paths that end in a backslash. In that shell, a path such as `'C:\Program Files\'` can be passed to eza with an extra quote, which surfaces as `OS error 123`.

The note points users to PowerShell 6+ (`pwsh`) or to omit the trailing backslash when passing that style of path.

Refs #404

##### How Has This Been Tested?

- `git diff --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`

Not run:

- `nix flake check` (`nix` is not installed in this local environment)
