### PR TITLE
build: add RUSTUP_HOME to cross build volumes

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,8 @@
+# Also bind-mount the host RUSTUP_HOME at its original path inside the
+# container. cross mounts the active toolchain at /rust, but the nixpkgs
+# rustup linker-wrapper has the toolchain's original absolute path baked in
+# (it calls .../bin/gcc-ld-unwrapped/ld.lld via -fuse-ld=lld). Without this
+# mount that path doesn't exist inside the container, so linking host-side
+# build scripts (e.g. windows_x86_64_gnu) fails with ENOENT / "ld returned 127".
+[build.env]
+volumes = ["RUSTUP_HOME"]


### PR DESCRIPTION
Mount the host `RUSTUP_HOME` into the cross container to ensure that
build scripts can locate absolute paths for linker-wrappers. This
resolves errors where `ld.lld` or other binaries are not found during
host-side build script execution inside the container.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Make sure you've read CONTRIBUTING.md and CODE_OF_CONDUCT.md -->
<!---  -->
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
##### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Consider including potentially useful screenshots of your feature in action -->

##### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

