### PR TITLE
feat: implement --print-total flag to show total number of entries that eza printed

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ These options are available when running with `--long` (`-l`):
 - **--no-filesize**: suppress the filesize field
 - **--no-user**: suppress the user field
 - **--no-time**: suppress the time field
+- **--print-total**: display total number of entries at the end
 - **--stdin**: read file names from stdin
 
 Some of the options accept parameters:

--- a/completions/fish/eza.fish
+++ b/completions/fish/eza.fish
@@ -37,6 +37,7 @@ complete -c eza -l icons -d "When to display icons" -x -a "
   never\t'Never display icons'
 "
 complete -c eza -l no-quotes -d "Don't quote file names with spaces"
+complete -c eza -l print-total -d "Display total number of entries"
 complete -c eza -l hyperlink -d "When to display entries as hyperlinks" -x -a "
   always\t'Always display entries as hyperlinks'
   auto\t'Display hyperlinks if standard output is a terminal'

--- a/completions/nush/eza.nu
+++ b/completions/nush/eza.nu
@@ -17,6 +17,7 @@ export extern "eza" [
     --colour-scale-mode        # Use gradient or fixed colors in --colour-scale
     --icons                    # When to display icons
     --no-quotes                # Don't quote file names with spaces
+    --print-total              # Display total number of entries
     --hyperlink                # When to display entries as hyperlinks
     --absolute                 # Display entries with their absolute path
     --follow-symlinks          # Drill down into symbolic links that point to directories

--- a/completions/zsh/_eza
+++ b/completions/zsh/_eza
@@ -25,6 +25,7 @@ __eza() {
         --colo{,u}r-scale-mode"[Use gradient or fixed colors in --color-scale]:(mode):(fixed gradient)" \
         --icons="[When to display icons]:(when):(always auto automatic never)" \
         --no-quotes"[Don't quote filenames with spaces]" \
+        --print-total"[Display total number of entries]" \
         --hyperlink="[When to display entries as hyperlinks]:(when):(always auto automatic never)" \
         --absolute"[Display entries with their absolute path]:(mode):(on follow off)" \
         --follow-symlinks"[Drill down into symbolic links that point to directories]" \

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -274,6 +274,9 @@ Alternatively, `<FORMAT>` can be a two line string, the first line will be used 
 `--no-time`
 : Suppress the time field.
 
+`--print-total`
+: Display total number of entries listed.
+
 `--stdin`
 : When you wish to pipe directories to eza/read from stdin. Separate one per line or define custom separation char in `EZA_STDIN_SEPARATOR` env variable.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -398,14 +398,16 @@ impl Exa<'_> {
                 .filter(|f| !f.is_directory())
                 .collect::<Vec<_>>();
         }
+        let files_count = files.len();
         let theme = &self.theme;
         let View {
             ref mode,
             ref file_style,
+            ref total_entries,
             ..
         } = self.options.view;
 
-        match (mode, self.console_width) {
+        let result = match (mode, self.console_width) {
             (Mode::Grid(opts), Some(console_width)) => {
                 let filter = &self.options.filter;
                 let r = grid::Render {
@@ -512,7 +514,14 @@ impl Exa<'_> {
                 };
                 r.render(&mut self.writer)
             }
+        };
+        result?;
+
+        if *total_entries {
+            writeln!(&mut self.writer, "total: {files_count}")?;
         }
+
+        Ok(())
     }
 }
 

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -90,7 +90,6 @@ pub fn get_command() -> clap::Command {
             .value_parser(value_parser!(ShowWhen))
             .default_missing_value("auto"))
         .arg(arg!(--"no-quotes" "don't quote file names with spaces"))
-        .arg(arg!(--"print-total" "display total number of entries"))
 
         .next_help_heading("FILTERING OPTIONS")
         .arg(arg!(-a --all... "show hidden files. Use this twice to also show the '.' and '..' directories"))
@@ -152,6 +151,7 @@ pub fn get_command() -> clap::Command {
         .arg(arg!(--"no-user" "suppress the user field"))
         .arg(arg!(--"no-time" "suppress the time field"))
         .arg(arg!(--"no-git" "suppress Git fields (overrides --git, --git-repos, --git-repos-no-status)"))
+        .arg(arg!(--"print-total" "display total number of entries"))
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -90,6 +90,7 @@ pub fn get_command() -> clap::Command {
             .value_parser(value_parser!(ShowWhen))
             .default_missing_value("auto"))
         .arg(arg!(--"no-quotes" "don't quote file names with spaces"))
+        .arg(arg!(--"print-total" "display total number of entries"))
 
         .next_help_heading("FILTERING OPTIONS")
         .arg(arg!(-a --all... "show hidden files. Use this twice to also show the '.' and '..' directories"))

--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -35,6 +35,7 @@ impl View {
         let deref_links = matches.get_flag("dereference");
         let follow_links = matches.get_flag("follow-symlinks");
         let total_size = matches.get_flag("total-size");
+        let total_entries = matches.get_flag("print-total");
         let file_style = FileStyle::deduce(matches, vars, is_tty)?;
         Ok(Self {
             mode,
@@ -43,6 +44,7 @@ impl View {
             deref_links,
             follow_links,
             total_size,
+            total_entries,
         })
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -32,6 +32,7 @@ pub struct View {
     pub deref_links: bool,
     pub follow_links: bool,
     pub total_size: bool,
+    pub total_entries: bool,
 }
 
 /// The **mode** is the “type” of output.


### PR DESCRIPTION
Adds a flag `--print-total` flag to show number of enteries eza prints at the end and updated the docs for it 

<img width="1394" height="308" alt="28467" src="https://github.com/user-attachments/assets/4b717903-07d3-4cdb-bc6a-c1a2bec28b01" />

Btw, The security_audit failure is a pre-existing RUSTSEC-2026-0195 vulnerability in quick-xml
0.38.4, unrelated to this PR and  The two Nix checks (trycmd, test) both timed out during Nix dependency builds. 

This resolves #1847.