### PR TITLE
fix(deps): pin palette_derive to 0.7.5 to actually avoid by_address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,12 +175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
-name = "by_address"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +439,7 @@ dependencies = [
  "natord-plus-plus",
  "nu-ansi-term",
  "palette",
+ "palette_derive",
  "path-clean",
  "percent-encoding",
  "phf",
@@ -899,11 +894,10 @@ dependencies = [
 
 [[package]]
 name = "palette_derive"
-version = "0.7.6"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+checksum = "e8890702dbec0bad9116041ae586f84805b13eecd1d8b1df27c29998a9969d6d"
 dependencies = [
- "by_address",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,10 @@ path-clean = "1.0.1"
 unit-prefix = "0.5.2"
 # palette 0.7.6 is broken: https://github.com/eza-community/eza/pull/1207
 palette = { version = "=0.7.5", default-features = false, features = ["std"] }
+# palette 0.7.5 requires palette_derive "0.7.5" (a caret requirement), so pinning
+# palette alone lets palette_derive 0.7.6+ in, which is what actually pulls the
+# unsound by_address crate. It must be pinned directly to have any effect.
+palette_derive = "=0.7.5"
 percent-encoding = "2.3.1"
 phf = { version = "0.13.1", features = ["macros"] }
 plist = { version = "1.7.0", default-features = false }


### PR DESCRIPTION
### Problem

The `palette = "=0.7.5"` pin does not achieve what it was meant to achieve.

That pin exists to avoid `by_address`, which `palette_derive` 0.7.6 introduced and which has an unresolved soundness issue (mbrubeck/by_address#9 — still open). The intent was correct, but `palette_derive` is a transitive dependency, and `palette` 0.7.5 declares it with a caret requirement:

```toml
[dependencies.palette_derive]
version = "0.7.5"
```

That resolves as `^0.7.5`, so pinning `palette` exactly does nothing to hold `palette_derive` back. On `main` today:

```
$ cargo tree -i by_address
by_address v1.2.1
└── palette_derive v0.7.6 (proc-macro)
    └── palette v0.7.5
        └── eza v0.23.5

$ cargo tree -i palette_derive
palette_derive v0.7.6 (proc-macro)
└── palette v0.7.5
    └── eza v0.23.5
```

`by_address` is in the committed `Cargo.lock`, and therefore in release builds. It has been there since the pin was introduced in 005170fa3 (#1721) — the `=0.7.5` form was chosen specifically to prevent accidental upgrades, but the upgrade it needed to prevent was on the derive crate, which the pin never covered.

### Second symptom: `cargo install eza` is broken

Since `palette` 0.7.7 was released, the same gap breaks installation outright for anyone not passing `--locked`. Without a lockfile, `palette_derive` resolves to 0.7.7 while `palette` stays pinned at 0.7.5, and the 0.7.7 derive macro expands to paths (`crate::lms`, `xyz::meta`) that do not exist in the 0.7.5 library:

```
$ rm Cargo.lock && cargo generate-lockfile
      Adding palette v0.7.5 (available: v0.7.7)

$ cargo build
error[E0433]: failed to resolve: could not find `lms` in the crate root
  --> .../palette-0.7.5/src/hsl.rs:46:28
   |
46 | #[derive(Debug, ArrayCast, FromColorUnclamped, WithAlpha)]
   |                            ^^^^^^^^^^^^^^^^^^ could not find `lms` in the crate root
   |
   = note: this error originates in the derive macro `FromColorUnclamped`

error[E0433]: failed to resolve: could not find `meta` in `xyz`
...
error: could not compile `palette` (lib) due to 34 previous errors
```

`cargo install eza --locked` works, which is consistent with the diagnosis.

### Fix

Add `palette_derive` as a direct dependency pinned to `=0.7.5`, alongside the existing `palette` pin:

```toml
# palette 0.7.6 is broken: https://github.com/eza-community/eza/pull/1207
palette = { version = "=0.7.5", default-features = false, features = ["std"] }
# palette 0.7.5 requires palette_derive "0.7.5" (a caret requirement), so pinning
# palette alone lets palette_derive 0.7.6+ in, which is what actually pulls the
# unsound by_address crate. It must be pinned directly to have any effect.
palette_derive = "=0.7.5"
```

Depending on `palette_derive` directly is not something its own README recommends — it is re-exported through `palette` and normally should not be named explicitly. But since a pin on the parent crate does not propagate, there is no other way to constrain it from a manifest. The comment is there so the next person does not remove the line as redundant.

`Cargo.lock` was updated with `cargo update -p palette_derive --precise 0.7.5` to keep the diff minimal (12 lines).

### Verification

```
$ cargo tree -i by_address
error: package ID specification `by_address` did not match any packages

$ cargo tree -i palette_derive
palette_derive v0.7.5 (proc-macro)
├── eza v0.23.5
└── palette v0.7.5
    └── eza v0.23.5
```

`by_address` is gone from the graph, which is the actual point of this change.

Fresh resolution without a lockfile now succeeds as well, so `cargo install eza` works again without `--locked`:

```
$ rm Cargo.lock && cargo generate-lockfile && cargo build
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.59s
```

`cargo build` and `cargo test` pass (355 unit tests, 2 cli_tests, 3 doc-tests).

`cargo tree -e features -p palette` before/after shows no change other than the `palette_derive` version and the removal of `by_address`; the `syn` / `quote` / `proc-macro2` feature sets are identical. eza does not use palette's `find-crate` feature — the only feature palette forwards to `palette_derive` — so the direct dependency introduces no feature unification changes.

### Upstream

The underlying issue is on the `palette` side: because the derive crate is a transitive dependency that consumers are told not to depend on directly, there is no supported way for a consumer to control what it pulls in. A dependency added to `palette_derive` reaches every consumer regardless of how tightly they pin `palette`. I intend to open an issue upstream suggesting an exact version requirement between the two crates, and will link it here.

Related: #1207, #1232, #1680, #1721
Fixes #1912