### PR TITLE
docs(install): Update Fedora install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -115,18 +115,9 @@ The preceding repository also contains the Bash, Fish, and Zsh completions.
 
 ### Fedora
 
-[![Fedora package](https://repology.org/badge/version-for-repo/fedora_39/rust:eza.svg)](https://repology.org/project/eza/versions)
+[![Fedora package](https://repology.org/badge/version-for-repo/fedora_44/rust:eza.svg)](https://repology.org/project/eza/versions)
 
-> ⚠️ **Note:** As of **Fedora 42**, `eza` is **no longer available** in the official Fedora repositories due to the absence of an active maintainer.
->
-> If you're using Fedora 42 or newer, consider one of these options:
->
-> - **Use a pre-built binary** from the [Releases](https://github.com/eza-community/eza/releases) page
-> - **Build from source** by following the [Cargo (git)](#cargo-git) instructions above
->
-> 💬 Interested in helping? [Become a Fedora package maintainer](https://docs.fedoraproject.org/en-US/package-maintainers/) or reach out via [Matrix](https://matrix.to/#/#eza-community:gitter.im).
-
-For Fedora versions **prior to 42**, `eza` is available in the official repository:
+Eza is available as the [eza](https://packages.fedoraproject.org/pkgs/rust-eza/eza/) package in the official Fedora repository.
 
 ```bash
 sudo dnf install eza


### PR DESCRIPTION
## Description

The Fedora package is now available in the official repositories, so users can install directly from there.

References:
- https://bugzilla.redhat.com/show_bug.cgi?id=2413750
- https://packages.fedoraproject.org/pkgs/rust-eza/eza/
    - Shows version 0.23.4 for Fedora 42, 43 and 44.
    <img width="1247" height="949" alt="image" src="https://github.com/user-attachments/assets/bf140292-062b-4c5d-9eab-b61424121de7" />


Related to 57618a46bc7596fa1694ace30b2d46b5c85083ad and #1459.