### PR TITLE
test(options): document --hyperlink auto/always/never and override behavior (closes #1773)

### DIFF
--- a/src/options/file_name.rs
+++ b/src/options/file_name.rs
@@ -181,6 +181,23 @@ mod tests {
     }
 
     #[test]
+    fn deduce_embed_hyperlinks_last_flag_wins() {
+        assert_eq!(
+            EmbedHyperlinks::deduce(&mock_cli(vec![
+                "--hyperlink",
+                "never",
+                "--hyperlink",
+                "always"
+            ])),
+            EmbedHyperlinks::Always
+        );
+        assert_eq!(
+            EmbedHyperlinks::deduce(&mock_cli(vec!["--hyperlink", "always", "--hyperlink"])),
+            EmbedHyperlinks::Automatic
+        );
+    }
+
+    #[test]
     fn deduce_show_icons_never_no_arg() {
         assert_eq!(
             ShowIcons::deduce(&mock_cli(vec![""]), &MockVars::default()),


### PR DESCRIPTION
## Summary

Closes #1773.

The requested `--hyperlink` behavior is already implemented:

- `--hyperlink` defaults to `auto` via `default_missing_value("auto")`
- `--hyperlink auto|always|never` selects the corresponding mode
- Repeated `--hyperlink` flags override earlier values via global `args_override_self(true)`

This PR adds regression tests for the override behavior so the feature is explicitly covered.

## Test plan

- [x] `cargo test deduce_embed_hyperlinks`

Made with [Cursor](https://cursor.com)