### PR TITLE
fix(options): require equals for bare --hyperlink value

### DIFF
--- a/src/options/file_name.rs
+++ b/src/options/file_name.rs
@@ -157,7 +157,7 @@ mod tests {
             EmbedHyperlinks::Automatic
         );
         assert_eq!(
-            EmbedHyperlinks::deduce(&mock_cli(vec!["--hyperlink", "auto"])),
+            EmbedHyperlinks::deduce(&mock_cli(vec!["--hyperlink=auto"])),
             EmbedHyperlinks::Automatic
         );
     }
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn deduce_embed_hyperlinks_always() {
         assert_eq!(
-            EmbedHyperlinks::deduce(&mock_cli(vec!["--hyperlink", "always"])),
+            EmbedHyperlinks::deduce(&mock_cli(vec!["--hyperlink=always"])),
             EmbedHyperlinks::Always
         );
     }
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn deduce_embed_hyperlinks_never() {
         assert_eq!(
-            EmbedHyperlinks::deduce(&mock_cli(vec!["--hyperlink", "never"])),
+            EmbedHyperlinks::deduce(&mock_cli(vec!["--hyperlink=never"])),
             EmbedHyperlinks::Never
         );
         assert_eq!(

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -93,6 +93,7 @@ pub fn get_command() -> clap::Command {
             .default_missing_value("auto"))
         .arg(arg!(--hyperlink <WHEN> "when to display entries as hyperlinks")
             .num_args(0..=1)
+            .require_equals(true)
             .value_parser(value_parser!(ShowWhen))
             .default_missing_value("auto"))
         .arg(arg!(--"no-quotes" "don't quote file names with spaces"))

--- a/tests/cmd/hyperlink_bare_path_all.toml
+++ b/tests/cmd/hyperlink_bare_path_all.toml
@@ -1,0 +1,3 @@
+bin.name = "eza"
+args = "--hyperlink tests/cmd"
+status.code = 0

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -27,7 +27,7 @@ DISPLAY OPTIONS:
       --color-scale [<FIELDS>...]  highlight value of FIELDS distinctly [possible values: all, age, size]
       --color-scale-mode <MODE>    mode for --color-scale [default: gradient] [possible values: fixed, gradient]
       --icons [<WHEN>]             when to display icons [possible values: always, auto, never]
-      --hyperlink [<WHEN>]         when to display entries as hyperlinks [possible values: always, auto, never]
+      --hyperlink[=<WHEN>]         when to display entries as hyperlinks [possible values: always, auto, never]
       --no-quotes                  don't quote file names with spaces
       --short-nix                  abbreviate Nix store hashes in file names and paths
 

--- a/tests/ptests/ptest_295b1dd87a9bb792.toml
+++ b/tests/ptests/ptest_295b1dd87a9bb792.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir --hyperlink never"
+args = "tests/test_dir --hyperlink=never"

--- a/tests/ptests/ptest_a82ad7ec2e961f84.stdout
+++ b/tests/ptests/ptest_a82ad7ec2e961f84.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 

--- a/tests/ptests/ptest_af29d370729835d8.stdout
+++ b/tests/ptests/ptest_af29d370729835d8.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 

--- a/tests/ptests/ptest_bba388583551f506.toml
+++ b/tests/ptests/ptest_bba388583551f506.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir --hyperlink always"
+args = "tests/test_dir --hyperlink=always"

--- a/tests/ptests/ptest_e8471ce10a208fd.toml
+++ b/tests/ptests/ptest_e8471ce10a208fd.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir --hyperlink auto"
+args = "tests/test_dir --hyperlink=auto"


### PR DESCRIPTION
## Summary
`--hyperlink` is optional (`num_args(0..=1)`), so clap was happy to treat the next positional path as `WHEN`. That made `eza --hyperlink /usr/bin` fail with `invalid value '/usr/bin'`.

## Fix
Require `=` for an explicit value (`require_equals(true)`), same pattern as `--code` / `--loc` and the open icons sibling. Bare `--hyperlink` still defaults to `auto`; paths stay paths. Explicit modes use `--hyperlink=always|auto|never`.

## Test plan
- [x] `cargo test --lib` (355 passed)
- [x] `cargo test --test cli_tests` (includes new `tests/cmd/hyperlink_bare_path_all.toml`)
- [x] Manual: `eza --hyperlink /usr/bin` succeeds; `--hyperlink=always PATH` works

Fixes #1879
