### PR TITLE
feat: add --no-symlink-target

### DIFF
--- a/src/options/file_name.rs
+++ b/src/options/file_name.rs
@@ -8,7 +8,9 @@ use crate::options::parser::ShowWhen;
 use crate::options::vars::{self, Vars};
 use crate::options::{NumberSource, OptionsError};
 
-use crate::output::file_name::{Classify, EmbedHyperlinks, Options, QuoteStyle, ShowIcons};
+use crate::output::file_name::{
+    Classify, EmbedHyperlinks, Options, QuoteStyle, ShowIcons, ShowSymlinkTargets,
+};
 
 use clap::ArgMatches;
 
@@ -26,6 +28,8 @@ impl Options {
 
         let absolute = *matches.get_one("absolute").unwrap();
 
+        let show_symlink_targets = ShowSymlinkTargets::deduce(matches);
+
         Ok(Self {
             classify,
             show_icons,
@@ -33,6 +37,7 @@ impl Options {
             embed_hyperlinks,
             absolute,
             is_a_tty,
+            show_symlink_targets,
         })
     }
 }
@@ -99,6 +104,16 @@ impl EmbedHyperlinks {
             Some(ShowWhen::Never) | None => Self::Never,
             Some(ShowWhen::Always) => Self::Always,
             Some(ShowWhen::Auto) => Self::Automatic,
+        }
+    }
+}
+
+impl ShowSymlinkTargets {
+    pub fn deduce(matches: &ArgMatches) -> Self {
+        if matches.get_flag("no-symlink-targets") {
+            Self::NoSymlinkTargets
+        } else {
+            Self::ShowSymlinkTargets
         }
     }
 }
@@ -273,6 +288,7 @@ mod tests {
                 embed_hyperlinks: EmbedHyperlinks::Never,
                 absolute: Absolute::Off,
                 is_a_tty: true,
+                show_symlink_targets: ShowSymlinkTargets::ShowSymlinkTargets,
             })
         );
     }

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -90,6 +90,7 @@ pub fn get_command() -> clap::Command {
             .value_parser(value_parser!(ShowWhen))
             .default_missing_value("auto"))
         .arg(arg!(--"no-quotes" "don't quote file names with spaces"))
+        .arg(arg!(--"no-symlink-targets" "do not show symlink targets (the `-> ...`)"))
 
         .next_help_heading("FILTERING OPTIONS")
         .arg(arg!(-a --all... "show hidden files. Use this twice to also show the '.' and '..' directories"))

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -339,7 +339,7 @@ impl<'a> Render<'a> {
             let file_name = self
                 .file_style
                 .for_file(egg.file, self.theme)
-                .with_link_paths()
+                .use_symlink_targets()
                 .with_mount_details(self.opts.mounts)
                 .paint()
                 .promote();

--- a/src/output/file_name.rs
+++ b/src/output/file_name.rs
@@ -38,6 +38,9 @@ pub struct Options {
 
     /// Whether we are in a console or redirecting the output
     pub is_a_tty: bool,
+
+    /// Whether to show `-> <sym target>` for symlinks
+    pub show_symlink_targets: ShowSymlinkTargets,
 }
 
 impl Options {
@@ -51,6 +54,8 @@ impl Options {
         FileName {
             file,
             colours,
+            // keeping JustFilenames as default
+            // because only a few display modes show symlink target
             link_style: LinkStyle::JustFilenames,
             options: self,
             target: if file.is_link() {
@@ -150,6 +155,16 @@ pub enum QuoteStyle {
     QuoteSpaces,
 }
 
+/// Whether or not to show symlink target (-> ...)
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum ShowSymlinkTargets {
+    /// Do not show symlink target
+    NoSymlinkTargets,
+
+    /// Show symlink target
+    ShowSymlinkTargets,
+}
+
 /// A **file name** holds all the information necessary to display the name
 /// of the given file. This is used in all of the views.
 pub struct FileName<'a, 'dir, C> {
@@ -192,6 +207,17 @@ impl<C> FileName<'_, '_, C> {
             MountStyle::JustDirectoryNames
         };
         self
+    }
+
+    /// Set the `link_style` of `FileName` to the correct style.
+    /// Because there are only a few display modes show symlink target,
+    /// I think it is a good idea to explicitly invoke a function.
+    pub fn use_symlink_targets(self) -> Self {
+        if self.options.show_symlink_targets == ShowSymlinkTargets::ShowSymlinkTargets {
+            self.with_link_paths()
+        } else {
+            self
+        }
     }
 }
 
@@ -284,6 +310,7 @@ impl<C: Colours> FileName<'_, '_, C> {
                             embed_hyperlinks: EmbedHyperlinks::Never,
                             is_a_tty: self.options.is_a_tty,
                             absolute: Absolute::Off,
+                            show_symlink_targets: self.options.show_symlink_targets,
                         };
 
                         let target_name = FileName {

--- a/src/output/lines.rs
+++ b/src/output/lines.rs
@@ -36,7 +36,7 @@ impl<'a> Render<'a> {
     fn render_file<'f>(&self, file: &'f File<'a>) -> TextCellContents {
         self.file_style
             .for_file(file, self.theme)
-            .with_link_paths()
+            .use_symlink_targets()
             .with_mount_details(false)
             .paint()
     }


### PR DESCRIPTION
I added `--no-symlink-target` which hides the symlink targets when set.

Closes #1540

Although, I think a better approach would be doing `auto|never|always`, where `auto` may not show symlink during pipe for example.

Relates #662

Output:
Patched ver:
```
$> cargo run -q -- ~/test -1 --no-symlink-targets
broken_link
file.txt
multi_link
valid_link
```
Eza:
```
$> eza ~/test/ -1
broken_link -> non_existent.txt
file.txt
multi_link -> valid_link
valid_link -> file.txt
```

No tests added. (TODO)