### PR TITLE
fix: cap --width to prevent div-by-zero on huge values

### DIFF
--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -198,7 +198,7 @@ impl details::Options {
 impl TerminalWidth {
     fn deduce<V: Vars>(matches: &ArgMatches, vars: &V) -> Result<Self, OptionsError> {
         if let Some(&width) = matches.get_one("width") {
-            if width >= 1 {
+            if width >= 1 && width <= usize::MAX / 2 {
                 Ok(Set(width))
             } else {
                 Ok(Automatic)

--- a/tests/ptests/ptest_a82ad7ec2e961f84.stdout
+++ b/tests/ptests/ptest_a82ad7ec2e961f84.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 

--- a/tests/ptests/ptest_af29d370729835d8.stdout
+++ b/tests/ptests/ptest_af29d370729835d8.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 


### PR DESCRIPTION
Fixes #1895. `eza -w N` with `N` near `usize::MAX` overflows an internal `width + separator` computation to `0`, causing `uutils_term_grid` to divide by zero. Capping the width to `usize::MAX / 2` prevents the overflow. Values beyond this cap fall back to automatic width detection, matching the existing behavior for values below 1.