### PR TITLE
fix(loc): detect block comments before line comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ SPDX-License-Identifier: EUPL-1.2
 -->
 # Changelog
 
+## Upcoming
+
+### Bug Fixes
+
+- Fix `--loc` miscounting Lua block comments whose opener (`--[[`) starts with the line-comment token (`--`), see #1918
+
 ## [0.23.5] - 2026-07-09
 
 ### Bug Fixes

--- a/src/loc/mod.rs
+++ b/src/loc/mod.rs
@@ -130,13 +130,10 @@ fn classify_line(line: &str, lang: &Language, block: &mut Option<&'static str>) 
             break;
         }
 
-        // A line comment swallows the remainder of the line.
-        if lang.line_comments.iter().any(|lc| rest.starts_with(lc)) {
-            has_comment = true;
-            break;
-        }
-
-        // A block comment opener starts a (possibly multi-line) comment.
+        // A block-comment opener starts a (possibly multi-line) comment. This is
+        // checked *before* line comments so that when a line-comment token is a
+        // prefix of a block opener (e.g. Lua's `--` vs `--[[`), the longer, more
+        // specific block opener wins instead of being swallowed as a line comment.
         if let Some((open, close)) = lang
             .block_comments
             .iter()
@@ -146,6 +143,12 @@ fn classify_line(line: &str, lang: &Language, block: &mut Option<&'static str>) 
             *block = Some(close);
             rest = &rest[open.len()..];
             continue 'scan;
+        }
+
+        // A line comment swallows the remainder of the line.
+        if lang.line_comments.iter().any(|lc| rest.starts_with(lc)) {
+            has_comment = true;
+            break;
         }
 
         // Anything else is code. Consume one unit, skipping over string
@@ -604,6 +607,15 @@ mod test {
         let c = count("# comment\nname = 1\n", &TOML);
         assert_eq!(c.code, 1);
         assert_eq!(c.comments, 1);
+    }
+
+    #[test]
+    fn lua_block_comment_not_swallowed_by_line_comment() {
+        // Lua's line comment `--` is a prefix of its block-comment opener `--[[`.
+        // The block opener must win, so the inner lines count as comments, not code.
+        let c = count("local x = 1 --[[\nlocal y\nlocal z\n]]\n", &LUA);
+        assert_eq!(c.code, 1);
+        assert_eq!(c.comments, 3);
     }
 
     #[test]


### PR DESCRIPTION
  eza's LOC counter checked line-comment tokens before block-comment openers. Since Lua's line  comment `--` is a prefix of its block opener `--[[`, the `--` matched first and swallowed the opener, so a multi-line block comment was miscounted (e.g. `local x = 1 --[[ … ]]` counted as code + one comment line instead of 1 code, 3 comments).
  

 Check block-comment openers before line comments, so a longer opener that shares a prefix with a line comment wins. This is the general fix discussed in #1918 (not Lua-specific) and needs no  per-language logic. Added a regression test.

Fixes #1918