### PR TITLE
fix: correct typos in doc comments and trace log

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -317,7 +317,7 @@ impl<'dir> File<'dir> {
     /// the current file. It does not perform any validation to check if the
     /// file is actually a directory. To verify that, use `is_directory()`.
     pub fn to_dir(&self) -> Dir {
-        trace!("read_dir: initializating dir from path");
+        trace!("read_dir: initializing dir from path");
         Dir::new(self.path.clone())
     }
 

--- a/src/options/config.rs
+++ b/src/options/config.rs
@@ -170,7 +170,7 @@ pub struct StyleOverride {
     #[serde(alias = "strikethrough")]
     pub is_strikethrough: Option<bool>,
 
-    /// Wether this style is always displayed starting with a reset code to clear any remaining style artifacts
+    /// Whether this style is always displayed starting with a reset code to clear any remaining style artifacts
     #[serde(alias = "prefix_reset")]
     pub prefix_with_reset: Option<bool>,
 }

--- a/src/options/vars.rs
+++ b/src/options/vars.rs
@@ -61,7 +61,7 @@ pub static EZA_ICON_SPACING: &str = "EZA_ICON_SPACING";
 pub static EXA_OVERRIDE_GIT: &str = "EXA_OVERRIDE_GIT";
 pub static EZA_OVERRIDE_GIT: &str = "EZA_OVERRIDE_GIT";
 
-/// Enviroment variable used to set the minimum luminance in `color_scale`. It's value
+/// Environment variable used to set the minimum luminance in `color_scale`. It's value
 /// can be between -100 and 100
 pub static EXA_MIN_LUMINANCE: &str = "EXA_MIN_LUMINANCE";
 pub static EZA_MIN_LUMINANCE: &str = "EZA_MIN_LUMINANCE";

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -315,7 +315,7 @@ impl TimeType {
 /// How display file flags.
 #[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
 pub enum FlagsFormat {
-    /// Display flags as comma seperated descriptions
+    /// Display flags as comma separated descriptions
     #[default]
     Long,
     /// Display flags as single character abbreviations (Windows only)


### PR DESCRIPTION
## Summary

Fix four typos found in doc comments and a trace log string:

- `Wether` -> `Whether` in `StyleOverride` doc comment (`src/options/config.rs`)
- `Enviroment` -> `Environment` in `EXA_MIN_LUMINANCE` doc comment (`src/options/vars.rs`)
- `seperated` -> `separated` in `FlagsFormat::Long` doc comment (`src/output/table.rs`)
- `initializating` -> `initializing` in trace log string (`src/fs/file.rs`)

All are genuine misspellings in `///` doc comments or internal log strings — not in generated code, changelogs, or test fixtures.