### PR TITLE
fix(view): use stdout TTY detection for default grid layout (fixes #1769)

### DIFF
--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -32,7 +32,8 @@ impl View {
     ) -> Result<Self, OptionsError> {
         let width = TerminalWidth::deduce(matches, vars)?;
         let is_tty = io::stdout().is_terminal();
-        let mode = Mode::deduce(matches, vars, is_tty, strict)?;
+        let default_grid = is_tty || matches!(width, Set(_));
+        let mode = Mode::deduce(matches, vars, default_grid, strict)?;
         let deref_links = matches.get_flag("dereference");
         let follow_links = matches.get_flag("follow-symlinks");
         let total_size = matches.get_flag("total-size");
@@ -943,6 +944,20 @@ mod tests {
         assert_eq!(
             Mode::deduce(&mock_cli(vec![""]), &MockVars::default(), false, false),
             Ok(Mode::Lines)
+        );
+    }
+
+    #[test]
+    fn deduce_view_defaults_to_grid_with_explicit_width() {
+        assert_eq!(
+            View::deduce(
+                &mock_cli(vec!["--width", "80"]),
+                &MockVars::default(),
+                false
+            )
+            .unwrap()
+            .mode,
+            Mode::Grid(grid::Options { across: false })
         );
     }
 

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -5,6 +5,7 @@
 // SPDX-FileCopyrightText: 2014 Benjamin Sago
 // SPDX-License-Identifier: MIT
 use clap::{ArgMatches, ValueEnum};
+use std::io::{self, IsTerminal};
 
 use crate::output::TerminalWidth::Automatic;
 
@@ -30,7 +31,7 @@ impl View {
         strict: bool,
     ) -> Result<Self, OptionsError> {
         let width = TerminalWidth::deduce(matches, vars)?;
-        let is_tty = width.actual_terminal_width().is_some();
+        let is_tty = io::stdout().is_terminal();
         let mode = Mode::deduce(matches, vars, is_tty, strict)?;
         let deref_links = matches.get_flag("dereference");
         let follow_links = matches.get_flag("follow-symlinks");
@@ -926,6 +927,22 @@ mod tests {
                 false
             ),
             Ok(Mode::Grid(grid::Options { across: false }))
+        );
+    }
+
+    #[test]
+    fn deduce_mode_defaults_to_grid_on_tty() {
+        assert_eq!(
+            Mode::deduce(&mock_cli(vec![""]), &MockVars::default(), true, false),
+            Ok(Mode::Grid(grid::Options { across: false }))
+        );
+    }
+
+    #[test]
+    fn deduce_mode_defaults_to_lines_when_not_tty() {
+        assert_eq!(
+            Mode::deduce(&mock_cli(vec![""]), &MockVars::default(), false, false),
+            Ok(Mode::Lines)
         );
     }
 


### PR DESCRIPTION
## Summary

Default layout mode was inferred from whether terminal width could be detected. On some Windows terminals (e.g. Windows Terminal), width detection can fail even when stdout is an interactive TTY, causing eza to fall back to one-entry-per-line output instead of the default grid.

Use `stdout.is_terminal()` for layout selection; width detection remains separate and already falls back to 80 columns for grid rendering.

Fixes #1769

## Test plan

- [x] `cargo test --lib` — 334 passed
- [x] Added tests for default grid on TTY vs lines when not a TTY

Made with [Cursor](https://cursor.com)