### PR TITLE
fix: avoid panic on non-Unicode Windows paths

### DIFF
--- a/src/fs/feature/git.rs
+++ b/src/fs/feature/git.rs
@@ -357,12 +357,10 @@ fn reorient(path: &Path) -> PathBuf {
 fn reorient(path: &Path) -> PathBuf {
     let unc_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
     // On Windows UNC path is returned. We need to strip the prefix for it to work.
-    let normal_path = unc_path
-        .as_os_str()
-        .to_str()
-        .unwrap()
-        .trim_start_matches("\\\\?\\");
-    PathBuf::from(normal_path)
+    match unc_path.to_str() {
+        Some(text) => PathBuf::from(text.trim_start_matches("\\\\?\\")),
+        None => unc_path,
+    }
 }
 
 /// The character to display if the file has been modified, but not staged.


### PR DESCRIPTION
#### Description:

Eza previously panicked on non-Unicode characters on Windows while using Git features. This commit fixes that.

#1436 fixed a similar panic when reading Git status entries, but `reorient()` still used `to_str().unwrap()`. This change handles that case gracefully instead of panicking.

#### How has this been tested?

Tested with cargo fmt --check, cargo test, cargo hack test, and cargo clippy -- -D warnings.

It has been confirmed that `eza -l --git` panics when run inside a repo with a file containing a name with a non-unicode character. It has also been confirmed that this commit runs without panic.

