### PR TITLE
chore(snap): fix staged content, stage -> build packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ parts:
     source: .
     build-attributes:
       - enable-patchelf
-    stage-packages:
+    build-packages:
       - cmake
       - libz-dev
 platforms:


### PR DESCRIPTION
Fixing the wrong use of `stage-packages` vs `build-packages`

`stage-packages` defines dependencies, which are bundled in the snap and required @runtime
`build-packages` defines build-time dependencies

Closer look at listed dependencies:
- `cmake`: clear build-time dependency
- `libz` is already in `core24` base snap -> `libz-dev` is a build-time dependency

This change will drastically reduce the size of the produced snap package
~36MB ->  <1MB (amd64 target)