### PR TITLE
docs: fix man page $version placeholder and stale .md cross-links

### DIFF
--- a/justfile
+++ b/justfile
@@ -286,9 +286,9 @@ alias c := cross
 @mangen:
     # Setup Output Directory
     mkdir -p ./target/"man-$(convco version)"
-    pandoc --standalone -f markdown -t man man/eza.1.md > ./target/"man-$(convco version)"/eza.1
-    pandoc --standalone -f markdown -t man man/eza_colors.5.md > ./target/"man-$(convco version)"/eza_colors.5
-    pandoc --standalone -f markdown -t man man/eza_colors-explanation.5.md > ./target/"man-$(convco version)"/eza_colors-explanation.5
+    for page in eza.1 eza_colors.5 eza_colors-explanation.5; do \
+        sed "s/\$version/v$(convco version)/g" "man/${page}.md" | pandoc --standalone -f markdown -t man > ./target/"man-$(convco version)"/${page}; \
+    done;
     tar czvf ./target/"man-$(convco version)".tar.gz ./target/"man-$(convco version)"
 
 [group('documentation')]

--- a/man/eza.1.md
+++ b/man/eza.1.md
@@ -365,7 +365,7 @@ See `https://no-color.org/` for details.
 
 Specifies the colour scheme used to highlight files based on their name and kind, as well as highlighting metadata and parts of the UI.
 
-For more information on the format of these environment variables, see the [eza_colors.5.md](eza_colors.5.md) manual page.
+For more information on the format of these environment variables, see the [eza_colors(5)](eza_colors.5) manual page.
 
 ## `EZA_OVERRIDE_GIT`
 
@@ -417,5 +417,5 @@ Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors 
 SEE ALSO
 ========
 
-- [**eza_colors**(5)](eza_colors.5.md)
-- [**eza_colors-explanation**(5)](eza_colors-explanation.5.md)
+- [**eza_colors**(5)](eza_colors.5)
+- [**eza_colors-explanation**(5)](eza_colors-explanation.5)

--- a/man/eza_colors-explanation.5.md
+++ b/man/eza_colors-explanation.5.md
@@ -228,5 +228,5 @@ You must name the file `theme.yml`, no matter the directory you specify.
 
 ## See also
 
-- [**eza**(1)](eza.1.md)
-- [**eza_colors**(5)](eza_colors.5.md)
+- [**eza**(1)](eza.1)
+- [**eza_colors**(5)](eza_colors.5)

--- a/man/eza_colors.5.md
+++ b/man/eza_colors.5.md
@@ -399,5 +399,5 @@ Our infinite thanks to Benjamin ‘ogham’ Sago and all the other contributors 
 SEE ALSO
 ========
 
-- [**eza**(1)](eza.1.md)
-- [**eza_colors-explanation**(5)](eza_colors-explanation.5.md)
+- [**eza**(1)](eza.1)
+- [**eza_colors-explanation**(5)](eza_colors-explanation.5)


### PR DESCRIPTION
## Summary
- `mangen` (used to build release man page tarballs) never substituted the `$version` placeholder like the `man` dev recipe does, so shipped man pages showed literal `$version` in the header instead of the eza version.
- Cross-page links (`SEE ALSO` sections + one inline reference in `eza.1.md`) pointed at the `.md` source filenames instead of the built man page names (`eza.1`, `eza_colors.5`, `eza_colors-explanation.5`).

Fixes #981 (points 2 and 3 — `--absolute` documentation, point 1, was already fixed upstream).

## Test plan
- [x] Simulated the `mangen` sed substitution locally against all three `man/*.md` sources — confirms `% eza(1) $version` becomes `% eza(1) vX.X.X`.
- [x] Grepped the three man pages post-fix for `.md)` link targets — none remain.
- [ ] `pandoc`/`just`/`convco` not available in this environment to run `just mangen` end-to-end; CI should cover full render.