### PR TITLE
Fix panic on non-UTF-8 --time-style value

### DIFF
--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -294,7 +294,14 @@ impl clap::builder::TypedValueParser for TimeFormatParser {
         _arg: Option<&clap::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, Error> {
-        match TimeFormat::try_from_str(value.to_str().unwrap()) {
+        let Some(value) = value.to_str() else {
+            return Err(Error::raw(
+                clap::error::ErrorKind::InvalidUtf8,
+                "invalid utf-8 value for '--time-style'",
+            )
+            .with_cmd(cmd));
+        };
+        match TimeFormat::try_from_str(value) {
             Err(s) => Err(Error::raw(clap::error::ErrorKind::InvalidValue, s).with_cmd(cmd)),
             Ok(v) => Ok(v),
         }
@@ -333,6 +340,18 @@ pub mod test {
         T: Into<OsString> + Clone,
     {
         get_command().no_binary_name(true).try_get_matches_from(itr)
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn time_style_non_utf8_does_not_panic() {
+        use std::os::unix::ffi::OsStrExt;
+        let non_utf8 = std::ffi::OsStr::from_bytes(&[0xff, 0xfe]);
+        let result = mock_cli_try(vec![
+            std::ffi::OsString::from("--time-style"),
+            non_utf8.to_owned(),
+        ]);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
`--time-style` panics instead of erroring when given a non-UTF-8 value, e.g. on Unix:

```
eza --time-style="$(printf '\xff\xfe')"
```

## Root cause
`TimeFormatParser::parse_ref` in `src/options/parser.rs` called `OsStr::to_str().unwrap()` on the raw argument. `to_str()` returns `None` for non-UTF-8 input, so this unwraps to a panic instead of a clap error.

```rust
// before
match TimeFormat::try_from_str(value.to_str().unwrap()) { ... }

// after
let Some(value) = value.to_str() else {
    return Err(Error::raw(
        clap::error::ErrorKind::InvalidUtf8,
        "invalid utf-8 value for '--time-style'",
    )
    .with_cmd(cmd));
};
match TimeFormat::try_from_str(value) { ... }
```

Now it returns a normal clap usage error instead of crashing.

## Tests
Added `time_style_non_utf8_does_not_panic` (Unix-only, builds an `OsStr` from invalid UTF-8 bytes) asserting the parser returns `Err` instead of panicking.

Fixes #1837