### PR TITLE
fix(sort): map newest/oldest aliases to intuitive order (fixes #1772)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ These options are available when running with `--long` (`-l`):
 Some of the options accept parameters:
 
 - Valid **--colo\[u\]r** options are **always**, **automatic** (or **auto** for short), and **never**.
-- Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **newest**, while its reverse has the aliases **age** and **oldest**.
+- Valid sort fields are **accessed**, **changed**, **created**, **extension**, **Extension**, **inode**, **modified**, **name**, **Name**, **size**, **type**, and **none**. Fields starting with a capital letter sort uppercase before lowercase. The modified field has the aliases **date**, **time**, and **oldest**, while its reverse has the aliases **age** and **newest**.
 - Valid time fields are **modified**, **changed**, **accessed**, and **created**.
 - Valid time styles are **default**, **iso**, **long-iso**, **full-iso**, and **relative**.
 

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -79,7 +79,7 @@ complete -c eza -s s -l sort -d "Which field to sort by" -x -a "
     Name\t'Sort by filename (uppercase first)'
     newest\t'Sort by file modified time (newest first)'
     none\t'Do not sort files at all'
-    oldest\t'Sort by file modified time'
+    oldest\t'Sort by file modified time (oldest first)'
     size\t'Sort by file size'
     time\t'Sort by file modified time'
     type\t'Sort by file type'

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -164,7 +164,7 @@ Use this twice to also show the ‘`.`’ and ‘`..`’ directories.
 
 Valid sort fields are ‘`name`’, ‘`Name`’, ‘`extension`’, ‘`Extension`’, ‘`size`’, ‘`modified`’, ‘`changed`’, ‘`accessed`’, ‘`created`’, ‘`inode`’, ‘`type`’, and ‘`none`’.
 
-The `modified` sort field has the aliases ‘`date`’, ‘`time`’, and ‘`newest`’, and its reverse order has the aliases ‘`age`’ and ‘`oldest`’.
+The `modified` sort field has the aliases ‘`date`’, ‘`time`’, and ‘`oldest`’, and its reverse order has the aliases ‘`age`’ and ‘`newest`’.
 
 Sort fields starting with a capital letter will sort uppercase before lowercase: ‘A’ then ‘B’ then ‘a’ then ‘b’. Fields starting with a lowercase letter will mix them: ‘A’ then ‘a’ then ‘B’ then ‘b’.
 

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -347,6 +347,22 @@ mod tests {
     }
 
     #[test]
+    fn deduce_sort_field_newest() {
+        assert_eq!(
+            mock_cli(vec!["--sort", "newest"]).get_one::<SortField>("sort"),
+            Some(&SortField::ModifiedAge)
+        );
+    }
+
+    #[test]
+    fn deduce_sort_field_oldest() {
+        assert_eq!(
+            mock_cli(vec!["--sort", "oldest"]).get_one::<SortField>("sort"),
+            Some(&SortField::ModifiedDate)
+        );
+    }
+
+    #[test]
     fn deduce_sort_field_ch() {
         assert_eq!(
             mock_cli(vec!["--sort", "ch"]).get_one::<SortField>("sort"),

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -231,15 +231,13 @@ impl ValueEnum for SortField {
             Self::Size => PossibleValue::new("size"),
             Self::Extension(SortCase::AaBbCc) => PossibleValue::new("ext").alias("extension"),
             Self::Extension(SortCase::ABCabc) => PossibleValue::new("Ext").alias("Extension"),
-            // “new” sorts oldest at the top and newest at the bottom; “old” sorts newest at the
-            // top and oldest at the bottom. I think this is the right way round to do this:
-            // “size” puts the smallest at  the top and the largest at the bottom, doesn’t it?
+            // `date`/`time`/`modified` sort oldest at the top; `age`/`newest` sort newest first.
             Self::ModifiedDate => {
-                PossibleValue::new("date").aliases(vec!["time", "mod", "modified", "new", "newest"])
+                PossibleValue::new("date").aliases(vec!["time", "mod", "modified", "new", "oldest"])
             }
             // Similarly, “age” means that files with the least age (the newest files) get sorted
             //  at the top, and files with the most age (the oldest) at the bottom.
-            Self::ModifiedAge => PossibleValue::new("age").aliases(vec!["old", "oldest"]),
+            Self::ModifiedAge => PossibleValue::new("age").aliases(vec!["old", "newest"]),
             Self::ChangedDate => PossibleValue::new("changed").alias("ch"),
             Self::AccessedDate => PossibleValue::new("accessed").alias("acc"),
             Self::CreatedDate => PossibleValue::new("created").alias("cr"),


### PR DESCRIPTION
## Summary

Fixes #1772.

Previously `--sort=newest` mapped to `ModifiedDate` (oldest files first) and `--sort=oldest` mapped to `ModifiedAge` (newest files first), which is the opposite of what the names and fish completion text suggest.

This PR swaps the aliases so that:

- `--sort=newest` → `ModifiedAge` (newest files first)
- `--sort=oldest` → `ModifiedDate` (oldest files first)

Docs and fish completion are updated accordingly.

## Test plan

- [x] `cargo test options::filter::tests::deduce_sort_field`
- [x] `cargo clippy -- -D warnings`