### PR TITLE
docs: add link to a live browser demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ And it’s **small**, **fast**, and just **one single binary**.
 
 By deliberately making some decisions differently, eza attempts to be a more featureful, more user-friendly version of `ls`.
 
+[![Live demo by Demoshell](https://build.demoshell.com/v1/embed/badge.svg)](https://build.demoshell.com/launch?snapshot=demoshell%2Ftui%3Aeza)
 ---
 
 **eza** features not in exa (non-exhaustive):


### PR DESCRIPTION
Added an "Online demo" link to the README pointing to eza running in the browser (see preview below, click to see the demo):
[![Live demo by Demoshell](https://build.demoshell.com/v1/embed/badge.svg)](https://build.demoshell.com/launch?snapshot=demoshell%2Ftui%3Aeza)

It's the actual eza binary inside an emulated Linux VM (WebAssembly). The VM is seeded with a directory tree and a git repo, so --long, --tree, --icons and the git status column all show real output. The image rebuilds automatically when a new release is published.

Disclosure: I run the service behind this (Demoshell). The demo and hosting are free for open-source projects (the badge carries a small attribution).

The demo page also allows the maintainer to claim that VM if you'd like to support it. Otherwise I'll keep taking care of it.