### PR TITLE
fix: bump uutils_term_grid to 0.8.0 for grid width estimation (fixes #1738)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,9 +1723,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uutils_term_grid"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcba141ce511bad08e80b43f02976571072e1ff4286f7d628943efbd277c6361"
+checksum = "382d49b39de4a115f203305057741126b09a615892d773a2d419a2b816e30e39"
 dependencies = [
  "ansi-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ palette = { version = "=0.7.5", default-features = false, features = ["std"] }
 percent-encoding = "2.3.1"
 phf = { version = "0.13.1", features = ["macros"] }
 plist = { version = "1.7.0", default-features = false }
-uutils_term_grid = "0.7.0"
+uutils_term_grid = "0.8.0"
 terminal_size = "0.4.2"
 timeago = { version = "0.6.0", default-features = false }
 unicode-width = "0.2"


### PR DESCRIPTION
## Summary

Fixes #1738 by bumping `uutils_term_grid` from 0.7.0 to 0.8.0.

When listing entries in the default grid view, eza uses `uutils_term_grid` to compute column layout. Version 0.7.0 had an off-by-one in the column-search loop: when cells have varying widths, the algorithm could fail to try a single-row layout (`num_columns == cells.len()`), causing unnecessary line breaks.

Version 0.8.0 fixes this upstream (see [uutils/uutils-term-grid#…](https://github.com/uutils/uutils-term-grid) and the `all_cells_fit_on_one_row_when_widths_vary` regression test).

**Reproduction (before fix):** With terminal width 96 and files like `code Desktop Documents Downloads Music Pictures Public Templates Videos` (total width 79), eza split output across two rows.

**After fix:** All entries fit on one row as expected.

## Changes

- `Cargo.toml`: `uutils_term_grid` 0.7.0 → 0.8.0
- `Cargo.lock`: updated accordingly

## Test plan

- [x] `cargo test --lib` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Verified `uutils_term_grid` 0.8.0 renders the #1738 scenario in a single row