### PR TITLE
fix(ci): substitute version string in mangen recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -286,9 +286,10 @@ alias c := cross
 @mangen:
     # Setup Output Directory
     mkdir -p ./target/"man-$(convco version)"
-    pandoc --standalone -f markdown -t man man/eza.1.md > ./target/"man-$(convco version)"/eza.1
-    pandoc --standalone -f markdown -t man man/eza_colors.5.md > ./target/"man-$(convco version)"/eza_colors.5
-    pandoc --standalone -f markdown -t man man/eza_colors-explanation.5.md > ./target/"man-$(convco version)"/eza_colors-explanation.5
+    version=$(awk 'BEGIN { FS = "\"" } ; /^version/ { print $2 ; exit }' Cargo.toml); \
+    for page in eza.1 eza_colors.5 eza_colors-explanation.5; do \
+        sed "s/\$version/v${version}/g" "man/${page}.md" | pandoc --standalone -f markdown -t man > ./target/"man-$(convco version)/${page}"; \
+    done;
     tar czvf ./target/"man-$(convco version)".tar.gz ./target/"man-$(convco version)"
 
 [group('documentation')]


### PR DESCRIPTION
Fixes #951

### Root Cause
The `@man` recipe in `justfile` previously performed `sed "s/\$version/v${version}/g"` before piping markdown files into `pandoc`, substituting the version string. However, the `@mangen` recipe (used during release generation) piped the raw markdown directly into `pandoc`, causing released man pages to retain the literal `$version` placeholder string.

### Fix
Updated `@mangen` in `justfile` to run the same `sed "s/\$version/v${version}/g"` substitution as `@man` for `eza.1`, `eza_colors.5`, and `eza_colors-explanation.5` before invoking `pandoc`. The output paths and tarball archive generation (`./target/man-$(convco version).tar.gz`) remain unchanged.

### Test Output

**Before:**
```console
$ grep '\$version' target/man-*/eza.1
.TH "eza" "1" "" "$version"
```

**After:**
```console
$ just mangen
./target/man-0.23.5/
./target/man-0.23.5/eza.1
./target/man-0.23.5/eza_colors.5
./target/man-0.23.5/eza_colors-explanation.5

$ grep '\$version' target/man-*/eza.1
(exit code 1 - no matches found)

$ head -n 5 target/man-*/eza.1
.\" Automatically generated by Pandoc 3.6.3
.\"
.TH "eza" "1" "" "v0.23.5"
.SH NAME
eza \[em] a modern replacement for ls

$ man -l target/man-*/eza.1 | tail -n 1
v0.23.5                                                                  eza(1)
```