### PR TITLE
Fix: Remove arguments from -F flag in zsh completion

### DIFF
--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -19,7 +19,7 @@ __eza() {
         {-R,--recurse}"[Recurse into directories]" \
         {-T,--tree}"[Recurse into directories as a tree]" \
         {-X,--dereference}"[Dereference symbolic links when displaying file information]" \
-        {-F,--classify}"[Display type indicator by file names]:(when):(always auto automatic never)" \
+        {-F,--classify}"[Display type indicator by file names]" \
         --colo{,u}r="[When to use terminal colours]:(when):(always auto automatic never)" \
         --colo{,u}r-scale"[highlight levels of 'field' distinctly]:(fields):(all age size)" \
         --colo{,u}r-scale-mode"[Use gradient or fixed colors in --color-scale]:(mode):(fixed gradient)" \


### PR DESCRIPTION
This PR fixes a bug where the -F flag would break tab completion in zsh. This was because the arguments for the -F flag were being defined in the completion script, which was causing issues with how zsh was parsing the alias.

This PR fixes the issue by removing the arguments from the -F flag in the completion script. This means that the user will no longer get completions for the arguments to the -F flag, but it will fix the tab completion issue.