### PR TITLE
chore(releases): add test dumping to upgrade releases as the cargo ve…

### DIFF
--- a/justfile
+++ b/justfile
@@ -126,7 +126,7 @@ version := ""
 new_version := if version == "" { "$(convco version --bump)" } else { version }
 
 # If you're not cafkafk and she isn't dead, don't run this!
-#
+# We redump the tests to update the test that needs the new version.
 # usage: release major, release minor, release patch
 [group('release')]
 release:
@@ -134,6 +134,7 @@ release:
     git cliff -c .config/cliff.toml -t "{{new_version}}" > CHANGELOG.md
     cargo check
     nix build -L ./#clippy
+    just idump 
     git checkout -b "cafk-release-v{{new_version}}"
     git commit -asm "chore: eza v{{new_version}} changelogs, version bump"
     git push

--- a/tests/ptests/ptest_a82ad7ec2e961f84.stdout
+++ b/tests/ptests/ptest_a82ad7ec2e961f84.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 

--- a/tests/ptests/ptest_af29d370729835d8.stdout
+++ b/tests/ptests/ptest_af29d370729835d8.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 


### PR DESCRIPTION
…rsion is ugraded


As we always have the slight issue of --version tests not being up to date after release adding this should fix it