### PR TITLE
feat: add --ignore-contents for tree mode

### DIFF
--- a/src/fs/filter.rs
+++ b/src/fs/filter.rs
@@ -82,6 +82,11 @@ pub struct FileFilter {
     /// patterns won’t be displayed in the list.
     pub ignore_patterns: IgnorePatterns,
 
+    /// Glob patterns for directories whose contents should be hidden in tree
+    /// mode. Matching directories are still shown, with a `…` placeholder
+    /// instead of their children.
+    pub ignore_contents_patterns: IgnorePatterns,
+
     /// Whether to ignore Git-ignored patterns.
     pub git_ignore: GitIgnore,
 
@@ -374,8 +379,13 @@ impl IgnorePatterns {
     }
 
     /// Test whether the given file should be hidden from the results.
-    fn is_ignored(&self, file: &str) -> bool {
+    pub fn matches(&self, file: &str) -> bool {
         self.patterns.iter().any(|p| p.matches(file))
+    }
+
+    /// Test whether the given file should be hidden from the results.
+    fn is_ignored(&self, file: &str) -> bool {
+        self.matches(file)
     }
 }
 

--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -42,6 +42,7 @@ impl FileFilter {
             sort_field: *matches.get_one("sort").unwrap(),
             dot_filter: DotFilter::deduce(matches, strict)?,
             ignore_patterns: IgnorePatterns::deduce(matches)?,
+            ignore_contents_patterns: IgnorePatterns::deduce_contents(matches)?,
             git_ignore: GitIgnore::deduce(matches),
         })
     }
@@ -124,9 +125,19 @@ impl IgnorePatterns {
     /// `--ignore-glob` argument’s value. This is a list of strings
     /// separated by pipe (`|`) characters, given in any order.
     pub fn deduce(matches: &ArgMatches) -> Result<Self, OptionsError> {
+        Self::deduce_from_arg(matches, "ignore-glob")
+    }
+
+    /// Determines the set of glob patterns to use based on the
+    /// `--ignore-contents` argument’s value.
+    pub fn deduce_contents(matches: &ArgMatches) -> Result<Self, OptionsError> {
+        Self::deduce_from_arg(matches, "ignore-contents")
+    }
+
+    fn deduce_from_arg(matches: &ArgMatches, arg: &str) -> Result<Self, OptionsError> {
         // If there are no inputs, we return a set of patterns that doesn’t
         // match anything, rather than, say, `None`.
-        let Some(inputs) = matches.get_one::<String>("ignore-glob") else {
+        let Some(inputs) = matches.get_one::<String>(arg) else {
             return Ok(Self::empty());
         };
 
@@ -188,6 +199,17 @@ mod tests {
 
         assert_eq!(
             IgnorePatterns::deduce(&mock_cli(vec!["--ignore-glob", "*.o"])),
+            Ok(res)
+        );
+    }
+
+    #[test]
+    fn deduce_ignore_contents_one() {
+        let pattern = OsString::from("target");
+        let (res, _) = IgnorePatterns::parse_from_iter(pattern.to_string_lossy().split('|'));
+
+        assert_eq!(
+            IgnorePatterns::deduce_contents(&mock_cli(vec!["--ignore-contents", "target"])),
             Ok(res)
         );
     }
@@ -384,6 +406,7 @@ mod tests {
                 sort_field: SortField::default(),
                 dot_filter: DotFilter::JustFiles,
                 ignore_patterns: IgnorePatterns::empty(),
+                ignore_contents_patterns: IgnorePatterns::empty(),
                 git_ignore: GitIgnore::Off,
                 no_symlinks: false,
                 show_symlinks: false,
@@ -400,6 +423,7 @@ mod tests {
                 sort_field: SortField::default(),
                 dot_filter: DotFilter::JustFiles,
                 ignore_patterns: IgnorePatterns::empty(),
+                ignore_contents_patterns: IgnorePatterns::empty(),
                 git_ignore: GitIgnore::Off,
                 no_symlinks: false,
                 show_symlinks: false,
@@ -416,6 +440,7 @@ mod tests {
                 sort_field: SortField::default(),
                 dot_filter: DotFilter::JustFiles,
                 ignore_patterns: IgnorePatterns::empty(),
+                ignore_contents_patterns: IgnorePatterns::empty(),
                 git_ignore: GitIgnore::Off,
                 no_symlinks: false,
                 show_symlinks: false,
@@ -432,6 +457,7 @@ mod tests {
                 sort_field: SortField::default(),
                 dot_filter: DotFilter::JustFiles,
                 ignore_patterns: IgnorePatterns::empty(),
+                ignore_contents_patterns: IgnorePatterns::empty(),
                 git_ignore: GitIgnore::Off,
                 no_symlinks: false,
                 show_symlinks: false,

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -102,6 +102,7 @@ pub fn get_command() -> clap::Command {
         .arg(arg!(--"show-symlinks" "explicitly show symbolic links (with --only-dirs and --only-files)"))
         .arg(arg!(--"no-symlinks" "do not show symbolic links"))
         .arg(arg!(-I --"ignore-glob" <GLOBS> "glob patterns (pipe-separated) of files to ignore"))
+        .arg(arg!(--"ignore-contents" <GLOBS> "in tree mode, hide contents of matching directories (pipe-separated globs)"))
         .arg(arg!(--"git-ignore" "ignore files mentioned in '.gitignore'"))
 
         .next_help_heading("SORTING OPTIONS")

--- a/src/output/details.rs
+++ b/src/output/details.rs
@@ -156,6 +156,7 @@ struct Egg<'a> {
     errors:    Vec<(io::Error, Option<PathBuf>)>,
     dir:       Option<Dir>,
     file:      &'a File<'a>,
+    hide_contents: bool,
 }
 
 impl<'a> AsRef<File<'a>> for Egg<'a> {
@@ -295,6 +296,13 @@ impl<'a> Render<'a> {
 
                 let mut dir = None;
                 let follow_links = self.opts.follow_links;
+                let hide_contents = self.recurse.as_ref().is_some_and(|r| r.tree)
+                    && self.filter.ignore_contents_patterns.matches(&file.name)
+                    && (if follow_links {
+                        file.points_to_directory()
+                    } else {
+                        file.is_directory()
+                    });
                 if let Some(r) = self.recurse
                     && (if follow_links {
                         file.points_to_directory()
@@ -303,6 +311,7 @@ impl<'a> Render<'a> {
                     })
                     && r.tree
                     && !r.is_too_deep(depth.0)
+                    && !hide_contents
                 {
                     trace!("matching on read_dir");
                     match file.read_dir() {
@@ -321,6 +330,7 @@ impl<'a> Render<'a> {
                     errors,
                     dir,
                     file,
+                    hide_contents,
                 }
             })
             .collect();
@@ -353,6 +363,11 @@ impl<'a> Render<'a> {
             };
 
             rows.push(row);
+
+            if egg.hide_contents {
+                rows.push(self.render_tree_placeholder(TreeParams::new(depth.deeper(), true)));
+                continue;
+            }
 
             if let Some(ref dir) = egg.dir {
                 for file_to_add in dir.files(
@@ -428,6 +443,14 @@ impl<'a> Render<'a> {
             cells: None,
             name,
             tree,
+        }
+    }
+
+    fn render_tree_placeholder(&self, tree: TreeParams) -> Row {
+        Row {
+            tree,
+            cells: None,
+            name: TextCell::paint_str(self.theme.ui.punctuation.unwrap_or_default(), "…"),
         }
     }
 

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -30,15 +30,16 @@ DISPLAY OPTIONS:
       --no-quotes                  don't quote file names with spaces
 
 FILTERING OPTIONS:
-  -a, --all...               show hidden files. Use this twice to also show the '.' and '..' directories
-  -A, --almost-all           equivalent to --all; included for compatibility with `ls -A`
-  -d, --treat-dirs-as-files  treat directories as files; don't list their contents
-  -D, --only-dirs            list only directories
-  -f, --only-files           list only files
-      --show-symlinks        explicitly show symbolic links (with --only-dirs and --only-files)
-      --no-symlinks          do not show symbolic links
-  -I, --ignore-glob <GLOBS>  glob patterns (pipe-separated) of files to ignore
-      --git-ignore           ignore files mentioned in '.gitignore'
+  -a, --all...                   show hidden files. Use this twice to also show the '.' and '..' directories
+  -A, --almost-all               equivalent to --all; included for compatibility with `ls -A`
+  -d, --treat-dirs-as-files      treat directories as files; don't list their contents
+  -D, --only-dirs                list only directories
+  -f, --only-files               list only files
+      --show-symlinks            explicitly show symbolic links (with --only-dirs and --only-files)
+      --no-symlinks              do not show symbolic links
+  -I, --ignore-glob <GLOBS>      glob patterns (pipe-separated) of files to ignore
+      --ignore-contents <GLOBS>  in tree mode, hide contents of matching directories (pipe-separated globs)
+      --git-ignore               ignore files mentioned in '.gitignore'
 
 SORTING OPTIONS:
       --group-directories-first  list directories before other files


### PR DESCRIPTION
## Summary

- Add `--ignore-contents <GLOBS>` (pipe-separated globs, like `--ignore-glob`)
- In tree mode, matching directories remain visible but their children are replaced with a `…` placeholder
- Useful for showing `.git` / `target` in a tree without listing their contents

Fixes #1778

Related: #1446

## Test plan

- [x] `cargo test options::filter::tests::deduce_ignore_contents_one`
- [x] Manual: `eza --all --tree --ignore-contents 'target|.git'` shows directories with `…` children
- [x] `cargo clippy -- -D warnings`