### PR TITLE
feat(icons): add Apple icon for macOS `Icon\r` files

### DIFF
--- a/src/output/icons.rs
+++ b/src/output/icons.rs
@@ -381,6 +381,7 @@ const FILENAME_ICONS: Map<&'static str, char> = phf_map! {
     "id_ed25519"          => Icons::PRIVATE_KEY,    // 󰌆
     "id_ed25519_sk"       => Icons::PRIVATE_KEY,    // 󰌆
     "id_rsa"              => Icons::PRIVATE_KEY,    // 󰌆
+    "Icon\r"              => Icons::OS_APPLE,       //  (macOS custom folder icon file)
     "index.theme"         => '\u{ee72}',            // 
     "inputrc"             => Icons::CONFIG,         // 󱁻
     "Jenkinsfile"         => '\u{e66e}',            // 


### PR DESCRIPTION
## Description

Closes #1683.

macOS stores a folder's custom icon in a file literally named `Icon` followed by a carriage return (`Icon\r`). This file wasn't in `FILENAME_ICONS`, so it rendered with the generic fallback icon and wasn't colourized by the theme.

This adds `"Icon\r" => Icons::OS_APPLE`, matching how other macOS-specific files (`.DS_Store`, `.CFUserTextEncoding`) are handled, so it now shows the Apple icon () and is themed accordingly.

## Verification

Built locally and confirmed the icon is applied. With `--icons=always`, both `.DS_Store` and `Icon\r` now emit `U+F179` (the Apple icon), while unrelated files get their normal icon:

```
 .DS_Store
 Icon\r        ← now the Apple icon
 normalfile.txt
```

`cargo check`, `cargo clippy`, and `cargo fmt --check` all pass.
