### PR TITLE
refactor(git): rename GitColours::new to added

### DIFF
--- a/src/output/render/git.rs
+++ b/src/output/render/git.rs
@@ -23,7 +23,7 @@ impl f::GitStatus {
         #[rustfmt::skip]
         return match self {
             Self::NotModified  => colours.not_modified().paint("-"),
-            Self::New          => colours.new().paint("N"),
+            Self::New          => colours.added().paint("N"),
             Self::Modified     => colours.modified().paint("M"),
             Self::Deleted      => colours.deleted().paint("D"),
             Self::Renamed      => colours.renamed().paint("R"),
@@ -36,10 +36,7 @@ impl f::GitStatus {
 
 pub trait Colours {
     fn not_modified(&self) -> Style;
-    // FIXME: this amount of allows needed to keep clippy happy should be enough
-    // of an argument that new needs to be renamed.
-    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
-    fn new(&self) -> Style;
+    fn added(&self) -> Style;
     fn modified(&self) -> Style;
     fn deleted(&self) -> Style;
     fn renamed(&self) -> Style;
@@ -110,7 +107,7 @@ pub mod test {
         fn not_modified(&self) -> Style {
             Fixed(90).normal()
         }
-        fn new(&self) -> Style {
+        fn added(&self) -> Style {
             Fixed(91).normal()
         }
         fn modified(&self) -> Style {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -364,7 +364,7 @@ impl render::FiletypeColours for Theme {
 impl render::GitColours for Theme {
     fn not_modified(&self)  -> Style { self.ui.punctuation() }
     #[allow(clippy::new_ret_no_self)]
-    fn new(&self)           -> Style { self.ui.git.unwrap_or_default().new() }
+    fn added(&self)           -> Style { self.ui.git.unwrap_or_default().new() }
     fn modified(&self)      -> Style { self.ui.git.unwrap_or_default().modified() }
     fn deleted(&self)       -> Style { self.ui.git.unwrap_or_default().deleted() }
     fn renamed(&self)       -> Style { self.ui.git.unwrap_or_default().renamed() }


### PR DESCRIPTION
## Description
Resolves the FIXME in `src/output/render/git.rs` by renaming the `GitColours::new` method to `added`.

I elminated the need for #[allow] annotations for `new_ret_no_self` and `wrong_self_convention`. Renaming  `new` to `added` preserves the semantic meaning (status for newly added files)... It still matches the past-tense verb naming of the other struct. 

AFAIK in standard Git nomenclature, newly created/staged files are almost always referred to as "added" anyways.

## How Has This Been Tested?
- Ran `cargo check && cargo test --all` — all tests pass
