### PR TITLE
fix: graceful error on non-UTF-8 --time-style value instead of panic

### DIFF
--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -316,7 +316,14 @@ impl clap::builder::TypedValueParser for TimeFormatParser {
         _arg: Option<&clap::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, Error> {
-        match TimeFormat::try_from_str(value.to_str().unwrap()) {
+        let Some(value) = value.to_str() else {
+            return Err(Error::raw(
+                clap::error::ErrorKind::InvalidUtf8,
+                "invalid UTF-8 in --time-style value\n",
+            )
+            .with_cmd(cmd));
+        };
+        match TimeFormat::try_from_str(value) {
             Err(s) => Err(Error::raw(clap::error::ErrorKind::InvalidValue, s).with_cmd(cmd)),
             Ok(v) => Ok(v),
         }
@@ -367,5 +374,15 @@ pub mod test {
                 .collect::<Vec<_>>(),
             ["file1", "file2"]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn time_style_non_utf8_is_a_usage_error() {
+        use std::os::unix::ffi::OsStringExt;
+        // A non-UTF-8 --time-style value should be a usage error, not a panic.
+        let value = OsString::from_vec(vec![0xff, 0xfe]);
+        let result = mock_cli_try(vec![OsString::from("--time-style"), value]);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
##### Description
`eza --time-style VALUE` aborted with a panic (exit 134) when `VALUE` was not valid UTF-8, e.g. `eza --time-style "$(printf '\xff\xfe')" .`. The custom `TimeFormatParser::parse_ref` called `value.to_str().unwrap()`, and `OsStr::to_str()` returns `None` for non-UTF-8, so the `.unwrap()` panicked.

This makes the parser return a clap `InvalidUtf8` usage error when the value is not valid UTF-8, matching how every other flag rejects bad input. The sibling env-var path in `view.rs` already handles this with `to_str().unwrap_or("")`.

Fixes #1837.

##### How Has This Been Tested?
`cargo test --lib` passes, including a new `#[cfg(unix)]` regression test that feeds a non-UTF-8 `--time-style` value and asserts a usage error rather than a panic. Manually confirmed `eza --time-style "$(printf '\xff\xfe')" .` now prints `error: invalid UTF-8 in --time-style value` instead of crashing. `cargo fmt` and `cargo clippy --lib` are clean.
