### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,4 +219,4 @@ After having understood the code of conduct, you can have a look at our
 [CONTRIBUTING.md](https://github.com/eza-community/eza/blob/main/CONTRIBUTING.md) 
 for more info about actual hacking.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=eza-community/eza&type=Date)](https://star-history.com/#eza-community/eza&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=eza-community/eza&type=Date)](https://star-history.dera.page/#eza-community/eza&Date)


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken and no longer renders, which is a shame for a project like eza that is growing quickly.

This switches the chart image and its wrapping link to a working star history service so the chart displays correctly again, keeping the same repository and type parameters.