### PR TITLE
fix: sort newest aliases newest first

### DIFF
--- a/src/options/filter.rs
+++ b/src/options/filter.rs
@@ -339,10 +339,34 @@ mod tests {
     }
 
     #[test]
+    fn deduce_sort_field_new() {
+        assert_eq!(
+            mock_cli(vec!["--sort", "new"]).get_one::<SortField>("sort"),
+            Some(&SortField::ModifiedAge)
+        );
+    }
+
+    #[test]
+    fn deduce_sort_field_newest() {
+        assert_eq!(
+            mock_cli(vec!["--sort", "newest"]).get_one::<SortField>("sort"),
+            Some(&SortField::ModifiedAge)
+        );
+    }
+
+    #[test]
     fn deduce_sort_field_old() {
         assert_eq!(
             mock_cli(vec!["--sort", "old"]).get_one::<SortField>("sort"),
-            Some(&SortField::ModifiedAge)
+            Some(&SortField::ModifiedDate)
+        );
+    }
+
+    #[test]
+    fn deduce_sort_field_oldest() {
+        assert_eq!(
+            mock_cli(vec!["--sort", "oldest"]).get_one::<SortField>("sort"),
+            Some(&SortField::ModifiedDate)
         );
     }
 

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -231,15 +231,13 @@ impl ValueEnum for SortField {
             Self::Size => PossibleValue::new("size"),
             Self::Extension(SortCase::AaBbCc) => PossibleValue::new("ext").alias("extension"),
             Self::Extension(SortCase::ABCabc) => PossibleValue::new("Ext").alias("Extension"),
-            // “new” sorts oldest at the top and newest at the bottom; “old” sorts newest at the
-            // top and oldest at the bottom. I think this is the right way round to do this:
-            // “size” puts the smallest at  the top and the largest at the bottom, doesn’t it?
+            // “old” sorts oldest at the top and newest at the bottom.
             Self::ModifiedDate => {
-                PossibleValue::new("date").aliases(vec!["time", "mod", "modified", "new", "newest"])
+                PossibleValue::new("date").aliases(vec!["time", "mod", "modified", "old", "oldest"])
             }
             // Similarly, “age” means that files with the least age (the newest files) get sorted
             //  at the top, and files with the most age (the oldest) at the bottom.
-            Self::ModifiedAge => PossibleValue::new("age").aliases(vec!["old", "oldest"]),
+            Self::ModifiedAge => PossibleValue::new("age").aliases(vec!["new", "newest"]),
             Self::ChangedDate => PossibleValue::new("changed").alias("ch"),
             Self::AccessedDate => PossibleValue::new("accessed").alias("acc"),
             Self::CreatedDate => PossibleValue::new("created").alias("cr"),


### PR DESCRIPTION
## Summary
- Map `--sort=new` and `--sort=newest` to the existing newest-first modified-time ordering.
- Map `--sort=old` and `--sort=oldest` to the existing oldest-first modified-time ordering.
- Add parser regressions for the explicit new/newest/old/oldest aliases.

Fixes #1772

## Tests
- `cargo fmt --all -- --check`
- `cargo test deduce_sort_field_new --lib` (failed before the fix, passed after the fix via focused alias tests)
- `cargo test deduce_sort_field_ --lib`
- `cargo test options::filter::tests --lib`
- `cargo test --test cli_tests cli_all_tests`
- `cargo test --test cli_tests cli_unix_tests`
- `cargo test --lib`
- `cargo check --all-targets`
- Manual CLI QA with temp files using controlled mtimes: `--sort=newest` produced `newest`, `middle`, `oldest`; `--sort=oldest` produced `oldest`, `middle`, `newest`.