### PR TITLE
fix(cli)!: require explicit --stdin flag to read standard input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,22 +53,22 @@ fn main() {
     };
     match Options::deduce(&cli, &LiveVars) {
         Ok(options) => {
-            if input_paths.is_empty() {
-                match &options.stdin {
-                    FilesInput::Args => {
+            match &options.stdin {
+                FilesInput::Stdin(separator) => {
+                    stdin()
+                        .read_to_string(&mut input)
+                        .expect("Failed to read from stdin");
+                    input_paths.extend(
+                        input
+                            .split(&separator.clone().into_string().unwrap_or("\n".to_string()))
+                            .map(OsStr::new)
+                            .filter(|s| !s.is_empty())
+                            .collect::<Vec<_>>(),
+                    );
+                }
+                FilesInput::Args => {
+                    if input_paths.is_empty() {
                         input_paths = vec![OsStr::new(".")];
-                    }
-                    FilesInput::Stdin(separator) => {
-                        stdin()
-                            .read_to_string(&mut input)
-                            .expect("Failed to read from stdin");
-                        input_paths.extend(
-                            input
-                                .split(&separator.clone().into_string().unwrap_or("\n".to_string()))
-                                .map(OsStr::new)
-                                .filter(|s| !s.is_empty())
-                                .collect::<Vec<_>>(),
-                        );
                     }
                 }
             }

--- a/src/options/stdin.rs
+++ b/src/options/stdin.rs
@@ -9,10 +9,8 @@ use clap::ArgMatches;
 use crate::options::Vars;
 use crate::options::vars::EZA_STDIN_SEPARATOR;
 use std::ffi::OsString;
-use std::io;
-use std::io::IsTerminal;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FilesInput {
     Stdin(OsString),
     Args,
@@ -20,7 +18,7 @@ pub enum FilesInput {
 
 impl FilesInput {
     pub fn deduce<V: Vars>(matches: &ArgMatches, vars: &V) -> Self {
-        if matches.get_flag("stdin") || !io::stdin().is_terminal() {
+        if matches.get_flag("stdin") {
             let separator = vars
                 .get(EZA_STDIN_SEPARATOR)
                 .unwrap_or(OsString::from("\n"));
@@ -28,5 +26,41 @@ impl FilesInput {
         } else {
             FilesInput::Args
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::options::parser::test::mock_cli;
+    use crate::options::vars::test::MockVars;
+
+    #[test]
+    fn deduce_stdin_disabled_by_default() {
+        let vars = MockVars::default();
+        assert_eq!(
+            FilesInput::deduce(&mock_cli(vec![""]), &vars),
+            FilesInput::Args
+        );
+    }
+
+    #[test]
+    fn deduce_stdin_enabled_with_flag() {
+        let vars = MockVars::default();
+        assert_eq!(
+            FilesInput::deduce(&mock_cli(vec!["--stdin"]), &vars),
+            FilesInput::Stdin(OsString::from("\n"))
+        );
+    }
+
+    #[test]
+    fn deduce_stdin_custom_separator() {
+        let mut vars = MockVars::default();
+        let sep = OsString::from("0");
+        vars.set(EZA_STDIN_SEPARATOR, &sep);
+        assert_eq!(
+            FilesInput::deduce(&mock_cli(vec!["--stdin"]), &vars),
+            FilesInput::Stdin(OsString::from("0"))
+        );
     }
 }

--- a/src/options/vars.rs
+++ b/src/options/vars.rs
@@ -120,6 +120,7 @@ pub mod test {
         pub luminance: OsString,
         pub icons: OsString,
         pub time: OsString,
+        pub stdin_separator: OsString,
     }
 
     impl Vars for MockVars {
@@ -143,6 +144,9 @@ pub mod test {
                 "COLUMNS" if !self.columns.is_empty() => Some(self.columns.clone()),
                 "NO_COLOR" if !self.no_colors.is_empty() => Some(self.no_colors.clone()),
                 "TIME_STYLE" if !self.time.is_empty() => Some(self.time.clone()),
+                "EZA_STDIN_SEPARATOR" if !self.stdin_separator.is_empty() => {
+                    Some(self.stdin_separator.clone())
+                }
                 _ => None,
             }
         }
@@ -161,6 +165,7 @@ pub mod test {
                 "COLUMNS" => self.columns = value.clone(),
                 "NO_COLOR" => self.no_colors = value.clone(),
                 "TIME_STYLE" => self.time = value.clone(),
+                "EZA_STDIN_SEPARATOR" => self.stdin_separator = value.clone(),
                 _ => (),
             };
         }

--- a/tests/ptests/ptest_a82ad7ec2e961f84.stdout
+++ b/tests/ptests/ptest_a82ad7ec2e961f84.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 

--- a/tests/ptests/ptest_af29d370729835d8.stdout
+++ b/tests/ptests/ptest_af29d370729835d8.stdout
@@ -1,4 +1,4 @@
 eza eza - A modern, maintained replacement for ls
-v0.23.4 [+git] (pre-release debug build!)
+v0.23.5 [+git] (pre-release debug build!)
 https://github.com/eza-community/eza
 

--- a/tests/stdin_behavior.rs
+++ b/tests/stdin_behavior.rs
@@ -11,9 +11,10 @@ fn test_stdin_ignored_by_default_without_flag() {
         .spawn()
         .expect("Failed to spawn eza");
 
-    {
-        let mut stdin = child.stdin.take().expect("Failed to open stdin");
-        stdin.write_all(b"non_existent_file_xyz_123\n").unwrap();
+    if let Some(mut stdin) = child.stdin.take() {
+        // eza may exit immediately without reading from stdin (expected behavior),
+        // so writing to the pipe might result in BrokenPipe on Unix.
+        let _ = stdin.write_all(b"non_existent_file_xyz_123\n");
     }
 
     let output = child.wait_with_output().expect("Failed to read stdout");
@@ -54,9 +55,8 @@ fn test_stdin_explicit_flag_reads_paths() {
         .spawn()
         .expect("Failed to spawn eza");
 
-    {
-        let mut stdin = child.stdin.take().expect("Failed to open stdin");
-        stdin.write_all(b"src\nCargo.toml\n").unwrap();
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(b"src\nCargo.toml\n");
     }
 
     let output = child.wait_with_output().expect("Failed to read stdout");

--- a/tests/stdin_behavior.rs
+++ b/tests/stdin_behavior.rs
@@ -1,0 +1,88 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[test]
+fn test_stdin_ignored_by_default_without_flag() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_eza"))
+        .arg("--oneline")
+        .arg("--color=never")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn eza");
+
+    {
+        let mut stdin = child.stdin.take().expect("Failed to open stdin");
+        stdin.write_all(b"non_existent_file_xyz_123\n").unwrap();
+    }
+
+    let output = child.wait_with_output().expect("Failed to read stdout");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Cargo.toml") || stdout.contains("src"));
+    assert!(!stdout.contains("non_existent_file_xyz_123"));
+}
+
+#[test]
+fn test_stdin_empty_input_without_flag_lists_current_dir() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_eza"))
+        .arg("--oneline")
+        .arg("--color=never")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn eza");
+
+    {
+        let _ = child.stdin.take();
+    }
+
+    let output = child.wait_with_output().expect("Failed to read stdout");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Cargo.toml") || stdout.contains("src"));
+}
+
+#[test]
+fn test_stdin_explicit_flag_reads_paths() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_eza"))
+        .arg("--stdin")
+        .arg("--oneline")
+        .arg("--color=never")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn eza");
+
+    {
+        let mut stdin = child.stdin.take().expect("Failed to open stdin");
+        stdin.write_all(b"src\nCargo.toml\n").unwrap();
+    }
+
+    let output = child.wait_with_output().expect("Failed to read stdout");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("src"));
+    assert!(stdout.contains("Cargo.toml"));
+}
+
+#[test]
+fn test_stdin_explicit_flag_with_empty_input_lists_nothing() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_eza"))
+        .arg("--stdin")
+        .arg("--oneline")
+        .arg("--color=never")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn eza");
+
+    {
+        let _ = child.stdin.take();
+    }
+
+    let output = child.wait_with_output().expect("Failed to read stdout");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.trim().is_empty());
+}


### PR DESCRIPTION
##### Description

Fixes #1568
Fixes #1725
Fixes #1563

### Background & Problem
Prior to this change, `eza` attempted to auto-read standard input whenever `!io::stdin().is_terminal()` was true and no positional file arguments were passed. This caused several severe issues across different environments:

1. **Subshells, CI runners, and Agent environments (Hang / Deadlock)**:
   In non-interactive environments where `stdin` is connected to a pipe or pseudo-terminal that remains open, `eza` executes `stdin().read_to_string(&mut input)` which blocks indefinitely waiting for EOF, causing processes to hang.
2. **Empty stdin and `/dev/null` redirection (Silent exit / No output)**:
   When `stdin` is redirected from `/dev/null` or an empty pipe (e.g. `eza < /dev/null`), `read_to_string` immediately reaches EOF with empty content. `input_paths` stays empty, and `eza` exits with 0 without printing anything, breaking standard scripts and widgets.
3. **Shell pipelines & loops**:
   In scripts like `find . | while read line; do eza; done`, `eza` would unintentionally consume data from `stdin`, disrupting the outer loop.
4. **POSIX / `ls` consistency**:
   Standard `ls` and traditional `exa` do not implicitly read file paths from standard input without explicit user instruction.

### Solution
- Update `FilesInput::deduce` so `stdin` is only read when the `--stdin` flag is explicitly supplied on the command line.
- When `--stdin` is absent and no positional paths are passed, default to the current directory (`.`), matching standard `ls` behavior.
- Retain full functionality of explicit `--stdin`, custom delimiters (`EZA_STDIN_SEPARATOR`), and combining positional args with `--stdin`.

### Breaking Changes
- `eza` will no longer automatically read file paths from `stdin` just because `stdin` is non-terminal. Users must explicitly pass `--stdin` to read paths from standard input (e.g., `printf "foo\nbar" | eza --stdin`).

##### How Has This Been Tested?
- Added unit tests in `src/options/stdin.rs` verifying `FilesInput::deduce` behavior (default, `--stdin`, custom separator).
- Added integration tests in `tests/stdin_behavior.rs` covering:
  - Stdin data ignored when `--stdin` is not passed -> lists current directory.
  - Stdin data read and listed when `--stdin` is passed.
  - Empty stdin (`< /dev/null`) without `--stdin` -> lists current directory.
  - Empty stdin with `--stdin` -> lists nothing.
- Ran `cargo test --lib` (218 unit tests passing).
- Ran `cargo test --test stdin_behavior` (4 integration tests passing).
- Formatted with `cargo fmt` and checked with `cargo clippy`.