### PR TITLE
fix(options): clamp requested terminal width to u16::MAX

### DIFF
--- a/src/options/view.rs
+++ b/src/options/view.rs
@@ -197,15 +197,15 @@ impl details::Options {
 
 impl TerminalWidth {
     fn deduce<V: Vars>(matches: &ArgMatches, vars: &V) -> Result<Self, OptionsError> {
-        if let Some(&width) = matches.get_one("width") {
+        if let Some(&width) = matches.get_one::<usize>("width") {
             if width >= 1 {
-                Ok(Set(width))
+                Ok(Set(width.min(TerminalWidth::MAXIMUM)))
             } else {
                 Ok(Automatic)
             }
         } else if let Some(columns) = vars.get(vars::COLUMNS).and_then(|s| s.into_string().ok()) {
-            match columns.parse() {
-                Ok(width) => Ok(Set(width)),
+            match columns.parse::<usize>() {
+                Ok(width) => Ok(Set(width.min(TerminalWidth::MAXIMUM))),
                 Err(e) => {
                     let source = NumberSource::Env(vars::COLUMNS);
                     Err(OptionsError::FailedParse(columns, source, e))
@@ -1066,6 +1066,27 @@ mod tests {
         assert_eq!(
             TerminalWidth::deduce(&mock_cli(vec![""]), &vars),
             Ok(Set(80))
+        );
+    }
+
+    #[test]
+    fn deduce_terminal_width_huge_arg_is_clamped() {
+        assert_eq!(
+            TerminalWidth::deduce(
+                &mock_cli(vec!["--width", &usize::MAX.to_string()]),
+                &MockVars::default()
+            ),
+            Ok(Set(TerminalWidth::MAXIMUM))
+        );
+    }
+
+    #[test]
+    fn deduce_terminal_width_huge_env_is_clamped() {
+        let mut vars = MockVars::default();
+        vars.set(vars::COLUMNS, &OsString::from(usize::MAX.to_string()));
+        assert_eq!(
+            TerminalWidth::deduce(&mock_cli(vec![""]), &vars),
+            Ok(Set(TerminalWidth::MAXIMUM))
         );
     }
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -59,6 +59,10 @@ pub enum TerminalWidth {
 }
 
 impl TerminalWidth {
+    /// The largest width that can be requested. Terminals report their size as
+    /// a `u16`, and widths beyond that overflow the grid layout arithmetic.
+    pub const MAXIMUM: usize = u16::MAX as usize;
+
     #[must_use]
     pub fn actual_terminal_width(self) -> Option<usize> {
         // All of stdin, stdout, and stderr could not be connected to a


### PR DESCRIPTION
Fixes #1895.

## Problem

`eza -w N` / `--width N` with `N` near `usize::MAX` aborts:

```console
$ eza -w 18446744073709551615 /tmp/d
thread 'main' panicked at uutils_term_grid-0.7.0/src/lib.rs:204:
attempt to add with overflow          # debug
attempt to divide by zero             # release (wrapping)
```

`TerminalWidth::deduce` only enforced a lower bound (`width >= 1`), so the raw
`usize` reached `uutils_term_grid`, where `self.options.width + filling.width()`
wraps to a tiny value, yielding `min_columns == 0` and then `div_ceil(len, 0)`.

The `COLUMNS` environment variable took the same unbounded path.

## Fix

Clamp the user-requested width to `u16::MAX`. Terminal sizes are already
reported by the OS as `u16` (that is what the `Automatic` path receives from
`terminal_size`), so this bounds the explicit path to the same range instead of
inventing a new limit. 65535 columns is far past any layout that could
realistically differ, so no reachable output changes.

## Verification

```console
$ ./target/debug/eza -w 18446744073709551615 /tmp/d
a  b
$ echo $?
0

$ cargo fmt --check          # exit 0
$ cargo clippy --all-targets -- -D warnings   # exit 0, 0 warnings
$ cargo test                 # 357 lib + 2 cli + 3 doc tests pass, 0 failed
```

Two regression tests added in `src/options/view.rs`, covering the `--width`
argument and the `COLUMNS` variable.

---

*Disclosure: this patch was prepared with AI assistance (Claude). The diagnosis,
the fix, and every command shown above were run and verified locally by me.*
