### PR TITLE
feat: add colors to CLI help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 dirs = "6.0.0"
 serde_norway = "0.9"
 backtrace = "0.3"
-clap = { version = "4.5.38", features = ["cargo", "derive"] }
+clap = { version = "4.5.38", features = ["cargo", "derive", "wrap_help"] }
 
 [dependencies.git2]
 version = "0.21"

--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -6,7 +6,14 @@
 // SPDX-License-Identifier: MIT
 use std::ffi::OsString;
 
-use clap::{Error, ValueEnum, arg, builder::PossibleValue, value_parser};
+use clap::{
+    Error, ValueEnum, arg,
+    builder::{
+        PossibleValue,
+        styling::{AnsiColor, Effects, Styles},
+    },
+    value_parser,
+};
 
 use crate::{
     fs::filter::{SortCase, SortField},
@@ -24,6 +31,15 @@ const TIME_FIELDS_HELP: &str = "[possible values:
 const FORMAT_STYLE_FIELDS_HELP: &str = "[possible values:
   default, iso, long-iso, full-iso, relative, \"+<CUSTOM_FORMAT>\"]";
 
+const HELP_STYLES: Styles = Styles::styled()
+    .header(AnsiColor::BrightGreen.on_default().effects(Effects::BOLD))
+    .usage(AnsiColor::BrightGreen.on_default().effects(Effects::BOLD))
+    .literal(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
+    .placeholder(AnsiColor::Cyan.on_default())
+    .error(AnsiColor::BrightRed.on_default().effects(Effects::BOLD))
+    .valid(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
+    .invalid(AnsiColor::Yellow.on_default().effects(Effects::BOLD));
+
 pub fn get_command() -> clap::Command {
     clap::Command::new(clap::crate_name!())
         .author(clap::crate_authors!())
@@ -32,6 +48,7 @@ pub fn get_command() -> clap::Command {
         .disable_help_flag(true)
         .disable_version_flag(true)
         .args_override_self(true)
+        .styles(HELP_STYLES)
 
         .arg(arg!([FILE]...).value_parser(clap::value_parser!(OsString)).hide_short_help(true))
 
@@ -367,5 +384,17 @@ pub mod test {
                 .collect::<Vec<_>>(),
             ["file1", "file2"]
         );
+    }
+
+    #[test]
+    fn help_uses_cargo_style_colors() {
+        let command = get_command();
+        let styles = command.get_styles();
+        let header = AnsiColor::BrightGreen.on_default().effects(Effects::BOLD);
+        let literal = AnsiColor::BrightCyan.on_default().effects(Effects::BOLD);
+
+        assert_eq!(styles.get_header(), &header);
+        assert_eq!(styles.get_literal(), &literal);
+        assert_eq!(styles.get_placeholder(), &AnsiColor::Cyan.on_default());
     }
 }

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -20,19 +20,26 @@ LAYOUT OPTIONS:
   -w, --width <COLS>     set screen width in columns
 
 DISPLAY OPTIONS:
-  -F, --classify [<WHEN>]          display type indicator by file names [possible values: always, auto, never]
+  -F, --classify [<WHEN>]          display type indicator by file names [possible values: always,
+                                   auto, never]
   -X, --dereference                dereference symbolic links when displaying information
-      --absolute [<absolute>]      display entries with their absolute path [possible values: on, off, follow]
-      --color [<WHEN>]             When to use colours. [default: auto] [possible values: always, auto, never]
-      --color-scale [<FIELDS>...]  highlight value of FIELDS distinctly [possible values: all, age, size]
-      --color-scale-mode <MODE>    mode for --color-scale [default: gradient] [possible values: fixed, gradient]
+      --absolute [<absolute>]      display entries with their absolute path [possible values: on,
+                                   off, follow]
+      --color [<WHEN>]             When to use colours. [default: auto] [possible values: always,
+                                   auto, never]
+      --color-scale [<FIELDS>...]  highlight value of FIELDS distinctly [possible values: all, age,
+                                   size]
+      --color-scale-mode <MODE>    mode for --color-scale [default: gradient] [possible values:
+                                   fixed, gradient]
       --icons [<WHEN>]             when to display icons [possible values: always, auto, never]
-      --hyperlink [<WHEN>]         when to display entries as hyperlinks [possible values: always, auto, never]
+      --hyperlink [<WHEN>]         when to display entries as hyperlinks [possible values: always,
+                                   auto, never]
       --no-quotes                  don't quote file names with spaces
       --short-nix                  abbreviate Nix store hashes in file names and paths
 
 FILTERING OPTIONS:
-  -a, --all...               show hidden files. Use this twice to also show the '.' and '..' directories
+  -a, --all...               show hidden files. Use this twice to also show the '.' and '..'
+                             directories
   -A, --almost-all           equivalent to --all; included for compatibility with `ls -A`
   -d, --treat-dirs-as-files  treat directories as files; don't list their contents
   -D, --only-dirs            list only directories
@@ -83,4 +90,5 @@ LONG VIEW OPTIONS:
       --no-filesize          suppress the filesize field
       --no-user              suppress the user field
       --no-time              suppress the time field
-      --no-git               suppress Git fields (overrides --git, --git-repos, --git-repos-no-status)
+      --no-git               suppress Git fields (overrides --git, --git-repos,
+                             --git-repos-no-status)

--- a/tests/ptests/ptest_a82ad7ec2e961f84.stdout
+++ b/tests/ptests/ptest_a82ad7ec2e961f84.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 

--- a/tests/ptests/ptest_af29d370729835d8.stdout
+++ b/tests/ptests/ptest_af29d370729835d8.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Make sure you've read CONTRIBUTING.md and CODE_OF_CONDUCT.md -->
<!---  -->
<!--- If suggesting a major new feature or major change, please discuss it in an issue/discussions first -->
<!--- If fixing a bug, IDEALLY there should be an issue describing it with steps to reproduce -->
##### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Consider including potentially useful screenshots of your feature in action -->

Add Cargo-inspired colors to clap-generated help and diagnostics. Headings use bright green, command-line syntax uses bright cyan, and placeholders use cyan.

Enable clap’s `wrap_help` feature so long descriptions wrap to the terminal width. Color remains subject to clap/anstream’s automatic terminal detection and `NO_COLOR` support.

This revisits [#444](https://github.com/eza-community/eza/pull/444), which proposed colored help before eza used clap. That implementation embedded ANSI escapes directly and did not respect `NO_COLOR`; the current clap-based approach handles those concerns centrally.

This change does not introduce a command-line flag, so no completion, man page, or README updates are required.

##### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on macOS 15.7.7 with rustc and Cargo 1.97.1.

- `cargo fmt --all --check`
- `cargo test`
- checked the help output in Ghostty with colors enabled and with `NO_COLOR` set
- rendered and visually inspected the complete help output using [Betamax](https://www.joshka.net/betamax/)
