### PR TITLE
fix: require equals for icons values

### DIFF
--- a/src/options/file_name.rs
+++ b/src/options/file_name.rs
@@ -203,7 +203,7 @@ mod tests {
     #[test]
     fn deduce_show_icon_always() {
         assert_eq!(
-            ShowIcons::deduce(&mock_cli(vec!["--icons", "always"]), &MockVars::default()),
+            ShowIcons::deduce(&mock_cli(vec!["--icons=always"]), &MockVars::default()),
             Ok(ShowIcons::Always(1)),
         );
     }
@@ -211,7 +211,7 @@ mod tests {
     #[test]
     fn deduce_show_icons_never() {
         assert_eq!(
-            ShowIcons::deduce(&mock_cli(vec!["--icons", "never"]), &MockVars::default()),
+            ShowIcons::deduce(&mock_cli(vec!["--icons=never"]), &MockVars::default()),
             Ok(ShowIcons::Never)
         );
     }
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn deduce_show_icons_auto() {
         assert_eq!(
-            ShowIcons::deduce(&mock_cli(vec!["--icons", "auto"]), &MockVars::default()),
+            ShowIcons::deduce(&mock_cli(vec!["--icons=auto"]), &MockVars::default()),
             Ok(ShowIcons::Automatic(1))
         );
     }
@@ -255,7 +255,7 @@ mod tests {
             .parse();
 
         assert_eq!(
-            ShowIcons::deduce(&mock_cli(vec!["--icons", "auto"]), &vars),
+            ShowIcons::deduce(&mock_cli(vec!["--icons=auto"]), &vars),
             Err(OptionsError::FailedParse(
                 String::from("foo"),
                 NumberSource::Env(vars::EXA_ICON_SPACING),

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -89,6 +89,7 @@ pub fn get_command() -> clap::Command {
             .default_value("gradient"))
         .arg(arg!(--icons <WHEN> "when to display icons")
             .num_args(0..=1)
+            .require_equals(true)
             .value_parser(value_parser!(ShowWhen))
             .default_missing_value("auto"))
         .arg(arg!(--hyperlink <WHEN> "when to display entries as hyperlinks")
@@ -366,6 +367,19 @@ pub mod test {
                 .map(OsString::as_os_str)
                 .collect::<Vec<_>>(),
             ["file1", "file2"]
+        );
+    }
+
+    #[test]
+    fn icons_without_equals_does_not_consume_file() {
+        let cli = mock_cli(vec!["--icons", "file1"]);
+        assert_eq!(cli.get_one::<ShowWhen>("icons"), Some(&ShowWhen::Auto));
+        assert_eq!(
+            cli.get_many("FILE")
+                .unwrap()
+                .map(OsString::as_os_str)
+                .collect::<Vec<_>>(),
+            ["file1"]
         );
     }
 }

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -26,7 +26,7 @@ DISPLAY OPTIONS:
       --color [<WHEN>]             When to use colours. [default: auto] [possible values: always, auto, never]
       --color-scale [<FIELDS>...]  highlight value of FIELDS distinctly [possible values: all, age, size]
       --color-scale-mode <MODE>    mode for --color-scale [default: gradient] [possible values: fixed, gradient]
-      --icons [<WHEN>]             when to display icons [possible values: always, auto, never]
+      --icons[=<WHEN>]             when to display icons [possible values: always, auto, never]
       --hyperlink [<WHEN>]         when to display entries as hyperlinks [possible values: always, auto, never]
       --no-quotes                  don't quote file names with spaces
       --short-nix                  abbreviate Nix store hashes in file names and paths

--- a/tests/ptests/ptest_581533c37ac03853.toml
+++ b/tests/ptests/ptest_581533c37ac03853.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir --icons never"
+args = "tests/test_dir --icons=never"

--- a/tests/ptests/ptest_6d64a7584b621832.toml
+++ b/tests/ptests/ptest_6d64a7584b621832.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir --icons always"
+args = "tests/test_dir --icons=always"

--- a/tests/ptests/ptest_ded586a10b97281e.toml
+++ b/tests/ptests/ptest_ded586a10b97281e.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir --icons auto"
+args = "tests/test_dir --icons=auto"


### PR DESCRIPTION
##### Description

Require `--icons` optional values to use `=` (for example `--icons=always`) so a bare `--icons` does not consume the following positional file argument. Updated the parser/unit tests and powertest expectations for the help text and explicit icon modes.

Fixes #1864

##### How Has This Been Tested?

- `cargo fmt --check`
- `cargo test`
- `./target/debug/eza --icons src/options/parser.rs`
- `./target/debug/eza --icons=always src/options/parser.rs`
