### PR TITLE
fix(smart-group)!: make --smart-group imply --group

### DIFF
--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -269,7 +269,11 @@ impl Columns {
 
         let file_flags = matches.get_flag("file-flags");
         let blocksize = matches.get_flag("blocksize");
-        let group = matches.get_flag("group");
+        // `--smart-group` only controls *how* the group is rendered; on its own
+        // it would have no effect because the group column is hidden unless
+        // `--group` is given. Treat it as implying `--group` so the column
+        // actually shows up.
+        let group = matches.get_flag("group") || matches.get_flag("smart-group");
         let inode = matches.get_flag("inode");
         let links = matches.get_flag("links");
         let octal = matches.get_flag("octal-permissions");
@@ -680,6 +684,21 @@ mod tests {
             GroupFormat::deduce(&mock_cli(vec![""])),
             GroupFormat::Regular
         );
+    }
+
+    #[test]
+    fn deduce_columns_smart_group_implies_group() {
+        // Regression test for #1648: `--smart-group` on its own must enable the
+        // group column, otherwise the flag has no effect.
+        let columns =
+            Columns::deduce(&mock_cli(vec!["--smart-group"]), &MockVars::default()).unwrap();
+        assert!(columns.group);
+    }
+
+    #[test]
+    fn deduce_columns_no_group_by_default() {
+        let columns = Columns::deduce(&mock_cli(vec![""]), &MockVars::default()).unwrap();
+        assert!(!columns.group);
     }
 
     #[test]


### PR DESCRIPTION
##### Description

Fixes #1648.

Previously `--smart-group` only selected the smart group format ("hide the group column when it's the same as the owner") but never actually turned the group column on. Since the group column is hidden unless `--group`/`-g` is passed, using `--smart-group` on its own had no visible effect at all.

This change makes `--smart-group` imply `--group`, so the group column is enabled whenever `--smart-group` is passed:

```rust
let group = matches.get_flag("group") || matches.get_flag("smart-group");
```

Marked as breaking (`!`) per the maintainer's request in the issue thread, since it changes the output of `--smart-group` when used without `--group`.

##### How Has This Been Tested?

Added two regression unit tests in `src/options/view.rs`:

- `deduce_columns_smart_group_implies_group` — asserts that `--smart-group` on its own enables the group column (the #1648 regression).
- `deduce_columns_no_group_by_default` — asserts the group column stays off by default, guarding against over-enabling.

Verified locally with `cargo test` (options view tests pass) and `cargo fmt`/`cargo clippy` clean on the change. Also manually confirmed `eza --smart-group` now shows the group column where it previously showed nothing.
