### PR TITLE
fix(options): handle non-UTF-8 `--time-style` value gracefully

### DIFF
--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -294,8 +294,15 @@ impl clap::builder::TypedValueParser for TimeFormatParser {
         _arg: Option<&clap::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, Error> {
-        match TimeFormat::try_from_str(value.to_str().unwrap()) {
-            Err(s) => Err(Error::raw(clap::error::ErrorKind::InvalidValue, s).with_cmd(cmd)),
+        let Some(s) = value.to_str() else {
+            return Err(Error::raw(
+                clap::error::ErrorKind::InvalidUtf8,
+                "argument is not valid UTF-8",
+            )
+            .with_cmd(cmd));
+        };
+        match TimeFormat::try_from_str(s) {
+            Err(e) => Err(Error::raw(clap::error::ErrorKind::InvalidValue, e).with_cmd(cmd)),
             Ok(v) => Ok(v),
         }
     }


### PR DESCRIPTION
## Summary

Fixes #1837: `eza --time-style VALUE` aborts (panic, exit 134) when `VALUE` is not valid UTF-8. The custom clap value parser unwrapped the UTF-8 conversion of the raw `OsStr` argument, so a non-UTF-8 value made `to_str()` return `None` and `.unwrap()` panicked.

## Changes

- In `src/options/parser.rs`, `TimeFormatParser::parse_ref` now handles the `None` case from `OsStr::to_str()` and returns a proper clap error with `ErrorKind::InvalidUtf8` instead of panicking.

## Testing

- All existing tests pass (332 unit tests + 2 CLI tests + 3 doc tests)
- `cargo fmt --check` and `cargo clippy -- -D warnings` pass
- Manual verification:
  - Non-UTF-8 input: `eza --time-style "$(printf '\\xff\\xfe')" .` now returns "error: argument is not valid UTF-8" with exit code 2
  - Valid time-style (e.g., `long-iso`) continues to work correctly
  - Invalid time-style format (e.g., `invalid-format`) still returns proper usage error

## Checklist

- [x] Tests pass
- [x] Code formatting correct
- [x] No clippy warnings
- [x] Conventional Commits format