### PR TITLE
fix(theme): honor XDG_CONFIG_HOME for theme lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ precedence for backwards compatibility.
 Check out the themes available in the official [eza-themes](https://github.com/eza-community/eza-themes) repository, or contribute your own.
 
 An example theme file is available in `docs/theme.yml`, and needs to either be placed in a directory specified by the 
-environment variable `EZA_CONFIG_DIR`, or will looked for by default in `$XDG_CONFIG_HOME/eza`.
+environment variable `EZA_CONFIG_DIR`, or will be looked for by default in `$XDG_CONFIG_HOME/eza` when that variable is set.
+If `XDG_CONFIG_HOME` is not set, eza uses the platform configuration directory.
 
 Full details are available on the [man page](https://github.com/eza-community/eza/tree/main/man/eza_colors-explanation.5.md) and an example theme file is included [here](https://github.com/eza-community/eza/tree/main/docs/theme.yml)
 

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -369,7 +369,7 @@ Specifies the separator to use when file names are piped from stdin. Defaults to
 
 ## `EZA_CONFIG_DIR`
 
-Specifies the directory where eza will look for its configuration and theme files. Defaults to `$XDG_CONFIG_HOME/eza` or `$HOME/.config/eza` if `XDG_CONFIG_HOME` is not set.
+Specifies the directory where eza will look for its configuration and theme files. Defaults to `$XDG_CONFIG_HOME/eza` when `XDG_CONFIG_HOME` is set, otherwise eza uses the platform configuration directory.
 
 EXIT STATUSES
 =============

--- a/man/eza_colors-explanation.5.md
+++ b/man/eza_colors-explanation.5.md
@@ -49,8 +49,9 @@ in the same directory as one of its source files: styles.css will count as compi
 
 Now you can specify these options and more in a `theme.yml` file with convenient syntax for defining your styles.
 
-Set `EZA_CONFIG_DIR` to specify which directory you would like eza to look for your `theme.yml` file,
-otherwise eza will look for `$XDG_CONFIG_HOME/eza/theme.yml`.
+Set `EZA_CONFIG_DIR` to specify which directory you would like eza to look for your `theme.yml` file.
+If `EZA_CONFIG_DIR` is not set, eza will look for `$XDG_CONFIG_HOME/eza/theme.yml` when `XDG_CONFIG_HOME` is set.
+If neither variable is set, eza uses the platform configuration directory.
 
 
 These are the available options:
@@ -223,7 +224,7 @@ Not all glyphs support changing colors.
 If your theme is not working properly, double check the syntax in the config file, as
 a syntax issue can cause multiple properties to not be applied.
 
-You must name the file `theme.yml`, no matter the directory you specify.
+You can name the file `theme.yml` or `theme.yaml`, no matter the directory you specify.
 
 
 ## See also

--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -4,6 +4,7 @@
 // SPDX-FileCopyrightText: 2023-2024 Christina Sørensen, eza contributors
 // SPDX-FileCopyrightText: 2014 Benjamin Sago
 // SPDX-License-Identifier: MIT
+use crate::options::vars;
 use crate::theme::ThemeFileType as FileType;
 use crate::theme::{
     FileKinds, FileNameStyle, Git, GitRepo, IconStyle, Links, Permissions, SELinuxContext,
@@ -13,6 +14,7 @@ use nu_ansi_term::{Color, Style};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_norway;
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::path::PathBuf;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -23,13 +25,32 @@ pub struct ThemeConfig {
 
 impl Default for ThemeConfig {
     fn default() -> Self {
+        let config_dir = config_dir_from_env(
+            std::env::var_os(vars::EZA_CONFIG_DIR),
+            std::env::var_os(vars::XDG_CONFIG_HOME),
+        );
+
         ThemeConfig {
-            location: dirs::config_dir()
-                .unwrap_or_default()
-                .join("eza")
-                .join("theme.yml"),
+            location: config_dir.join("theme.yml"),
         }
     }
+}
+
+pub(crate) fn config_dir_from_env(
+    eza_config_dir: Option<OsString>,
+    xdg_config_home: Option<OsString>,
+) -> PathBuf {
+    eza_config_dir
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            xdg_config_home
+                .filter(|path| !path.as_os_str().is_empty())
+                .map(PathBuf::from)
+                .filter(|path| path.is_absolute())
+                .map(|path| path.join("eza"))
+        })
+        .unwrap_or_else(|| dirs::config_dir().unwrap_or_default().join("eza"))
 }
 
 trait FromOverride<T>: Sized {
@@ -634,6 +655,40 @@ impl ThemeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+
+    fn default_config_dir() -> std::path::PathBuf {
+        dirs::config_dir().unwrap_or_default().join("eza")
+    }
+
+    #[test]
+    fn config_dir_ignores_empty_xdg_config_home() {
+        assert_eq!(
+            config_dir_from_env(None, Some(OsString::new())),
+            default_config_dir()
+        );
+    }
+
+    #[test]
+    fn config_dir_ignores_relative_xdg_config_home() {
+        assert_eq!(
+            config_dir_from_env(None, Some(OsString::from("relative"))),
+            default_config_dir()
+        );
+    }
+
+    #[test]
+    fn config_dir_ignores_empty_eza_config_dir() {
+        let xdg_config_home = std::env::temp_dir().join("eza-xdg-config-home");
+
+        assert_eq!(
+            config_dir_from_env(
+                Some(OsString::new()),
+                Some(xdg_config_home.as_os_str().to_os_string()),
+            ),
+            xdg_config_home.join("eza")
+        );
+    }
 
     #[test]
     fn parse_none_color_from_string() {

--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -10,9 +10,8 @@ use crate::options::parser::ShowWhen;
 use crate::options::{vars, Vars};
 use crate::output::color_scale::ColorScaleOptions;
 use crate::theme::{Definitions, Options, UseColours};
-use std::path::PathBuf;
 
-use super::config::ThemeConfig;
+use super::config::{config_dir_from_env, ThemeConfig};
 
 impl Options {
     pub fn deduce<V: Vars>(matches: &ArgMatches, vars: &V) -> Self {
@@ -37,30 +36,20 @@ impl Options {
 
 impl ThemeConfig {
     fn deduce<V: Vars>(vars: &V) -> Option<Self> {
-        if let Some(path) = vars.get("EZA_CONFIG_DIR") {
-            let path = PathBuf::from(path);
-            let theme = path.join("theme.yml");
-            if theme.exists() {
-                return Some(ThemeConfig::from_path(theme));
-            }
-            let theme = path.join("theme.yaml");
-            if theme.exists() {
-                return Some(ThemeConfig::from_path(theme));
-            }
-            None
-        } else {
-            let path = dirs::config_dir().unwrap_or_default();
-            let path = path.join("eza");
-            let theme = path.join("theme.yml");
-            if theme.exists() {
-                return Some(ThemeConfig::default());
-            }
-            let theme = path.join("theme.yaml");
-            if theme.exists() {
-                return Some(ThemeConfig::from_path(theme));
-            }
-            None
+        let path = config_dir_from_env(
+            vars.get(vars::EZA_CONFIG_DIR),
+            vars.get(vars::XDG_CONFIG_HOME),
+        );
+
+        let theme = path.join("theme.yml");
+        if theme.exists() {
+            return Some(ThemeConfig::from_path(theme));
         }
+        let theme = path.join("theme.yaml");
+        if theme.exists() {
+            return Some(ThemeConfig::from_path(theme));
+        }
+        None
     }
 }
 
@@ -96,6 +85,19 @@ mod tests {
     use super::*;
     use crate::options::{parser::test::mock_cli, vars::test::MockVars};
     use std::ffi::OsString;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("eza-{name}-{nanos}"));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
 
     #[test]
     fn deduce_definitions() {
@@ -126,6 +128,72 @@ mod tests {
                 ls: Some("uR=1;34".to_string()),
                 exa: Some("uR=1;34".to_string()),
             }
+        );
+    }
+
+    #[test]
+    fn deduce_theme_from_eza_config_dir() {
+        let config_dir = temp_dir("eza-config-dir");
+        let theme = config_dir.join("theme.yml");
+        fs::write(&theme, "filekinds:\n  normal: { foreground: red }\n").unwrap();
+
+        let mut vars = MockVars {
+            ..MockVars::default()
+        };
+        vars.set(vars::EZA_CONFIG_DIR, &config_dir.as_os_str().to_os_string());
+
+        assert_eq!(ThemeConfig::deduce(&vars), Some(ThemeConfig::from_path(theme)));
+    }
+
+    #[test]
+    fn deduce_theme_from_xdg_config_home() {
+        let xdg_config_home = temp_dir("xdg-config-home");
+        let config_dir = xdg_config_home.join("eza");
+        fs::create_dir_all(&config_dir).unwrap();
+        let theme = config_dir.join("theme.yml");
+        fs::write(&theme, "filekinds:\n  normal: { foreground: red }\n").unwrap();
+
+        let mut vars = MockVars {
+            ..MockVars::default()
+        };
+        vars.set(
+            vars::XDG_CONFIG_HOME,
+            &xdg_config_home.as_os_str().to_os_string(),
+        );
+
+        assert_eq!(ThemeConfig::deduce(&vars), Some(ThemeConfig::from_path(theme)));
+    }
+
+    #[test]
+    fn eza_config_dir_takes_precedence_over_xdg_config_home() {
+        let eza_config_dir = temp_dir("eza-config-dir-priority");
+        let eza_theme = eza_config_dir.join("theme.yml");
+        fs::write(&eza_theme, "filekinds:\n  normal: { foreground: red }\n").unwrap();
+
+        let xdg_config_home = temp_dir("xdg-config-home-priority");
+        let xdg_config_dir = xdg_config_home.join("eza");
+        fs::create_dir_all(&xdg_config_dir).unwrap();
+        fs::write(
+            xdg_config_dir.join("theme.yml"),
+            "filekinds:\n  normal: { foreground: blue }\n",
+        )
+        .unwrap();
+
+        let mut vars = MockVars {
+            ..MockVars::default()
+        };
+        vars.set(
+            vars::EZA_CONFIG_DIR,
+            &eza_config_dir.as_os_str().to_os_string(),
+        );
+        vars.set(
+            vars::XDG_CONFIG_HOME,
+            &xdg_config_home.as_os_str().to_os_string(),
+        );
+
+        assert_eq!(
+            ThemeConfig::deduce(&vars),
+            Some(ThemeConfig::from_path(eza_theme))
         );
     }
 

--- a/src/options/vars.rs
+++ b/src/options/vars.rs
@@ -72,6 +72,12 @@ pub static EZA_ICONS_AUTO: &str = "EZA_ICONS_AUTO";
 
 pub static EZA_STDIN_SEPARATOR: &str = "EZA_STDIN_SEPARATOR";
 
+/// Environment variable used to set the eza configuration directory.
+pub static EZA_CONFIG_DIR: &str = "EZA_CONFIG_DIR";
+
+/// Environment variable used to set the XDG base configuration directory.
+pub static XDG_CONFIG_HOME: &str = "XDG_CONFIG_HOME";
+
 /// Environment variable used to choose how windows attributes are displayed.
 /// Short will display a single character for each set attribute, long will
 /// display a comma separated list of descriptions.
@@ -119,6 +125,8 @@ pub mod test {
         pub icon_spacing: OsString,
         pub luminance: OsString,
         pub icons: OsString,
+        pub config_dir: OsString,
+        pub xdg_config_home: OsString,
         pub time: OsString,
     }
 
@@ -140,6 +148,10 @@ pub mod test {
                     Some(self.luminance.clone())
                 }
                 "EZA_ICONS_AUTO" if !self.icons.is_empty() => Some(self.icons.clone()),
+                "EZA_CONFIG_DIR" if !self.config_dir.is_empty() => Some(self.config_dir.clone()),
+                "XDG_CONFIG_HOME" if !self.xdg_config_home.is_empty() => {
+                    Some(self.xdg_config_home.clone())
+                }
                 "COLUMNS" if !self.columns.is_empty() => Some(self.columns.clone()),
                 "NO_COLOR" if !self.no_colors.is_empty() => Some(self.no_colors.clone()),
                 "TIME_STYLE" if !self.time.is_empty() => Some(self.time.clone()),
@@ -158,6 +170,8 @@ pub mod test {
                 "EXA_ICON_SPACING" | "EZA_ICON_SPACING" => self.icon_spacing = value.clone(),
                 "EXA_MIN_LUMINANCE" | "EZA_MIN_LUMINANCE" => self.luminance = value.clone(),
                 "EZA_ICONS_AUTO" => self.icons = value.clone(),
+                "EZA_CONFIG_DIR" => self.config_dir = value.clone(),
+                "XDG_CONFIG_HOME" => self.xdg_config_home = value.clone(),
                 "COLUMNS" => self.columns = value.clone(),
                 "NO_COLOR" => self.no_colors = value.clone(),
                 "TIME_STYLE" => self.time = value.clone(),


### PR DESCRIPTION
##### Description

Fixes #1224.

This updates theme lookup to use `EZA_CONFIG_DIR` first, then `$XDG_CONFIG_HOME/eza` when `XDG_CONFIG_HOME` is set to an absolute path, and finally the platform config directory as the fallback.

That keeps the platform-native fallback on macOS, while honoring an explicitly configured `XDG_CONFIG_HOME` for users who keep their eza config under `~/.config/eza`.

This also fixes the default `theme.yml` branch to load the discovered file path instead of returning `ThemeConfig::default()`, matching the existing `theme.yaml` behavior.

##### How Has This Been Tested?

Reproduced the current macOS lookup behavior with temporary `XDG_CONFIG_HOME` and `EZA_CONFIG_DIR` directories using eza v0.23.4.

Added unit coverage for `EZA_CONFIG_DIR`, `XDG_CONFIG_HOME`, empty and relative `XDG_CONFIG_HOME`, and precedence.

CI covers the full formatting, lint, build, and test matrix on the PR.
