### PR TITLE
ci(star-history): add star-history chart action

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,24 @@
+name: Star History
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'   # every 6 hours; see interval table below
+  watch:
+    types: [started]        # optional: also refresh right after a new star
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: star-history
+  cancel-in-progress: true  # collapse a burst of stars into one run
+
+jobs:
+  star-history:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: narayann7/star-history-action@v1
+        with:
+          repos: ${{ github.repository }}   # or a list: owner/repo,owner/repo2

--- a/README.md
+++ b/README.md
@@ -219,4 +219,6 @@ After having understood the code of conduct, you can have a look at our
 [CONTRIBUTING.md](https://github.com/eza-community/eza/blob/main/CONTRIBUTING.md) 
 for more info about actual hacking.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=eza-community/eza&type=Date)](https://star-history.com/#eza-community/eza&Date)
+<!-- star-history:start -->
+
+<!-- star-history:end -->


### PR DESCRIPTION
Hello @eza-community

So as of 30 June 2026, github had restricted its stargazers endpoint to a repo's own admins and collaborators. So I have added a CI which reads the star count from the repository itself and commits it as an SVG. 

This is the action https://github.com/marketplace/actions/star-history-action. I use it myself and it works very well.

