### PR TITLE
fix(format): rounding could cause incorrect number rendering

### DIFF
--- a/src/output/render/blocks.rs
+++ b/src/output/render/blocks.rs
@@ -51,7 +51,9 @@ impl f::Blocksize {
         };
 
         let symbol = prefix.symbol();
-        let number = if n.round() < 10_f64 {
+        // perform rounding before formatting for edge cases near n = 10
+        let rounded_1dp = (n * 10_f64).round() / 10_f64;
+        let number = if rounded_1dp < 10_f64 {
             numerics.format_float(n, 1)
         } else {
             numerics.format_int(n.round() as isize)

--- a/src/output/render/blocks.rs
+++ b/src/output/render/blocks.rs
@@ -167,4 +167,40 @@ pub mod test {
             )
         );
     }
+
+    #[test]
+    fn rounding_down_to_float() {
+        let directory = f::Blocksize::Some(9_940);
+        let expected = TextCell {
+            width: DisplayWidth::from(4),
+            contents: vec![Fixed(66).paint("9.9"), Fixed(77).bold().paint("k")].into(),
+        };
+
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::DecimalBytes,
+                &NumericLocale::english()
+            )
+        );
+    }
+
+    #[test]
+    fn rounding_up_to_integer() {
+        let directory = f::Blocksize::Some(9_990);
+        let expected = TextCell {
+            width: DisplayWidth::from(3),
+            contents: vec![Fixed(66).paint("10"), Fixed(77).bold().paint("k")].into(),
+        };
+
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::DecimalBytes,
+                &NumericLocale::english()
+            )
+        );
+    }
 }

--- a/src/output/render/blocks.rs
+++ b/src/output/render/blocks.rs
@@ -51,7 +51,7 @@ impl f::Blocksize {
         };
 
         let symbol = prefix.symbol();
-        let number = if n < 10_f64 {
+        let number = if n.round() < 10_f64 {
             numerics.format_float(n, 1)
         } else {
             numerics.format_int(n.round() as isize)

--- a/src/output/render/size.rs
+++ b/src/output/render/size.rs
@@ -75,7 +75,7 @@ impl f::Size {
         };
 
         let symbol = prefix.symbol();
-        let number = if n < 10_f64 {
+        let number = if n.round() < 10_f64 {
             numerics.format_float(n, 1)
         } else {
             numerics.format_int(n.round() as isize)

--- a/src/output/render/size.rs
+++ b/src/output/render/size.rs
@@ -230,6 +230,44 @@ pub mod test {
     }
 
     #[test]
+    fn rounding_down_to_float() {
+        let directory = f::Size::Some(9_940);
+        let expected = TextCell {
+            width: DisplayWidth::from(4),
+            contents: vec![Fixed(66).paint("9.9"), Fixed(77).bold().paint("k")].into(),
+        };
+
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::DecimalBytes,
+                &NumericLocale::english(),
+                None
+            )
+        );
+    }
+
+    #[test]
+    fn rounding_up_to_integer() {
+        let directory = f::Size::Some(9_990);
+        let expected = TextCell {
+            width: DisplayWidth::from(3),
+            contents: vec![Fixed(66).paint("10"), Fixed(77).bold().paint("k")].into(),
+        };
+
+        assert_eq!(
+            expected,
+            directory.render(
+                &TestColours,
+                SizeFormat::DecimalBytes,
+                &NumericLocale::english(),
+                None
+            )
+        );
+    }
+
+    #[test]
     fn device_ids() {
         let directory = f::Size::DeviceIDs(f::DeviceIDs {
             major: 10,

--- a/src/output/render/size.rs
+++ b/src/output/render/size.rs
@@ -75,7 +75,9 @@ impl f::Size {
         };
 
         let symbol = prefix.symbol();
-        let number = if n.round() < 10_f64 {
+        // perform rounding before formatting for edge cases near n = 10
+        let rounded_1dp = (n * 10_f64).round() / 10_f64;
+        let number = if rounded_1dp < 10_f64 {
             numerics.format_float(n, 1)
         } else {
             numerics.format_int(n.round() as isize)


### PR DESCRIPTION
# Problem

For file sizes near and below `10[prefix]` values like `10.0k` could be displayed.

This is because a number smaller than 10k could, because of rounding, be rounded back up to 10k in its displayed form. In this case, the format displays a float, which seems inconsistent with how other numbers are displayed.

# Root cause

In `size.rs` and `block.rs`:

```rust
let number = if n < 10_f64 {
    numerics.format_float(n, 1)
} else {
    numerics.format_int(n.round() as isize)
};
```

# Fix

Round to one decimal place before entering the if statement in a way that mimics how the final format will be made:

```rust
let rounded_1dp = (n * 10_f64).round() / 10_f64;
let number = if rounded_1dp < 10_f64 {
    numerics.format_float(n, 1)
} else {
    numerics.format_int(n.round() as isize)
};
```