### PR TITLE
feat: add --gen-completions for runtime shell completion generation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,14 @@ fn main() {
 
     let cli = get_command().get_matches();
 
+    if let Some(shell) = cli.get_one::<String>("gen-completions") {
+        if let Err(err) = options::completions::print_completions(shell, &mut io::stdout()) {
+            eprintln!("eza: {err}");
+            exit(2);
+        }
+        return;
+    }
+
     let stdout_istty = io::stdout().is_terminal();
     let mut input = String::new();
     let mut input_paths: Vec<&OsStr> = match cli.get_many("FILE") {

--- a/src/options/completions.rs
+++ b/src/options/completions.rs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2024 Christina Sørensen
+// SPDX-License-Identifier: EUPL-1.2
+use std::io::{self, Write};
+
+pub fn print_completions(shell: &str, dest: &mut dyn Write) -> io::Result<()> {
+    let script = match shell {
+        "bash" => include_str!("../../completions/bash/eza"),
+        "fish" => include_str!("../../completions/fish/eza.fish"),
+        "zsh" => include_str!("../../completions/zsh/_eza"),
+        "powershell" | "pwsh" => include_str!("../../completions/pwsh/_eza.ps1"),
+        "nushell" | "nu" => include_str!("../../completions/nush/eza.nu"),
+        other => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unknown shell for completions: {other}"),
+            ));
+        }
+    };
+    dest.write_all(script.as_bytes())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn fish_completions_contain_complete_directive() {
+        let mut buf = Cursor::new(Vec::new());
+        print_completions("fish", &mut buf).unwrap();
+        let out = String::from_utf8(buf.into_inner()).unwrap();
+        assert!(out.contains("complete -c eza"));
+    }
+
+    #[test]
+    fn unknown_shell_is_rejected() {
+        let mut buf = Cursor::new(Vec::new());
+        assert!(print_completions("nope", &mut buf).is_err());
+    }
+}

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -92,6 +92,7 @@ mod view;
 
 pub use self::error::{NumberSource, OptionsError};
 
+pub mod completions;
 pub mod parser;
 
 pub mod vars;

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -37,6 +37,11 @@ pub fn get_command() -> clap::Command {
 
         .next_help_heading("META OPTIONS")
         .arg(arg!(--stdin "read file names from stdin"))
+        .arg(
+            arg!(--"gen-completions" <SHELL> "print shell completions to stdout")
+                .alias("generate-shell-completion")
+                .value_parser(["bash", "fish", "zsh", "powershell", "pwsh", "nushell", "nu"]),
+        )
         .arg(arg!(-'?' --help "Print help").action(clap::ArgAction::HelpShort))
         .arg(arg!(-v --version "Print help").action(clap::ArgAction::Version))
 

--- a/tests/cmd/gen_completions_fish_all.toml
+++ b/tests/cmd/gen_completions_fish_all.toml
@@ -1,0 +1,2 @@
+bin.name = "eza"
+args = "--gen-completions fish"

--- a/tests/cmd/gen_completions_invalid_all.toml
+++ b/tests/cmd/gen_completions_invalid_all.toml
@@ -1,0 +1,3 @@
+bin.name = "eza"
+args = "--gen-completions nope"
+status.code = 2


### PR DESCRIPTION
## Summary
- Add `--gen-completions <SHELL>` (alias `--generate-shell-completion`) to print bundled shell completion scripts to stdout
- Supports `bash`, `fish`, `zsh`, `powershell`/`pwsh`, and `nushell`/`nu`
- Enables sourcing completions from tool managers (mise, aqua, etc.) without bundled completion files

Fixes #1779

## Usage
```bash
eza --gen-completions fish | source
eza --generate-shell-completion zsh > ~/.local/share/zsh/site-functions/_eza
```

## Test plan
- [x] `cargo test completions`
- [x] `cargo test cli_all_tests` (includes gen_completions trycmd cases)