### PR TITLE
fix(hyperlink): encode unsafe URI path characters

### DIFF
--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -45,18 +45,56 @@ pub fn escape(
     }
 }
 
-const HYPERLINK_ESCAPE_CHARS: &AsciiSet = &CONTROLS.add(b' ');
+const HYPERLINK_ESCAPE_CHARS: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}');
 const HYPERLINK_OPENING_START: &str = "\x1B]8;;";
 const HYPERLINK_OPENING_END: &str = "\x1B\x5C";
 // Combination of both above tags
 pub const HYPERLINK_CLOSING: &str = "\x1B]8;;\x1B\x5C";
 
-pub fn get_hyperlink_start_tag(abs_path: &str) -> String {
-    let abs_path = utf8_percent_encode(abs_path, HYPERLINK_ESCAPE_CHARS).to_string();
+#[cfg(any(target_os = "windows", test))]
+fn encode_windows_path_for_file_uri(abs_path: &str) -> String {
+    let (path, is_unc) = if let Some(path) = abs_path.strip_prefix(r"\\?\UNC\") {
+        (path, true)
+    } else {
+        let path = abs_path.strip_prefix(r"\\?\").unwrap_or(abs_path);
+        if let Some(path) = path.strip_prefix(r"\\") {
+            (path, true)
+        } else {
+            (path, false)
+        }
+    };
 
-    // On Windows, `std::fs::canonicalize` adds the Win32 File prefix, which we need to remove
+    let mut path = path.replace('\\', "/");
+    // Drive paths need an empty authority (`file:///C:/...`), while UNC paths
+    // use their server name as the authority (`file://server/share/...`).
+    if !is_unc && !path.starts_with('/') {
+        path.insert(0, '/');
+    }
+
+    utf8_percent_encode(&path, HYPERLINK_ESCAPE_CHARS).to_string()
+}
+
+pub fn get_hyperlink_start_tag(abs_path: &str) -> String {
     #[cfg(target_os = "windows")]
-    let abs_path = abs_path.strip_prefix("\\\\?\\").unwrap_or(&abs_path);
+    let abs_path = encode_windows_path_for_file_uri(abs_path);
+
+    #[cfg(not(target_os = "windows"))]
+    let abs_path = utf8_percent_encode(abs_path, HYPERLINK_ESCAPE_CHARS).to_string();
 
     format!("{HYPERLINK_OPENING_START}file://{abs_path}{HYPERLINK_OPENING_END}")
 }
@@ -73,5 +111,40 @@ mod test {
                 "{HYPERLINK_OPENING_START}file:///folder%20name/file%20name{HYPERLINK_OPENING_END}"
             ),
         );
+    }
+
+    #[test]
+    fn hyperlink_start_tag_escapes_uri_path_characters() {
+        assert_eq!(
+            get_hyperlink_start_tag(r#"/folder/file#?%[]\"<>^`{|}.txt"#),
+            format!(
+                "{HYPERLINK_OPENING_START}file:///folder/file%23%3F%25%5B%5D%5C%22%3C%3E%5E%60%7B%7C%7D.txt{HYPERLINK_OPENING_END}"
+            ),
+        );
+    }
+
+    #[test]
+    fn windows_paths_are_normalized_before_uri_escaping() {
+        for (path, expected) in [
+            (
+                r"\\?\C:\folder name\file#.txt",
+                "file:///C:/folder%20name/file%23.txt",
+            ),
+            (
+                r"C:\folder name\file#.txt",
+                "file:///C:/folder%20name/file%23.txt",
+            ),
+            (
+                r"\\?\UNC\server\share\folder name\file#.txt",
+                "file://server/share/folder%20name/file%23.txt",
+            ),
+            (
+                r"\\server\share\folder name\file#.txt",
+                "file://server/share/folder%20name/file%23.txt",
+            ),
+        ] {
+            let encoded_path = encode_windows_path_for_file_uri(path);
+            assert_eq!(format!("file://{encoded_path}"), expected);
+        }
     }
 }

--- a/src/output/escape.rs
+++ b/src/output/escape.rs
@@ -116,9 +116,20 @@ mod test {
     #[test]
     fn hyperlink_start_tag_escapes_uri_path_characters() {
         assert_eq!(
-            get_hyperlink_start_tag(r#"/folder/file#?%[]\"<>^`{|}.txt"#),
+            get_hyperlink_start_tag(r#"/folder/file#?%[]"<>^`{|}.txt"#),
             format!(
-                "{HYPERLINK_OPENING_START}file:///folder/file%23%3F%25%5B%5D%5C%22%3C%3E%5E%60%7B%7C%7D.txt{HYPERLINK_OPENING_END}"
+                "{HYPERLINK_OPENING_START}file:///folder/file%23%3F%25%5B%5D%22%3C%3E%5E%60%7B%7C%7D.txt{HYPERLINK_OPENING_END}"
+            ),
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn hyperlink_start_tag_escapes_backslashes_in_unix_file_names() {
+        assert_eq!(
+            get_hyperlink_start_tag(r"/folder/file\name.txt"),
+            format!(
+                "{HYPERLINK_OPENING_START}file:///folder/file%5Cname.txt{HYPERLINK_OPENING_END}"
             ),
         );
     }


### PR DESCRIPTION
##### Description

Percent-encode ASCII characters that are unsafe in an OSC 8 `file://` URI path or would change the path's meaning. In particular, filenames containing `?` or `#` now produce working hyperlinks instead of being interpreted as a query or fragment.

The expanded escape set also covers literal percent signs, backslashes, and unsafe delimiters. Encoding square brackets addresses the macOS `open` compatibility problem reported in #1468.

Windows drive and UNC paths are normalized before encoding. This removes canonical `\\?\` prefixes before the `?` is escaped, converts path separators to `/`, and produces standard `file:///C:/...` and `file://server/share/...` URLs.

Fixes #1633.

Developed with assistance from OpenAI Codex. The resulting implementation and tests were validated locally.

##### How Has This Been Tested?

- Added a cross-platform unit test covering `#`, `?`, `%`, square brackets, and the remaining unsafe ASCII path characters.
- Added a Unix-only test for literal backslashes in file names, since Windows treats backslashes as path separators.
- Added tests for canonical and plain Windows drive and UNC paths; these conversion tests run on every platform.
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (`358` library tests, `358` binary tests, `2` integration tests, and `3` doc tests passed)
- `cargo hack test`
- Manually generated an OSC 8 hyperlink for a temporary filename containing `?`, `#`, `%`, `[` and `]`, and confirmed the target contains the expected percent-encoded bytes.
