### PR TITLE
Fix strict-mode false positives for unset flags with default values

### DIFF
--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -4,7 +4,7 @@
 // SPDX-FileCopyrightText: 2023-2024 Christina Sørensen, eza contributors
 // SPDX-FileCopyrightText: 2014 Benjamin Sago
 // SPDX-License-Identifier: MIT
-use clap::{ArgMatches, ValueEnum};
+use clap::{ArgMatches, ValueEnum, parser::ValueSource};
 
 use crate::output::TerminalWidth::Automatic;
 
@@ -131,7 +131,7 @@ impl Mode {
             "mounts",
             "loc",
         ] {
-            if matches.contains_id(flag) {
+            if matches.value_source(flag) == Some(ValueSource::CommandLine) {
                 return Err(OptionsError::Useless(flag, false, "long"));
             }
         }
@@ -1028,6 +1028,24 @@ mod tests {
                 true
             ),
             Err(OptionsError::Useless("across", true, "long"))
+        );
+    }
+
+    #[test]
+    fn strict_check_long_flags_no_args_is_ok() {
+        // Regression test for https://github.com/eza-community/eza/issues/1874:
+        // strict mode used to reject a bare invocation (no relevant flags passed
+        // at all) because `contains_id` is true for every flag clap has a
+        // matched (even default/unset) value for, not just ones actually given
+        // on the command line.
+        assert_eq!(Mode::strict_check_long_flags(&mock_cli(vec![""])), Ok(()));
+    }
+
+    #[test]
+    fn strict_check_long_flags_binary_without_long_errors() {
+        assert_eq!(
+            Mode::strict_check_long_flags(&mock_cli(vec!["--binary"])),
+            Err(OptionsError::Useless("binary", false, "long"))
         );
     }
 


### PR DESCRIPTION
Fixes #1874

## Problem

`EZA_STRICT=true` (or `--strict`) rejects even a bare `eza` invocation with no relevant flags at all — `strict_check_long_flags` uses `matches.contains_id(flag)` to check whether the user passed a flag that only makes sense with `--long`, but clap's `contains_id` is `true` once a flag has been parsed and assigned *any* value, including its unset/default value, not just when the user actually supplied it on the command line.

## Fix

Switch to `matches.value_source(flag) == Some(ValueSource::CommandLine)`, which only matches flags the user actually supplied. This works uniformly for both boolean (`SetTrue`) and value-taking flags in the checked list (`get_flag` would panic on the value-taking ones like `time`/`loc`, which is why `contains_id` was presumably used originally).

## Testing

- Manually verified the exact false-positive from the issue is gone: `EZA_STRICT=true eza` (bare invocation) now runs cleanly.
- Verified true positives still correctly error: `-b`/`--binary` alone, `--git` alone, `--level 2` alone (all under `--strict`), and that `-l -b` together (long + binary, which is meaningful) still succeeds.
- Added two regression tests calling `Mode::strict_check_long_flags` directly: one asserting a bare invocation is `Ok(())`, one asserting `--binary` alone still errors. Confirmed the first test actually catches the regression by temporarily reverting just the source fix and re-running — it fails as expected, then passes again with the fix restored.
- Full existing `options::` test suite (124 tests) passes, no regressions.
- `cargo fmt --check` clean on the changed file.
- `cargo clippy --release -- -D warnings` fails on an unrelated pre-existing issue in `build.rs` (a `useless_borrows_in_formatting` lint) — confirmed this exists identically on a clean, unmodified `upstream/main` checkout, so it's a local clippy-version mismatch unrelated to this change, not something introduced here.
