### PR TITLE
fix(loc): prioritize block comment delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ SPDX-License-Identifier: EUPL-1.2
 -->
 # Changelog
 
+## Upcoming
+
+### Bug Fixes
+
+- Fix Lua block comments being counted as code when their opener starts with the line-comment token, see #1918 (@fly1d)
+
 ## [0.23.5] - 2026-07-09
 
 ### Bug Fixes
@@ -2889,5 +2895,4 @@ SPDX-License-Identifier: EUPL-1.2
 ### Vagrant
 
 - Update apt before installing
-
 

--- a/src/loc/mod.rs
+++ b/src/loc/mod.rs
@@ -130,13 +130,9 @@ fn classify_line(line: &str, lang: &Language, block: &mut Option<&'static str>) 
             break;
         }
 
-        // A line comment swallows the remainder of the line.
-        if lang.line_comments.iter().any(|lc| rest.starts_with(lc)) {
-            has_comment = true;
-            break;
-        }
-
         // A block comment opener starts a (possibly multi-line) comment.
+        // Check these before line comments because some languages (notably
+        // Lua) use a block opener that starts with their line-comment token.
         if let Some((open, close)) = lang
             .block_comments
             .iter()
@@ -146,6 +142,12 @@ fn classify_line(line: &str, lang: &Language, block: &mut Option<&'static str>) 
             *block = Some(close);
             rest = &rest[open.len()..];
             continue 'scan;
+        }
+
+        // A line comment swallows the remainder of the line.
+        if lang.line_comments.iter().any(|lc| rest.starts_with(lc)) {
+            has_comment = true;
+            break;
         }
 
         // Anything else is code. Consume one unit, skipping over string
@@ -572,6 +574,21 @@ mod test {
             LocCounts {
                 lines: 5,
                 code: 2,
+                comments: 3,
+                blanks: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn lua_block_comment_opener_takes_precedence_over_line_comment() {
+        let source = "local x = 1 --[[\nlocal y\nlocal z\n]]\n";
+        let c = count(source, &LUA);
+        assert_eq!(
+            c,
+            LocCounts {
+                lines: 4,
+                code: 1,
                 comments: 3,
                 blanks: 0,
             }


### PR DESCRIPTION
## Summary

Fixes #1918 by checking block-comment openers before line-comment tokens in the LOC scanner.

Lua uses `--` for line comments and `--[[` for block comments. The previous order treated `--[[` as a line comment, so the following lines were counted as code. Block-first matching preserves the existing behavior for other languages and handles comment delimiters that share a prefix.

The patch adds a regression test for the issue reproduction and an upcoming changelog entry.

## Verification

- `cargo fmt --check`
- `cargo test --all-targets`
- `git diff --check`
- GitHub-Verified SSH-signed commit: `aeb8b66a29ae2194d120734ec3a41c146e34b045`

OpenAI Codex assisted with repository inspection, implementation, and test execution. I reviewed the resulting patch and test behavior.