### PR TITLE
feat: support directorynames styling in theme.yml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_norway",
+ "tempfile",
  "terminal_size",
  "timeago",
  "trycmd",
@@ -863,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1292,9 +1293,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1486,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }
 trycmd = "1.0"
+tempfile = "3.27.0"
 
 [features]
 default = ["git"]

--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -236,10 +236,43 @@ impl FromOverride<IconStyleOverride> for IconStyle {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize)]
 pub struct FileNameStyleOverride {
     pub icon: Option<IconStyleOverride>,
     pub filename: Option<StyleOverride>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileNameStyleOverrideDetailed {
+    icon: Option<IconStyleOverride>,
+    filename: Option<StyleOverride>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum FileNameStyleOverrideRaw {
+    Detailed(FileNameStyleOverrideDetailed),
+    Simple(StyleOverride),
+}
+
+impl<'de> Deserialize<'de> for FileNameStyleOverride {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = FileNameStyleOverrideRaw::deserialize(deserializer)?;
+        Ok(match raw {
+            FileNameStyleOverrideRaw::Detailed(d) => FileNameStyleOverride {
+                icon: d.icon,
+                filename: d.filename,
+            },
+            FileNameStyleOverrideRaw::Simple(s) => FileNameStyleOverride {
+                icon: None,
+                filename: Some(s),
+            },
+        })
+    }
 }
 
 impl FromOverride<FileNameStyleOverride> for FileNameStyle {
@@ -578,6 +611,7 @@ pub struct UiStylesOverride {
 
     pub filenames: Option<HashMap<String, FileNameStyleOverride>>,
     pub extensions: Option<HashMap<String, FileNameStyleOverride>>,
+    pub directorynames: Option<HashMap<String, FileNameStyleOverride>>,
 }
 
 impl FromOverride<UiStylesOverride> for UiStyles {
@@ -613,6 +647,7 @@ impl FromOverride<UiStylesOverride> for UiStyles {
 
             filenames: FromOverride::from(value.filenames, default.filenames),
             extensions: FromOverride::from(value.extensions, default.extensions),
+            directorynames: FromOverride::from(value.directorynames, default.directorynames),
         }
     }
 }
@@ -675,5 +710,36 @@ mod tests {
         for (s, c) in &[("118", 118), ("10", 10), ("01", 1), ("1", 1), ("001", 1)] {
             assert_eq!(color_from_str(s), Some(Color::Fixed(*c)));
         }
+    }
+
+    #[test]
+    fn parse_filename_style_override_simple() {
+        let yaml = "foreground: Red\nis_bold: true";
+        let style: FileNameStyleOverride = serde_norway::from_str(yaml).unwrap();
+        assert_eq!(style.icon, None);
+        let filename_style = style.filename.unwrap();
+        assert_eq!(filename_style.foreground, Some(Color::Red));
+        assert_eq!(filename_style.is_bold, Some(true));
+    }
+
+    #[test]
+    fn parse_filename_style_override_detailed() {
+        let yaml = "icon:\n  glyph: 🦀\nfilename:\n  foreground: Red";
+        let style: FileNameStyleOverride = serde_norway::from_str(yaml).unwrap();
+        assert_eq!(style.icon.unwrap().glyph, Some('🦀'));
+        let filename_style = style.filename.unwrap();
+        assert_eq!(filename_style.foreground, Some(Color::Red));
+    }
+
+    #[test]
+    fn parse_ui_styles_override_directorynames() {
+        let yaml = "directorynames:\n  RUST:\n    foreground: Red\n    is_bold: true";
+        let ui_override: UiStylesOverride = serde_norway::from_str(yaml).unwrap();
+        let dirnames = ui_override.directorynames.unwrap();
+        let style = dirnames.get("RUST").unwrap();
+        assert_eq!(style.icon, None);
+        let filename_style = style.filename.unwrap();
+        assert_eq!(filename_style.foreground, Some(Color::Red));
+        assert_eq!(filename_style.is_bold, Some(true));
     }
 }

--- a/src/theme/default_theme.rs
+++ b/src/theme/default_theme.rs
@@ -141,6 +141,7 @@ impl Default for UiStyles {
 
             filenames: None,
             extensions: None,
+            directorynames: None,
         }
     }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -478,7 +478,14 @@ impl FileNameColours for Theme {
             .unwrap_or(self.ui.filekinds.unwrap_or_default().normal())
     }
 
- fn style_override(&self, file: &File<'_>) -> Option<FileNameStyle> {
+    fn style_override(&self, file: &File<'_>) -> Option<FileNameStyle> {
+        if file.is_directory() {
+            if let Some(ref dir_overrides) = self.ui.directorynames
+                && let Some(dir_override) = dir_overrides.get(&file.name) {
+                    return Some(*dir_override);
+                }
+        }
+
         if let Some(ref name_overrides) = self.ui.filenames
             && let Some(file_override) = name_overrides.get(&file.name) {
                 return Some(*file_override);
@@ -781,4 +788,48 @@ mod customs_test {
     test!(ls_fi_exa_txt:  ls "fi=33", exa "*.txt=31"  => colours c -> { c.filekinds().normal = Some(Yellow.normal()); }, exts [ ("*.txt", Red.normal()) ]);
     test!(ls_txt_exa_fi:  ls "*.txt=31", exa "fi=33"  => colours c -> { c.filekinds().normal = Some(Yellow.normal()); }, exts [ ("*.txt", Red.normal()) ]);
     test!(eza_fi_exa_txt: ls "", exa "fi=33:*.txt=31" => colours c -> { c.filekinds().normal = Some(Yellow.normal()); }, exts [ ("*.txt", Red.normal()) ]);
+
+    #[test]
+    fn test_directorynames_style_override() {
+        use std::collections::HashMap;
+        use crate::theme::ui_styles::FileNameStyle;
+
+        let dirnames = HashMap::from([(
+            "EZA".to_string(),
+            FileNameStyle {
+                icon: None,
+                filename: Some(Red.bold()),
+            },
+        )]);
+
+        let theme = Theme {
+            ui: UiStyles {
+                directorynames: Some(dirnames),
+                ..UiStyles::default()
+            },
+            exts: Box::new(NoFileStyle),
+        };
+
+        // Set up temporary directory
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir_path = tempdir.path().join("EZA");
+        std::fs::create_dir(&dir_path).unwrap();
+
+        // Test directory behavior
+        let file = File::from_args(dir_path.clone(), None, None, false, false, None);
+        assert!(file.is_directory());
+        
+        let style = theme.style_override(&file).unwrap();
+        assert_eq!(style.filename, Some(Red.bold()));
+
+        // Teardown directory and replace with a regular file
+        std::fs::remove_dir(&dir_path).unwrap();
+        std::fs::write(&dir_path, "").unwrap();
+
+        // Test regular file behavior
+        let file = File::from_args(dir_path, None, None, false, false, None);
+        
+        assert!(!file.is_directory());
+        assert!(theme.style_override(&file).is_none());
+    }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -479,11 +479,11 @@ impl FileNameColours for Theme {
     }
 
     fn style_override(&self, file: &File<'_>) -> Option<FileNameStyle> {
-        if file.is_directory() {
-            if let Some(ref dir_overrides) = self.ui.directorynames
-                && let Some(dir_override) = dir_overrides.get(&file.name) {
-                    return Some(*dir_override);
-                }
+        if file.is_directory()
+            && let Some(ref dir_overrides) = self.ui.directorynames
+            && let Some(dir_override) = dir_overrides.get(&file.name)
+        {
+            return Some(*dir_override);
         }
 
         if let Some(ref name_overrides) = self.ui.filenames
@@ -791,8 +791,8 @@ mod customs_test {
 
     #[test]
     fn test_directorynames_style_override() {
-        use std::collections::HashMap;
         use crate::theme::ui_styles::FileNameStyle;
+        use std::collections::HashMap;
 
         let dirnames = HashMap::from([(
             "EZA".to_string(),
@@ -818,7 +818,7 @@ mod customs_test {
         // Test directory behavior
         let file = File::from_args(dir_path.clone(), None, None, false, false, None);
         assert!(file.is_directory());
-        
+
         let style = theme.style_override(&file).unwrap();
         assert_eq!(style.filename, Some(Red.bold()));
 
@@ -828,7 +828,7 @@ mod customs_test {
 
         // Test regular file behavior
         let file = File::from_args(dir_path, None, None, false, false, None);
-        
+
         assert!(!file.is_directory());
         assert!(theme.style_override(&file).is_none());
     }

--- a/src/theme/ui_styles.rs
+++ b/src/theme/ui_styles.rs
@@ -55,6 +55,7 @@ pub struct UiStyles {
 
     pub filenames: Option<HashMap<String, FileNameStyle>>,
     pub extensions: Option<HashMap<String, FileNameStyle>>,
+    pub directorynames: Option<HashMap<String, FileNameStyle>>,
 }
 // Macro to generate .unwrap_or_default getters for each field to cut down boilerplate
 macro_rules! field_accessors {
@@ -503,6 +504,7 @@ impl UiStyles {
 
             filenames: None,
             extensions: None,
+            directorynames: None,
         }
     }
 }


### PR DESCRIPTION
Allows styles to be applied to specific directories in the same way as with filenames.

For example, in `theme.yml` you can add:

```
directorynames:
  docs:  {foreground: "#5f87ff", is_bold: true}
  src: {foreground: "#5f87ff", is_bold: true}
  tests:  {foreground: "#d75f00", background: "#ffff00", is_bold: true}
```

Opens up all sorts of fun possibilities!