### PR TITLE
fix(icons): use io::stdout().is_terminal() instead of terminal-width heuristic for --icons=auto

### DIFF
--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -294,7 +294,14 @@ impl clap::builder::TypedValueParser for TimeFormatParser {
         _arg: Option<&clap::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, Error> {
-        match TimeFormat::try_from_str(value.to_str().unwrap()) {
+        let s = value.to_str().ok_or_else(|| {
+            Error::raw(
+                clap::error::ErrorKind::InvalidUtf8,
+                format!("--time-style value '{:?}' is not valid UTF-8", value),
+            )
+            .with_cmd(cmd)
+        })?;
+        match TimeFormat::try_from_str(s) {
             Err(s) => Err(Error::raw(clap::error::ErrorKind::InvalidValue, s).with_cmd(cmd)),
             Ok(v) => Ok(v),
         }
@@ -345,5 +352,16 @@ pub mod test {
                 .collect::<Vec<_>>(),
             ["file1", "file2"]
         );
+    }
+
+    #[test]
+    fn time_style_rejects_non_utf8() {
+        use std::os::unix::ffi::OsStringExt;
+        let args = vec![
+            OsString::from("--time-style"),
+            OsString::from_vec(b"\xff\xfe".to_vec()),
+        ];
+        let err = mock_cli_try(args).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidUtf8);
     }
 }

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -21,6 +21,8 @@ use crate::output::table::{
 use crate::output::time::TimeFormat;
 use crate::output::{Mode, TerminalWidth, View, details, grid};
 
+use std::io::{self, IsTerminal};
+
 use super::parser::{ColorScaleArgs, TimeArgs};
 
 impl View {
@@ -30,7 +32,7 @@ impl View {
         strict: bool,
     ) -> Result<Self, OptionsError> {
         let width = TerminalWidth::deduce(matches, vars)?;
-        let is_tty = width.actual_terminal_width().is_some();
+        let is_tty = io::stdout().is_terminal();
         let mode = Mode::deduce(matches, vars, is_tty, strict)?;
         let deref_links = matches.get_flag("dereference");
         let follow_links = matches.get_flag("follow-symlinks");


### PR DESCRIPTION
Changes the  flag in `View::deduce` from being derived from terminal-width availability (`width.actual_terminal_width().is_some()`) to using `io::stdout().is_terminal()` directly.

The old heuristic returns `true` whenever `COLUMNS` is set in the environment (via `TerminalWidth::deduce`), even when stdout is piped to a file or another process. This caused `--icons=auto` to show icons in non-TTY output whenever `COLUMNS` was set.

Also fixes the default view (grid vs lines) selection when `COLUMNS` is set during a pipe.

Closes #1842