### PR TITLE
perf: only consider visible files for `--total-size`

### DIFF
--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -172,12 +172,18 @@ impl<'dir> Files<'dir, '_> {
                     }
                 }
 
+                let dotfilter = if self.dotfiles {
+                    DotFilter::Dotfiles
+                } else {
+                    DotFilter::JustFiles
+                };
                 let file = File::from_args(
                     path,
                     self.dir,
                     filename,
                     self.deref_links,
                     self.total_size,
+                    dotfilter,
                     entry.file_type().ok(),
                 );
 

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -208,7 +208,7 @@ impl<'dir> File<'dir> {
         };
 
         if total_size {
-            file.recursive_size = file.recursive_directory_size(DotFilter::DotfilesAndDots);
+            file.recursive_size = file.recursive_directory_size(DotFilter::Dotfiles);
         }
 
         file
@@ -684,7 +684,10 @@ impl<'dir> File<'dir> {
             Dir::read_dir(self.path.clone()).map_or(RecursiveSize::Unknown, |dir| {
                 let mut size = 0;
                 let mut blocks = 0;
-                for file in dir.files(dotfilter, None, false, false, true) {
+                for file in dir
+                    .files(dotfilter, None, false, false, true)
+                    .filter(|f| !f.is_all_all)
+                {
                     match file.recursive_directory_size(dotfilter) {
                         RecursiveSize::Some(bytes, blks) => {
                             size += bytes;

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -24,7 +24,10 @@ use std::time::SystemTime;
 
 use chrono::prelude::*;
 
+#[cfg(unix)]
+use log::info;
 use log::{debug, error, trace};
+
 #[cfg(unix)]
 use std::sync::LazyLock;
 
@@ -35,6 +38,7 @@ use crate::fs::fields as f;
 use crate::fs::fields::SecurityContextType;
 use crate::fs::recursive_size::RecursiveSize;
 
+use super::DotFilter;
 use super::mounts::MountedFs;
 use super::mounts::all_mounts;
 
@@ -125,6 +129,7 @@ impl<'dir> File<'dir> {
         filename: FN,
         deref_links: bool,
         total_size: bool,
+        dotfilter: DotFilter,
         filetype: Option<std::fs::FileType>,
     ) -> File<'dir>
     where
@@ -166,7 +171,7 @@ impl<'dir> File<'dir> {
         };
 
         if total_size {
-            file.recursive_size = file.recursive_directory_size();
+            file.recursive_size = file.recursive_directory_size(dotfilter);
         }
 
         file
@@ -203,7 +208,7 @@ impl<'dir> File<'dir> {
         };
 
         if total_size {
-            file.recursive_size = file.recursive_directory_size();
+            file.recursive_size = file.recursive_directory_size(DotFilter::DotfilesAndDots);
         }
 
         file
@@ -665,8 +670,10 @@ impl<'dir> File<'dir> {
     /// will be returned.  The directory size is cached for recursive directory
     /// listing.
     #[cfg(unix)]
-    fn recursive_directory_size(&self) -> RecursiveSize {
+    fn recursive_directory_size(&self, dotfilter: DotFilter) -> RecursiveSize {
         if self.is_directory() {
+            info!("Retrieving recursive directory size for {:?}", self.path);
+
             let key = (
                 self.metadata().map_or(0, MetadataExt::dev),
                 self.metadata().map_or(0, MetadataExt::ino),
@@ -677,8 +684,8 @@ impl<'dir> File<'dir> {
             Dir::read_dir(self.path.clone()).map_or(RecursiveSize::Unknown, |dir| {
                 let mut size = 0;
                 let mut blocks = 0;
-                for file in dir.files(super::DotFilter::Dotfiles, None, false, false, true) {
-                    match file.recursive_directory_size() {
+                for file in dir.files(dotfilter, None, false, false, true) {
+                    match file.recursive_directory_size(dotfilter) {
                         RecursiveSize::Some(bytes, blks) => {
                             size += bytes;
                             blocks += blks;
@@ -706,7 +713,7 @@ impl<'dir> File<'dir> {
     /// not cache the sizes.  Without caching we could end up walking the
     /// directory structure several times.
     #[cfg(windows)]
-    fn recursive_directory_size(&self) -> RecursiveSize {
+    fn recursive_directory_size(&self, _dotfilter: DotFilter) -> RecursiveSize {
         RecursiveSize::None
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,6 +276,7 @@ impl Exa<'_> {
                 None,
                 self.options.view.deref_links,
                 self.options.view.total_size,
+                self.options.filter.dot_filter,
                 None,
             );
 


### PR DESCRIPTION
Currently, `eza` considers hidden directories when `--total-size` is passed, regardless of whether these are actually displayed, potentially doing much more work than is necessary.

This behavior may be observed by running the following command in a directory containing a hidden directory (e.g., `$HOME`):

```bash
EZA_DEBUG=trace eza --total-size -l 2> >(rg -F /.) >/dev/null
```

Since recursive descent and stats into these hidden directories can be quite costly, this change results in significant performance improvements when viewing a directory containing a large hidden directory. A notable example is `$HOME`, with `$HOME/.local`:

```console
$ hyperfine -N "eza --total-size -l $HOME"
Benchmark 1: eza --total-size -l /home/tox
  Time (mean ± σ):      1.042 s ±  0.009 s    [User: 0.308 s, System: 0.737 s]
  Range (min … max):    1.022 s …  1.054 s    10 runs

$ hyperfine -N "eza --total-size -al $HOME"
Benchmark 1: eza --total-size -al /home/tox
  Time (mean ± σ):      1.042 s ±  0.013 s    [User: 0.312 s, System: 0.734 s]
  Range (min … max):    1.028 s …  1.076 s    10 runs
```

For the `$HOME` example, this fix yields a significant speedup on my system when `--total-size` is passed but `-a` is not:

```console
$ hyperfine -N "target/release/eza $HOME --total-size -l"
Benchmark 1: target/release/eza /home/tox --total-size -l
  Time (mean ± σ):     345.7 ms ±   4.4 ms    [User: 108.2 ms, System: 240.7 ms]
  Range (min … max):   341.5 ms … 352.9 ms    10 runs

$ hyperfine -N "target/release/eza $HOME --total-size -al"
Benchmark 1: target/release/eza /home/tox --total-size -al
  Time (mean ± σ):      1.073 s ±  0.006 s    [User: 0.326 s, System: 0.751 s]
  Range (min … max):    1.065 s …  1.084 s    10 runs
```

Ref: #1291, #1498, https://github.com/fxrdhan/lez/pull/38/changes/b4e0a3d4598bc829122c6d3126b7127974a7fae2

I do wish I noticed https://github.com/fxrdhan/lez/pull/38/changes/b4e0a3d4598bc829122c6d3126b7127974a7fae2 before I wrote this; that would have saved me some jumping around the codebase. My solution is independent of theirs.