### PR TITLE
fix(time): show dates for files modified before the UNIX epoch

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -771,13 +771,30 @@ impl<'dir> File<'dir> {
     /// Fixes #655 and #667 in `Self::modified_time`, `Self::accessed_time` and
     /// `Self::created_time`.
     fn systemtime_to_naivedatetime(st: SystemTime) -> Option<NaiveDateTime> {
-        let duration = st.duration_since(SystemTime::UNIX_EPOCH).ok()?;
+        let (secs, nanos) = match st.duration_since(SystemTime::UNIX_EPOCH) {
+            // Time at or after the UNIX epoch.
+            Ok(duration) => (
+                duration.as_secs().try_into().ok()?,
+                (duration.as_nanos() % 1_000_000_000).try_into().ok()?,
+            ),
+            // Time before the UNIX epoch (#1668): `duration_since` returns an
+            // `Err` whose duration is the absolute distance back to the epoch.
+            // Negate it, and when there is a sub-second part floor towards
+            // negative infinity so the timestamp matches how Unix counts time
+            // before 1970 (otherwise these files render their date as `-`).
+            Err(err) => {
+                let duration = err.duration();
+                let mut secs: i64 = -i64::try_from(duration.as_secs()).ok()?;
+                let mut nanos = duration.subsec_nanos();
+                if nanos > 0 {
+                    secs -= 1;
+                    nanos = 1_000_000_000 - nanos;
+                }
+                (secs, nanos)
+            }
+        };
 
-        DateTime::from_timestamp(
-            duration.as_secs().try_into().ok()?,
-            (duration.as_nanos() % 1_000_000_000).try_into().ok()?,
-        )
-        .map(|dt| dt.naive_local())
+        DateTime::from_timestamp(secs, nanos).map(|dt| dt.naive_local())
     }
 
     /// This file’s last modified timestamp, if available on this platform.
@@ -1115,5 +1132,53 @@ mod filename_test {
     #[cfg(unix)]
     fn topmost() {
         assert_eq!("/", File::filename(Path::new("/")));
+    }
+}
+
+#[cfg(test)]
+mod systemtime_to_naivedatetime_test {
+    use super::File;
+    use chrono::Datelike;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn post_epoch() {
+        // 2001-09-09T01:46:40 UTC == 1_000_000_000 seconds after the epoch.
+        let st = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000_000);
+        let dt = File::systemtime_to_naivedatetime(st).expect("post-epoch time");
+        assert_eq!(dt.and_utc().timestamp(), 1_000_000_000);
+        assert_eq!(dt.and_utc().timestamp_subsec_nanos(), 0);
+        assert_eq!(dt.year(), 2001);
+    }
+
+    #[test]
+    fn epoch() {
+        let dt = File::systemtime_to_naivedatetime(SystemTime::UNIX_EPOCH).expect("epoch time");
+        assert_eq!(dt.and_utc().timestamp(), 0);
+        assert_eq!(dt.year(), 1970);
+    }
+
+    #[test]
+    fn pre_epoch() {
+        // #1668: a time before the UNIX epoch must still yield a real date
+        // rather than `None` (which renders as `-`).
+        let st = SystemTime::UNIX_EPOCH - Duration::from_secs(2_147_483_648);
+        let dt = File::systemtime_to_naivedatetime(st).expect("pre-epoch time");
+        assert_eq!(dt.and_utc().timestamp(), -2_147_483_648);
+        assert_eq!(dt.and_utc().timestamp_subsec_nanos(), 0);
+        assert!(dt.year() < 1970);
+        assert_eq!(dt.year(), 1901);
+    }
+
+    #[test]
+    fn pre_epoch_subsecond() {
+        // A pre-epoch time with a sub-second component must floor towards
+        // negative infinity so the whole-seconds value and nanos line up.
+        let st = SystemTime::UNIX_EPOCH - Duration::new(10, 250_000_000);
+        let dt = File::systemtime_to_naivedatetime(st).expect("pre-epoch subsecond time");
+        // -10.25s == -11s + 0.75s.
+        assert_eq!(dt.and_utc().timestamp(), -11);
+        assert_eq!(dt.and_utc().timestamp_subsec_nanos(), 750_000_000);
+        assert!(dt.year() < 1970);
     }
 }


### PR DESCRIPTION
## Problem

Files whose modification (or access/change) time is **before the UNIX epoch** (1970-01-01) render their date as `-` in eza, even though `ls` shows the correct date (e.g. `1901-12-13 ...`). See #1668.

## Root cause

`File::systemtime_to_naivedatetime` in `src/fs/file.rs` did:

```rust
let duration = st.duration_since(SystemTime::UNIX_EPOCH).ok()?;
```

`SystemTime::duration_since` returns `Err` whenever the time is **earlier** than the epoch, and `.ok()?` silently converted that `Err` into `None`. Every pre-epoch timestamp therefore became "no date", which the table renderer prints as `-`.

## Fix

Handle the `Err` branch instead of discarding it:

- On `Ok(d)`: behave as before (positive seconds + nanos).
- On `Err(e)`: recover the absolute offset from `e.duration()`, negate the seconds, and when there is a sub-second part floor towards negative infinity (`secs -= 1; nanos = 1_000_000_000 - nanos`) so the value matches how Unix timestamps count time before 1970.

The timestamp is then built with `chrono::DateTime::from_timestamp(secs, nanos)`, which already accepts negative seconds, keeping the existing `Option<NaiveDateTime>` return type and `.naive_local()` conversion. The change is localized to this one function. `ls` is treated as the ground-truth behavior.

## Tests

Added a `#[cfg(test)] mod systemtime_to_naivedatetime_test` covering:

- a normal **post-epoch** time (still works, year 2001),
- the **epoch** itself (timestamp 0, year 1970),
- a **pre-epoch** time (`UNIX_EPOCH - 2_147_483_648s`, year 1901, timestamp `-2_147_483_648`),
- a **pre-epoch time with a sub-second part** (verifies the floor-towards-negative-infinity handling: `-10.25s` -> timestamp `-11`, nanos `750_000_000`).

`cargo build`, `cargo test fs::file`, `cargo clippy -- -D warnings`, and `cargo fmt --check` all pass locally on the pinned toolchain (1.90).

Closes #1668