### PR TITLE
build(deps): update naersk to fix crates.io download 403s

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769799857,
-        "narHash": "sha256-88IFXZ7Sa1vxbz5pty0Io5qEaMQMMUPMonLa3Ls/ss4=",
+        "lastModified": 1782220280,
+        "narHash": "sha256-thLTFbp9D5Qknmh8q/v4FRpLGphUSijT3E86cbLYTXo=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "9d4ed44d8b8cecdceb1d6fd76e74123d90ae6339",
+        "rev": "9aa07bb0256d300219b30622d2454e85f7f3667e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
crates.io recently started rejecting downloads with generic tool user-agents (see rust-lang/crates.io#13482), which breaks naersk's per-crate `fetchurl` derivations with HTTP 403:

```
curl: (22) The requested URL returned error: 403
error: cannot download download-aho-corasick-1.1.4 from any mirror
```

naersk fixed this in nix-community/naersk#391 (merged June 8) by downloading from `static.crates.io` instead. This PR just bumps the pinned naersk past that fix — no other inputs touched.

This is independent of #1869 (the `darwin.apple_sdk` eval fix); building on macOS needs both. Verified on aarch64-darwin: with this bump plus #1869's `flake.nix` change, `nix build` succeeds and produces a working `eza v0.23.5 [+git]`.

Refs #1619, #1622.