### PR TITLE
feat: add odin support to --code option

### DIFF
--- a/src/loc/mod.rs
+++ b/src/loc/mod.rs
@@ -380,6 +380,7 @@ macro_rules! languages {
 languages! {
     RUST       = ("Rust",         C_LINE,               &[("/*", "*/")]);
     C          = ("C",            C_LINE,               C_BLOCK);
+    ODIN       = ("Odin",         C_LINE,               C_BLOCK);
     CPP        = ("C++",          C_LINE,               C_BLOCK);
     CSHARP     = ("C#",           C_LINE,               C_BLOCK);
     JAVA       = ("Java",         C_LINE,               C_BLOCK);
@@ -451,6 +452,7 @@ static BY_EXTENSION: Map<&'static str, &'static Language> = phf_map! {
     "rs"    => &RUST,
     "c"     => &C,
     "h"     => &C,
+    "odin"  => &ODIN,
     "cc"    => &CPP,
     "cpp"   => &CPP,
     "cxx"   => &CPP,


### PR DESCRIPTION
**Description**
This PR adds support for the Odin programming language to the --code option to count lines of code.

**How Has This Been Tested?**
I ran `nix build`, `nix flake check`, `nix fmt`, `nix build .#test`, `nix build .#clippy`, and `just itest`. All of them succeeded except for `nix flake check` and `just itest`. I confirmed both of these failures already exist on the latest main. It looks like `nix flake check` fails due to a preexisting version mismatch and `just itest` fails due to `fd` not being found.

I did not attempt to fix the preexisting issues as I was not sure whether that was accepted practice in this repo or not.

I verified it counts lines of code for Odin correctly:
<img width="1048" height="203" alt="image" src="https://github.com/user-attachments/assets/686e4b72-59c3-4960-b93f-9d0a86601719" />
