### PR TITLE
fix: expand tilde in EZA_CONFIG_DIR path

### DIFF
--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -38,7 +38,17 @@ impl Options {
 impl ThemeConfig {
     fn deduce<V: Vars>(vars: &V) -> Option<Self> {
         if let Some(path) = vars.get("EZA_CONFIG_DIR") {
-            let path = PathBuf::from(path);
+            let path = {
+                let s = path.to_string_lossy();
+                if s.starts_with('~') {
+                    match dirs::home_dir() {
+                        Some(home) => PathBuf::from(s.replacen('~', &home.to_string_lossy(), 1)),
+                        None => PathBuf::from(s.as_ref()),
+                    }
+                } else {
+                    PathBuf::from(s.as_ref())
+                }
+            };
             let theme = path.join("theme.yml");
             if theme.exists() {
                 return Some(ThemeConfig::from_path(theme));


### PR DESCRIPTION
## Summary

When `EZA_CONFIG_DIR` is set to a path starting with `~` (e.g.,
`EZA_CONFIG_DIR=~/.config/eza`), the tilde was treated as a literal
character by `PathBuf::from()` instead of being expanded to the user's
home directory. This caused the theme configuration to silently not be
found.

This fix expands `~` to the user's home directory using the existing
`dirs::home_dir()` dependency before constructing the `PathBuf`.

## Test plan

- All 332 existing unit tests pass
- No new dependencies added
- Tilde expansion only applies when the path starts with `~`
- Falls back to literal path if `home_dir()` returns `None`

## Related issue

Fixes #1789