### PR TITLE
fix(options): keep classify from consuming paths

### DIFF
--- a/src/options/parser.rs
+++ b/src/options/parser.rs
@@ -62,6 +62,7 @@ pub fn get_command() -> clap::Command {
         .next_help_heading("DISPLAY OPTIONS")
         .arg(arg!(-F --classify <WHEN> "display type indicator by file names")
             .num_args(0..=1)
+            .require_equals(true)
             .value_parser(value_parser!(ShowWhen))
             .default_missing_value("auto"))
         .arg(arg!(-X --dereference  "dereference symbolic links when displaying information"))
@@ -367,5 +368,26 @@ pub mod test {
                 .collect::<Vec<_>>(),
             ["file1", "file2"]
         );
+    }
+
+    #[test]
+    fn classify_does_not_consume_file() {
+        let cli = mock_cli(vec!["-alF", "."]);
+
+        assert_eq!(
+            cli.get_many("FILE")
+                .unwrap()
+                .map(OsString::as_os_str)
+                .collect::<Vec<_>>(),
+            ["."]
+        );
+        assert_eq!(cli.get_one::<ShowWhen>("classify"), Some(&ShowWhen::Auto));
+    }
+
+    #[test]
+    fn classify_accepts_explicit_value() {
+        let cli = mock_cli(vec!["--classify=always", "."]);
+
+        assert_eq!(cli.get_one::<ShowWhen>("classify"), Some(&ShowWhen::Always));
     }
 }

--- a/tests/cmd/classify_bare_path_all.toml
+++ b/tests/cmd/classify_bare_path_all.toml
@@ -1,0 +1,3 @@
+bin.name = "eza"
+args = "-alF tests/cmd"
+status.code = 0

--- a/tests/ptests/ptest_109771b99ff4bc2c.toml
+++ b/tests/ptests/ptest_109771b99ff4bc2c.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir -F never"
+args = "tests/test_dir -F=never"

--- a/tests/ptests/ptest_219f7c8dfa0d0323.toml
+++ b/tests/ptests/ptest_219f7c8dfa0d0323.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir -F always"
+args = "tests/test_dir -F=always"

--- a/tests/ptests/ptest_2439b7d68089135b.stdout
+++ b/tests/ptests/ptest_2439b7d68089135b.stdout
@@ -20,7 +20,7 @@ LAYOUT OPTIONS:
   -w, --width <COLS>     set screen width in columns
 
 DISPLAY OPTIONS:
-  -F, --classify [<WHEN>]          display type indicator by file names [possible values: always, auto, never]
+  -F, --classify[=<WHEN>]          display type indicator by file names [possible values: always, auto, never]
   -X, --dereference                dereference symbolic links when displaying information
       --absolute [<absolute>]      display entries with their absolute path [possible values: on, off, follow]
       --color [<WHEN>]             When to use colours. [default: auto] [possible values: always, auto, never]

--- a/tests/ptests/ptest_365b1525fed70635.toml
+++ b/tests/ptests/ptest_365b1525fed70635.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir --classify never"
+args = "tests/test_dir --classify=never"

--- a/tests/ptests/ptest_3fe14fdeb5bf19de.toml
+++ b/tests/ptests/ptest_3fe14fdeb5bf19de.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir --classify auto"
+args = "tests/test_dir --classify=auto"

--- a/tests/ptests/ptest_80cd40f7a3947055.toml
+++ b/tests/ptests/ptest_80cd40f7a3947055.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir --classify always"
+args = "tests/test_dir --classify=always"

--- a/tests/ptests/ptest_a78bf581d9095079.toml
+++ b/tests/ptests/ptest_a78bf581d9095079.toml
@@ -1,2 +1,2 @@
 bin.name = "eza"
-args = "tests/test_dir -F auto"
+args = "tests/test_dir -F=auto"

--- a/tests/ptests/ptest_a82ad7ec2e961f84.stdout
+++ b/tests/ptests/ptest_a82ad7ec2e961f84.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 

--- a/tests/ptests/ptest_af29d370729835d8.stdout
+++ b/tests/ptests/ptest_af29d370729835d8.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 


### PR DESCRIPTION
##### Description
Keep optional classify values attached with = so a following path is parsed as a path. This restores eza -alF . while preserving --classify=always.

Fixes #1885.

##### How Has This Been Tested?
- cargo test classify
- exact CLI regression in tests/cmd/classify_bare_path_all.toml
- cargo clippy --all-targets
- cargo fmt --all -- --check

The new CLI regression passes. The unit suites pass; three existing symlink fixtures remain unsupported on Windows.